### PR TITLE
Parse nanometer unit in specutils.io.read_fits()

### DIFF
--- a/specutils/io/read_fits.py
+++ b/specutils/io/read_fits.py
@@ -71,7 +71,7 @@ def _get_num_coefficients(function_dict):
 
 def _parse_fits_units(fits_unit_string):
     """
-    Parse FITS units - only converting Angstroms to Angstrom
+    Parse FITS units - converting Angstroms to Angstrom and nanometers to nanometer
 
     Parameters
     ----------
@@ -81,6 +81,8 @@ def _parse_fits_units(fits_unit_string):
 
     if fits_unit_string.lower().strip() == 'angstroms':
         fits_unit_string = 'Angstrom'
+    elif fits_unit_string.lower().strip() == 'nanometers':
+        fits_unit_string = 'nanometer'
 
     return u.Unit(fits_unit_string)
 


### PR DESCRIPTION
I have fits spectra that have header values

`WAT0_001= 'system=equispec'`
`WAT1_001= 'wtype=linear label=Wavelength units=nanometers units_display=nm'`

When trying to use specutils.io.read_fits() I was getting this error 

`ValueError: 'nanometers' did not parse as unit: At col 0, nanometers is not a valid unit. Did you mean nanometer?`

which I narrowed down to occur in  `read_fits.FITSWCSSpectrum(hdr)`

I have included parsing of nanometers here to fix this issue.

I am assuming there is not a particular reason why only Angstroms where corrected here.
