### PR TITLE
Add new tag for astroconda incorporation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.2.1.dev'
+VERSION = '0.2.1'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
The astroconda maintainers usually use tags when incorporating packages into the anaconda channel. Obviously, the v0.2 tag is outdated with our current changes (not to mention, the fix for `setup.py` is not in the tagged version, meaning it suffers from the python 3.5.2 `ConfigParser()` regression).

A new tag should be created for the current version of specutils (v0.2.1?) encompassing the new Spectrum1DRef object and the `setup.py` fixes.