### PR TITLE
Astropy Deprecation Warning

### DIFF
--- a/specutils/io/read_fits.py
+++ b/specutils/io/read_fits.py
@@ -3,7 +3,7 @@ import re
 
 from astropy.io import fits
 from astropy import units as u
-from astropy.utils import OrderedDict
+from collections import OrderedDict
 
 from specutils.wcs import specwcs
 from specutils import Spectrum1D

--- a/specutils/wcs/specwcs.py
+++ b/specutils/wcs/specwcs.py
@@ -10,7 +10,7 @@ from astropy.modeling.parameters import Parameter
 from ..models.BSplineModel import BSplineModel
 import astropy.units as u
 
-from astropy.utils import OrderedDict
+from collections import OrderedDict
 from astropy.io import fits
 import copy
 from astropy import constants


### PR DESCRIPTION
When importing specutils, this warning appears: `WARNING: AstropyDeprecationWarning: astropy.utils.compat.odict.OrderedDict is now deprecated - import OrderedDict from the collections module instead [astropy.utils.compat.odict]`

This is an easy fix, so I just did it myself. I don't think I missed any.