### PR TITLE
Fix extinction units

### DIFF
--- a/specutils/extinction.py
+++ b/specutils/extinction.py
@@ -215,7 +215,7 @@ class ExtinctionF99(object):
         # Analytic function in the UV.
         uvmask = wave < (2700. * u.angstrom)
         if np.any(uvmask):
-            res[uvmask] = cextinction.f99uv(wave[uvmask].value, self.a_v, self.r_v) * wave.unit
+            res[uvmask] = cextinction.f99uv(wave[uvmask].value, self.a_v, self.r_v)
 
         # Spline in the Optical/IR
         oirmask = ~uvmask
@@ -293,7 +293,7 @@ def extinction_fm07(wave, a_v):
     # Simple analytic function in the UV
     uvmask = wave < (2700. * u.angstrom)
     if np.any(uvmask):
-        res[uvmask] = cextinction.fm07uv(wave[uvmask].value, a_v) * wave.unit
+        res[uvmask] = cextinction.fm07uv(wave[uvmask].value, a_v)
     
     # Spline in the Optical/IR
     oirmask = ~uvmask

--- a/specutils/extinction.py
+++ b/specutils/extinction.py
@@ -93,7 +93,7 @@ def extinction_ccm89(wave, a_v, r_v=3.1):
 
     _check_wave(wave, 909.091 * u.angstrom, 33333.333 * u.angstrom)
 
-    res = cextinction.ccm89(_process_wave(wave).value, a_v, r_v) * wave.unit
+    res = cextinction.ccm89(_process_wave(wave).value, a_v, r_v)
 
     return res.reshape(wave.shape)
 
@@ -132,7 +132,7 @@ def extinction_od94(wave, a_v, r_v=3.1):
 
     _check_wave(wave, 909.091 * u.angstrom, 33333.333 * u.angstrom)
 
-    res = cextinction.od94(_process_wave(wave).value, a_v, r_v) * wave.unit
+    res = cextinction.od94(_process_wave(wave).value, a_v, r_v)
 
     return res.reshape(wave.shape)
 
@@ -160,7 +160,7 @@ def extinction_gcc09(wave, a_v, r_v=3.1):
 
     _check_wave(wave, 909.091 * u.angstrom, 33333.333 * u.angstrom)
 
-    res = cextinction.gcc09(_process_wave(wave).value, a_v, r_v) * wave.unit
+    res = cextinction.gcc09(_process_wave(wave).value, a_v, r_v)
 
     return res.reshape(wave.shape)
 
@@ -525,10 +525,8 @@ def extinction(wave, a_v, r_v=3.1, model='od94'):
     ----------
     wave : float or list_like
         Wavelength(s) in angstroms.
-    ebv or a_v : float
-        E(B-V) differential extinction, or A(V) total V band extinction,
-        in magnitudes. Specify exactly one. The two values are related by
-        A(V) = R_V * E(B-V).
+    a_v : float
+        Total V band extinction A(V), in magnitudes. A(V) = R_V * E(B-V).
     r_v : float, optional
         R_V parameter. Default is the standard Milky Way average of 3.1.
     model : {'ccm89', 'od94', 'gcc09', 'f99', 'fm07', 'wd01', d03'}, optional
@@ -646,10 +644,8 @@ def reddening(wave, a_v, r_v=3.1, model='od94'):
     ----------
     wave : float or list_like
         Wavelength(s) in angstroms at which to evaluate the reddening.
-    ebv or a_v : float
-        E(B-V) differential extinction, or A(V) total V band extinction,
-        in magnitudes. Specify exactly one. The two values are related by
-        A(V) = R_V * E(B-V).
+    a_v : float
+        Total V band extinction, in magnitudes. A(V) = R_V * E(B-V).
     r_v : float, optional
         R_V parameter. Default is the standard Milky Way average of 3.1.
     model : {'ccm89', 'od94', 'gcc09', 'f99', 'fm07'}, optional

--- a/specutils/tests/test_extinction.py
+++ b/specutils/tests/test_extinction.py
@@ -41,7 +41,8 @@ def test_extinction_ccm89():
 
     wave = 1 / x  # wavelengths in Angstroms
     a_lambda_over_a_v = extinction_ccm89(wave, a_v=1., r_v=3.1)
-
+    assert (u.Quantity(a_lambda_over_a_v, unit=u.dimensionless_unscaled).unit ==
+            u.dimensionless_unscaled)
     np.testing.assert_allclose(a_lambda_over_a_v, ratio_true, atol=0.015)
     
 


### PR DESCRIPTION
This is my first pull-request, so I hope I'm doing this right! I faced some problems when trying to use the extinction laws included in specutils. Specifically, the code as written introduced extraneous units to the extinction laws, returning astropy quantities with units of Angstroms instead of the expected dimensionless quantities.

These changes aim to fix that problem. I have removed code which introduces the wavelength units to the extinction, and changed certain aspects of the docstrings which indicated functionality not yet implemented (specifically, the freedom to specify either A(V) or E(B-V): the extinction functions as written expect to be passed A(V), and the functinality to check the inputs and convert E(B-V) to A(V) doesn't seem like it's been integrated into the function calls, though I might be wrong about that.)

I have not figured out how to run the test suite yet, so I don't know if I've broken something subtle, but I have been able to import and use the reddening() function in my research code and got expected results - something I could not do before my changes (since the exponent was not unitless before these changes.)