### PR TITLE
make sure all keywords of from_array are passed to the __init__

### DIFF
--- a/specutils/spectrum1d.py
+++ b/specutils/spectrum1d.py
@@ -77,7 +77,8 @@ class Spectrum1D(NDData):
         if dispersion.ndim != 1 or dispersion.shape != flux.shape:
             raise ValueError("dispersion and flux need to be one-dimensional Numpy arrays with the same shape")
         spec_wcs = Spectrum1DLookupWCS(dispersion, unit=dispersion_unit)
-        return cls(data=flux, wcs=spec_wcs, unit=unit)
+        return cls(data=flux, wcs=spec_wcs, unit=unit, uncertainty=uncertainty,
+                   mask=mask, flags=flags, meta=meta)
     
     @classmethod
     def from_table(cls, table, dispersion_column='dispersion', flux_column='flux', uncertainty_column=None,
@@ -126,7 +127,8 @@ class Spectrum1D(NDData):
 
         return cls.from_array(flux=flux.data, dispersion=dispersion.data,
                               uncertainty=uncertainty, dispersion_unit=dispersion.units,
-                              unit=flux.units, mask=table.mask, flags=flags)
+                              unit=flux.units, mask=table.mask, flags=flags,
+                              meta=table.meta)
         
     
     


### PR DESCRIPTION
from_array accepted keywords for uncertaity, mask, flags and meta
but did not pass them on the `NDData.__init__`, so that informatmation
was lost. This bug needs to be fixed to make the units tests of #16 pass.
