### PR TITLE
fixed flux being a copy of data to being a reference

### DIFF
--- a/specutils/spectrum1d.py
+++ b/specutils/spectrum1d.py
@@ -245,7 +245,7 @@ class Spectrum1D(NDData):
 
     def flux_getter(self):
         #returning the flux
-        return u.Quantity(self.data, self.unit)
+        return u.Quantity(self.data, self.unit, copy=False)
 
     def flux_setter(self, flux):
         if hasattr(flux, 'unit'):

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -48,3 +48,6 @@ def test_spectrum1d_flux2():
         nptesting.assert_allclose(new_flux.to(u.erg / u.s).value,
                                   test_spec.data)
 
+        test_spec.flux[1000] = 1000 * u.erg/u.s
+
+        nptesting.assert_allclose(test_spec.flux[1000], 1000 * u.erg/u.s)


### PR DESCRIPTION
This was an unfortunate oversight in the previous fix. 

Thanks @mhvk for suggesting this solution. 

@keflavich @nhmc, will merge when TRAVIS passes. 
