### PR TITLE
Refactor dispersion

### DIFF
--- a/specutils/spectrum1d.py
+++ b/specutils/spectrum1d.py
@@ -87,7 +87,8 @@ class Spectrum1D(NDData):
         else:
             uncertainty = None
 
-        return cls.from_array(flux=flux.data, dispersion=dispersion.data, uncertainty=uncertainty, dispersion_unit=disp.units, unit=flux.units)
+        return cls.from_array(flux=flux.data, dispersion=dispersion.data, uncertainty=uncertainty,
+                              dispersion_unit=dispersion.units, unit=flux.units)
         
     
     


### PR DESCRIPTION
It was agreed upon in the very beginning of this project that the dispersion attribute is called `dispersion`. This PR fixes this oversight and refactors this code from `disp` to `dispersion`.
