### PR TITLE
change .flux to quantity

### DIFF
--- a/docs/specutils/spectrum1d.rst
+++ b/docs/specutils/spectrum1d.rst
@@ -18,9 +18,13 @@ There are several ways to instantiate a :class:`Spectrum1D` object::
     >>> from astropy import units as u
     >>> import numpy as np
     >>> wave = np.arange(6000, 9000) * u.Angstrom
-    >>> flux = np.random.random(3000) # due to current limitations in NDData, a quantity can not be given
-    >>> spec1d = Spectrum1D.from_array(wave, flux, unit='W m-2 angstrom-1 sr-1')
-
+    >>> flux = np.random.random(3000) * u.Unit('W m-2 angstrom-1 sr-1')
+    >>> spec1d = Spectrum1D.from_array(wave, flux)
+    >>> spec1d.wavelength
+    <Quantity [ 6000., 6001., 6002.,...,  8997., 8998., 8999.] Angstrom>
+    >>> spec1d.flux
+    <Quantity [ 0.75639906, 0.23677036, 0.08408417,...,  0.82740303,
+            0.38345114, 0.77815595] W / (Angstrom m2 sr)>
 
 The ability to instantiate from any two arrays allows to load from ascii files (see `astropy.io.ascii <http://docs.astropy.org/en/stable/io/ascii/index.html>`_)
 and other data structures like `~numpy.recarray` and `~astropy.table.Table`.

--- a/specutils/spectrum1d.py
+++ b/specutils/spectrum1d.py
@@ -243,6 +243,23 @@ class Spectrum1D(NDData):
                 self._wcs_attributes[key]['unit'] = self.wcs.unit
 
 
+    def flux_getter(self):
+        #returning the flux
+        return u.Quantity(self.data, self.unit)
+
+    def flux_setter(self, flux):
+        if hasattr(flux, 'unit'):
+            if self.unit is not None:
+                flux = flux.to(self.unit).value
+            else:
+                raise ValueError('Attempting to set a new unit for this object'
+                                 'this is not allowed by Spectrum1D')
+
+        self.data = flux
+
+
+    flux = property(flux_getter, flux_setter)
+
     def __getattr__(self, name):
         if name in self._wcs_attributes:
             return self.dispersion.to(self._wcs_attributes[name]['unit'], equivalencies=self.wcs.equivalencies)
@@ -263,14 +280,7 @@ class Spectrum1D(NDData):
                [item + '_unit' for item in self._wcs_attributes.keys()]
 
 
-    @property
-    def flux(self):
-        #returning the flux
-        return u.Quantity(self.data, self.unit)
-        
-    @flux.setter
-    def flux_setter(self, flux):
-        self.data = flux
+
 
     #TODO: let the WCS handle what to do with len(flux)
     @property

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -22,5 +22,29 @@ def test_spectrum1d_fromarray_quantity2():
     nptesting.assert_allclose(test_spec.wavelength.value,
                                np.arange(3000, 9000) / 10.)
 
+def test_spectrum1d_flux1():
+        test_spec = Spectrum1D.from_array(np.arange(3000, 9000) * u.angstrom,
+                          np.random.random(6000) * u.erg/u.s,
+                          )
 
+        assert not hasattr(test_spec.data, 'unit')
+        assert test_spec.flux.unit == u.erg / u.s
+        assert test_spec.unit == u.erg / u.s
+
+def test_spectrum1d_flux2():
+        test_spec = Spectrum1D.from_array(np.arange(3000, 9000) * u.angstrom,
+                          np.random.random(6000) * u.erg/u.s,
+                          )
+
+        assert not hasattr(test_spec.data, 'unit')
+        assert test_spec.flux.unit == u.erg / u.s
+        assert test_spec.unit == u.erg / u.s
+        new_flux = np.random.random(6000) * u.W
+
+        test_spec.flux = new_flux
+
+        assert test_spec.flux.unit == u.erg / u.s
+
+        nptesting.assert_allclose(new_flux.to(u.erg / u.s).value,
+                                  test_spec.data)
 


### PR DESCRIPTION
This change has been suggested both by @followthesheep and @mhvk as a current inconsistency.

While `spec1d.wavelength` gives back a `Quantity` - `spec1d.flux` only returns an `ndarray`. This PR fixes this and makes `spec1d.flux` a quantity. 

@nhmc @keflavich you guys might use this. Does that make sense to you? 
