### PR TITLE
Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
    - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install sphinx --use-mirrors; fi
    - if [[ $SETUP_CMD != egg_info ]]; then pip -q install Cython --use-mirrors; fi
    # use 0.2 release rather than latest dev release (using 0.2.1 explicitly)
-   - pip install -i http://stsdas.stsci.edu/download/packages/index astropy==0.2.1
+   - pip install astropy
 
 script:
    - export OPEN_FILES=""


### PR DESCRIPTION
This PR implements Travis tests.  At the moment, about half the tests are passing (there are no specutils tests implemented yet, so this is just testing-for-tests).

I'm submitting this now to ask for some assistance - why is travis complaining about `subprocess.communicate` in only some versions of python?

P.S. This is built on #15, so that should be merged first.
