### PR TITLE
Spectrum1d 2nd draft

### DIFF
--- a/specutils/spectrum1d.py
+++ b/specutils/spectrum1d.py
@@ -111,8 +111,7 @@ class SDError(np.ndarray):
         return obj
     
     def interpolate(self, old_lookup_table, new_lookup_table):
-        new_mask_raw = np.interp(new_lookup_table, old_lookup_table, self.astype(float64), left=1, right=1)
-        return np.ceil(new_mask_raw).astype(bool)
+        return np.interp(new_lookup_table, old_lookup_table)
     
     def check_operand(self, operand):
     #checking if both of the operands are SDerrors or raising an exception
@@ -198,13 +197,13 @@ class Spectrum1D(NDData):
             #### about that bounds_error & fill_value is ignored as scipy not available
             interpolated_flux = np.interp(new_)
         else:
-            spectrum_interp = interpolate.interp1d(self.disp, self.flux,
+            spectrum_interp = interpolate.interp1d(self.dispersion, self.flux,
                                         kind=kind, bounds_error=bounds_error,
                                         fill_value=fill_value)
             new_flux = spectrum_interp(dispersion)
             
             if error!=None:
-                new_error = self.error.interpolate(dispersion,
+                new_error = self.error.interpolate(self.dispersion, dispersion,
                                                    kind=kind,
                                                    bounds_error=bounds_error,
                                                    fill_value=fill_value)
@@ -212,7 +211,7 @@ class Spectrum1D(NDData):
                 new_error = None
             
             if mask!=None:
-                new_mask = self.mask.interpolate(dispersion,
+                new_mask = self.mask.interpolate(self.dispersion, dispersion,
                                                    kind=kind,
                                                    bounds_error=bounds_error,
                                                    fill_value=fill_value)


### PR DESCRIPTION
So I think I have most things that we talked about implemented. I have tried to put comments in the code to explain some of the things I did. There's also some questions in there (mainly about logging). 

The main issue I encountered when writing this up was the problem of handling errors and masks. 
Both errors and masks have different arithmetic (and interpolation) behaviour depending on what they are.
Fortunatley, this behaviour is the same for all children of nddata, be it a 1d Spectrum, an image or an n-dimensional simulation. Thus I believe that errors and masks should be implemented with nddata. 

As an example I have implemented a BoolMask and SDError. 

The arithmetic operations are implemented for the mask with mask_add, mask_sub, ... which does always the same thing - a logical_or (if only one of the values is masked the result will also be masked there). For interpolation the result will automatically be masked outside the data range and will flag pixels that used flagged pixels to be interpolated.  Another mask could be a bitflag mask that would need to be added instead of a logical_or. 

I have chosen a simple standard deviation error as an example for an error. The arithmetic operations are implemented for the error with error_add, error_sub, ... . For the SDError the interpolate function Another error would be VarianceError. 

I should reiterate that both of these apply to all nddata objects and we should utilise this to avoid code duplication. 

Finally here's a couple of initialization examples and one can play with the results. 

``` python
easy_spec = Spectrum1D(rand(1000), linspace(3000, 6000, 1000))

my_first_spec = Spectrum1D(np.random.rand(1000),
                               linspace(4000, 7000, 1000),
                               error=SDError(np.random.rand(1000)),
                               mask = BoolMask(np.random.rand(1000) > .5),
                               meta = dict(a=5, b=7, c=9))

my_second_spec = Spectrum1D(np.random.rand(1000),
                               linspace(4000, 7000, 1000),
                               error=SDError(np.random.rand(1000)),
                               mask = BoolMask(np.random.rand(1000) > .5),
                               meta = dict(c=9, d=11, e=13))
```

I believe this might spark a lot of discussion and maybe we want to have a quick video chat again. 
