### PR TITLE
Add min/max for 1d WCS

### DIFF
--- a/specutils/wcs/specwcs.py
+++ b/specutils/wcs/specwcs.py
@@ -149,6 +149,13 @@ class Spectrum1DLookupWCS(BaseSpectrum1DWCS):
             raise NotImplementedError('Interpolation type %s is not implemented' % self.lookup_table_interpolation_kind)
 
 
+    def min(self):
+        return self.lookup_table_parameter.value.min()
+
+    def max(self):
+        return self.lookup_table_parameter.value.max()
+
+
 class Spectrum1DLinearWCS(BaseSpectrum1DWCS):
     """
     A simple linear wcs


### PR DESCRIPTION
This implements `min`/`max` for 1D lookup tables.  `min`/`max` should be implemented for all wcs types, but I don't know how at the moment.  I think the polynomial and linear varieties both can be called for _any_ pixel, which is good, but it should also be possible to define them with a domain - any given spectrum clearly has a minimum and maximum value.

@wkerzendorf - I could use your help on this.  I need these implemented for a module I'm writing.
