### PR TITLE
Fix the LookupTable WCS to work with new models

### DIFF
--- a/specutils/wcs/specwcs.py
+++ b/specutils/wcs/specwcs.py
@@ -119,7 +119,7 @@ class Spectrum1DLookupWCS(BaseSpectrum1DWCS):
 
     def __init__(self, lookup_table, unit=None,
                  lookup_table_interpolation_kind='linear'):
-        super(Spectrum1DLookupWCS, self).__init__()
+        super(Spectrum1DLookupWCS, self).__init__(lookup_table_parameter=lookup_table)
 
         if unit is not None:
             self.lookup_table_parameter = u.Quantity(lookup_table, unit)


### PR DESCRIPTION
@embray, this is a fix that I had to introduce because some of the requirements for model changed. It seems a lot of the parameter stuff is now in. Can you look at some of the code around it and see if we can change more of the structure now to comply with your new model changes (i.e. requiring the parameter to be a quantity with certain units?)
