### PR TITLE
Update specutils description to better reflect the true goals

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,142 +1,68 @@
-******************
 Specutils
-******************
-An AstroPy affiliated package containing operations and tools on astronomical spectra.
+=========
 
-First Steps
-==============
-The `Spectrum1D`_ class is one of the core classes of the specutils package.
-You can import it like this:
+.. image:: http://img.shields.io/pypi/v/specutils.svg?text=version
+    :target: https://pypi.python.org/pypi/specutils/
+    :alt: Latest release
 
-.. code-block:: python
-  
-  from specutils import Spectrum1D
+.. image:: https://anaconda.org/astropy/specutils/badges/version.svg
+    :target: https://anaconda.org/astropy/specutils
 
-To instantiate it you can define a wave and a flux:
+.. image:: https://anaconda.org/astropy/specutils/badges/downloads.svg
+    :target: https://anaconda.org/astropy/specutils
 
-.. code-block:: python
-  
-  wave = np.arange(6000, 9000) * u.Angstrom
-  flux = np.random.random(3000) * u.Unit('W m-2 angstrom-1 sr-1')
+.. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
+    :target: http://www.astropy.org/
 
-and then call the **from_array** method:
+.. raw:: html
 
-.. code-block:: python
+    <br />
 
-  spec1d = Spectrum1D.from_array(wave, flux)
-  spec1d.wavelength
-  <Quantity [ 6000., 6001., 6002.,...,  8997., 8998., 8999.] Angstrom>
-  spec1d.flux
-  <Quantity [ 0.75639906, 0.23677036, 0.08408417,...,  0.82740303, 0.38345114,
-              0.77815595] W / (Angstrom m2 sr)>
+Specutils is an `Astropy`_ affiliated package with the goal of providing a
+shared set of Python representations of astronomical spectra, and basic tools to
+operate on these spectra.  The effort is also meant to be a "hub", helping to
+unite the Python astronomical spectroscopy community around shared effort, much
+as `Astropy`_ is meant to for the wider astronomy Python ecosystem.
 
-Or you can read a Spectrum from a .fits file with the **read_fits** method:
+Note that Specutils is *not* intended as an all-in-one spectroscopic analysis or
+reduction tool.  While it provides some baseline analysis (following the Python
+philosophy of "batteries included"), it is also meant to facilitate connecting
+together disparate reduction pipelines and analysis tools through shared data
+representations.
 
-.. code-block:: python
 
-  from specutils.io import read_fits
-  myspec = read_fits.read_fits_spectrum1d('myfile.fits')
+Project Status
+--------------
 
-It supports the types of FITS formats listed in `this page`_.
-**Note:** A list of spectra is returned whenever the input file is a multispec file.
+Documentation:
 
-Writing spectra to .fits files works in the same way with the **write_fits** method:
+.. image:: https://readthedocs.org/projects/specutils/badge/?version=stable
+    :target: http://specutils.readthedocs.io/en/stable/
+    :alt: Stable Documentation Status
 
-.. code-block:: python
+.. image:: https://readthedocs.org/projects/specutils/badge/?version=latest
+    :target: http://specutils.readthedocs.io/en/latest/
+    :alt: Latest Documentation Status
 
-  from specutils.io import write_fits
-  write_fits.write(myspec, 'mynewfile.fits')
-**Note:** write_fits.write deciphers the type of object passed and writes spectra to the given file in FITS format.
+Tests:
 
-Reading a Spectrum from a FITS file with no specified units in the header will give the following warning:
+.. image:: https://travis-ci.org/astropy/specutils.svg?branch=master
+    :target: https://travis-ci.org/astropy/specutils
 
-.. code-block:: python
+.. image:: https://coveralls.io/repos/astropy/specutils/badge.svg?branch=master
+    :target: https://coveralls.io/r/astropy/specutils
 
-  myspec = read_fits.read_fits_spectrum1d('specutils/io/tests/files/UVES.fits')
-  UserWarning: Initializing a Spectrum1D WCS with units set to `None` is not recommended
+.. image:: https://ci.appveyor.com/api/projects/status/by27a71echj18b4f/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/Astropy/specutils/branch/master
 
-the Spectrum1D.dispersion will be an array:
+.. image:: http://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat
+    :target: http://astropy.org/specutils-benchmarks/
 
-.. code-block:: python
-  
-  myspec.dispersion
-  array([ 3732.05623192,  3732.0858853 ,  3732.11553869, ...,  4999.67906915,
-          4999.70872253,  4999.73837591])
 
-and thus the Spectrum1D's wavelength, energy and frequency will not be available.
-In order to be convertible, the dispersion must be an astropy Quantity, which will happen if the FITS header has specified the units or if you specify them manually like this:
+License
+-------
 
-.. code-block:: python
+Specutils is licensed under a 3-clause BSD style license (see the
+``licenses/LICENSE.rst`` file).
 
-  myspec = read_fits.read_fits_spectrum1d('specutils/io/tests/files/UVES.fits', dispersion_unit='angstrom')
-  myspec.dispersion
-  <Quantity [ 3732.05623192, 3732.0858853 , 3732.11553869,...,
-              4999.67906915, 4999.70872253, 4999.73837591] Angstrom>
-  myspec.wavelength
-  <Quantity [ 3732.05623192, 3732.0858853 , 3732.11553869,...,
-              4999.67906915, 4999.70872253, 4999.73837591] Angstrom> 
-  myspec.energy
-  <Quantity [ 5.32265743e-19,  5.32261514e-19,  5.32257285e-19,...,
-              3.97314639e-19,  3.97312282e-19,  3.97309926e-19] J>
-  myspec.frequency
-  <Quantity [ 8.03290303e+14,  8.03283920e+14,  8.03277538e+14,...,
-              5.99623404e+14,  5.99619847e+14,  5.99616291e+14] Hz>
-
-You can easily make a plot of the Spectrum using matplotlib in ipython with the --pylab flag and calling:
-
-.. code-block:: python
-
-  plot(myspec.wavelength, myspec.flux)
-
-.. plot:: pyplots/plotting_example.py
-  
-World Coordinate System
-=========================
-* Spectral 1D WCS
-The simplest WCS for 1D is a lookup table. This is often found in a ascii tables where one column is the lookup table (wavelength array) and one column is the flux array. In terms of the functional transform view: the lookup table represents a parameter (c0):
-
-.. code-block:: python
-
-  lookup_table_wcs = specwcs.Spectrum1DLookupWCS(wave, unit='angstrom') # create the wcs
-  lookup_table_wcs(0) # doing the transformation for pixel 0
-  <Quantity 6000.0 Angstrom>
-  Spectrum1D(flux=flux, wcs=lookup_table_wcs)
-  Spectrum1D([ 0.66118716,  0.39584688,  0.81210479, ...,  0.5238203 ,
-               0.05986459,  0.11621466])
-
-Another common WCS is the **linear dispersion** and commonly serialized (encoded) to FITS keyword headers. For linear dispersion we are using the general `Spectrum1DPolynomialWCS`_ WCS.
-
-The `CompositeWCS`_ and `WeightedCombinationWCS`_ models can be useful to combine different WCS.
-Another important model available is the `DopplerShift`_ model. This model is specifically for calculating the doppler shift from velocity (v).
-
-In addition, the following WCS models exist as well:
-    * `Spectrum1DIRAFLegendreWCS`_
-    * `Spectrum1DIRAFChebyshevWCS`_
-    * `Spectrum1DIRAFBSplineWCS`_
-    * `MultispecIRAFCompositeWCS`_
-These models are just IRAF extensions of already existing models. This extensions enable the user to read and write from IRAF FITS files.
-
-Spectral Tools and Utilities
-================================
-* Interstellar Extinction calculations
-This module contains extinction law functions. See the documentation for individual functions.
-
-`Full Documentation`_ 
-
-.. image:: https://travis-ci.org/astropy/specutils.png?branch=master
-  :target: https://travis-ci.org/astropy/specutils
-
-.. image:: https://coveralls.io/repos/astropy/specutils/badge.png
-  :target: https://coveralls.io/r/astropy/specutils
-
-.. _Full Documentation: http://specutils.readthedocs.org/en/latest/specutils/index.html
-.. _this page: http://iraf.net/irafdocs/specwcs.php
-.. _Spectrum1D: http://specutils.readthedocs.org/en/latest/specutils/spectrum1d.html
-.. _Spectrum1DPolynomialWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.Spectrum1DPolynomialWCS.html#specutils.wcs.specwcs.Spectrum1DPolynomialWCS
-.. _CompositeWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.CompositeWCS.html#specutils.wcs.specwcs.CompositeWCS
-.. _WeightedCombinationWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.WeightedCombinationWCS.html#specutils.wcs.specwcs.WeightedCombinationWCS
-.. _DopplerShift: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.DopplerShift.html#specutils.wcs.specwcs.DopplerShift
-.. _Spectrum1DIRAFLegendreWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.Spectrum1DIRAFLegendreWCS.html#specutils.wcs.specwcs.Spectrum1DIRAFLegendreWCS
-.. _Spectrum1DIRAFChebyshevWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.Spectrum1DIRAFChebyshevWCS.html#specutils.wcs.specwcs.Spectrum1DIRAFChebyshevWCS
-.. _Spectrum1DIRAFBSplineWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.Spectrum1DIRAFBSplineWCS.html#specutils.wcs.specwcs.Spectrum1DIRAFBSplineWCS
-.. _MultispecIRAFCompositeWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.MultispecIRAFCompositeWCS.html#specutils.wcs.specwcs.MultispecIRAFCompositeWCS -->
+.. _Astropy: http://www.astropy.org/

--- a/README.rst
+++ b/README.rst
@@ -19,13 +19,13 @@ Specutils
     <br />
 
 Specutils is an `Astropy`_ affiliated package with the goal of providing a
-shared set of Python representations of astronomical spectra, and basic tools to
+shared set of Python representations of astronomical spectra and basic tools to
 operate on these spectra.  The effort is also meant to be a "hub", helping to
 unite the Python astronomical spectroscopy community around shared effort, much
 as `Astropy`_ is meant to for the wider astronomy Python ecosystem.
 
 Note that Specutils is *not* intended as an all-in-one spectroscopic analysis or
-reduction tool.  While it provides some baseline analysis (following the Python
+reduction tool.  While it provides some basic analysis (following the Python
 philosophy of "batteries included"), it is also meant to facilitate connecting
 together disparate reduction pipelines and analysis tools through shared data
 representations.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,13 @@
-******************
+*********
 Specutils
-******************
-An AstroPy affiliated package containing operations and tools on astronomical spectra.
+*********
+
+Specutils is an `Astropy`_ affiliated package with the goal of providing a
+shared set of Python representations of astronomical spectra, and basic tools to
+operate on these spectra.  The effort is also meant to be a "hub", helping to
+unite the Python astronomical spectroscopy community around shared effort, much
+as `Astropy`_ is meant to for the wider astronomy Python ecosystem.
+
 
 First Steps
 ==============
@@ -9,13 +15,13 @@ The `Spectrum1D`_ class is one of the core classes of the specutils package.
 You can import it like this:
 
 .. code-block:: python
-  
+
   >>> from specutils import Spectrum1D
 
 To instantiate it you can define a wave and a flux:
 
 .. code-block:: python
-  
+
   >>> wave = np.arange(6000, 9000) * u.Angstrom
   >>> flux = np.random.random(3000) * u.Unit('W m-2 angstrom-1 sr-1')
 
@@ -60,7 +66,7 @@ Reading a Spectrum from a FITS file with no specified units in the header will g
 the Spectrum1D.dispersion will be an array:
 
 .. code-block:: python
-  
+
   >>> myspec.dispersion
   array([ 3732.05623192,  3732.0858853 ,  3732.11553869, ...,  4999.67906915,
           4999.70872253,  4999.73837591])
@@ -76,7 +82,7 @@ In order to be convertible, the dispersion must be an astropy Quantity, which wi
               4999.67906915, 4999.70872253, 4999.73837591] Angstrom>
   >>> myspec.wavelength
   <Quantity [ 3732.05623192, 3732.0858853 , 3732.11553869,...,
-              4999.67906915, 4999.70872253, 4999.73837591] Angstrom> 
+              4999.67906915, 4999.70872253, 4999.73837591] Angstrom>
   >>> myspec.energy
   <Quantity [ 5.32265743e-19,  5.32261514e-19,  5.32257285e-19,...,
               3.97314639e-19,  3.97312282e-19,  3.97309926e-19] J>
@@ -93,7 +99,7 @@ You can easily make a plot of the Spectrum using matplotlib in ipython with the 
 
 .. plot:: pyplots/plotting_example.py
 
-`Full Documentation`_ 
+`Full Documentation`_
 
 .. image:: https://travis-ci.org/astropy/specutils.png?branch=master
   :target: https://travis-ci.org/astropy/specutils
@@ -112,3 +118,5 @@ You can easily make a plot of the Spectrum using matplotlib in ipython with the 
 .. _Spectrum1DIRAFChebyshevWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.Spectrum1DIRAFChebyshevWCS.html#specutils.wcs.specwcs.Spectrum1DIRAFChebyshevWCS
 .. _Spectrum1DIRAFBSplineWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.Spectrum1DIRAFBSplineWCS.html#specutils.wcs.specwcs.Spectrum1DIRAFBSplineWCS
 .. _MultispecIRAFCompositeWCS: http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.MultispecIRAFCompositeWCS.html#specutils.wcs.specwcs.MultispecIRAFCompositeWCS -->
+
+.. _Astropy: http://www.astropy.org/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Specutils
 *********
 
 Specutils is an `Astropy`_ affiliated package with the goal of providing a
-shared set of Python representations of astronomical spectra, and basic tools to
+shared set of Python representations of astronomical spectra and basic tools to
 operate on these spectra.  The effort is also meant to be a "hub", helping to
 unite the Python astronomical spectroscopy community around shared effort, much
 as `Astropy`_ is meant to for the wider astronomy Python ecosystem.


### PR DESCRIPTION
This updates the README and the docs index page with a more detailed description of the current "vision" for specutils.  

It also removes some material that to me looked like "documentation" from the README.  That's always dangerous because it inevitably becomes out-of-date.  I could add back a link that points to the "first steps" page or something, though...

@keflavich and/or @crawfordsm - look reasonable to you?