### PR TITLE
Fix spectrum1d attributes

### DIFF
--- a/specutils/spectrum1d.py
+++ b/specutils/spectrum1d.py
@@ -184,7 +184,7 @@ class Spectrum1D(NDData):
         if name in self._wcs_attributes:
             if 'lookup_table' not in self._wcs_attributes[name]:
                 self._wcs_attributes[name]['lookup_table'] = self.dispersion.to(self._wcs_attributes[name]['unit'],
-                                                                                equivalencies=u.spectral())
+                                                                                equivalencies=self.wcs.equivalencies)
             return self._wcs_attributes[name]['lookup_table']
 
         elif name[:-5] in self._wcs_attributes and name[-5:] == '_unit':


### PR DESCRIPTION
*\* This was originally PR https://github.com/astropy/specutils/pull/42 but somehow things went awry **

A fix up of the `.wavelength`, `.energy`, ... attributes. These are now saved in a dictionary called `wcs_attributes`:
the `.wavelength` entry is an attribute `{'unit':u.m}`. 

Thus we can easily add on attributes like `.velocity` by simply adding it to the dictionary. 

This PR will have to be updated slightly after https://github.com/astropy/specutils/pull/40 is merged. 

@keflavich - that allows `.velocity` now (among others), thoughts (now with your equivalencies)?
