### PR TITLE
Fixes sphinx extension error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,6 @@ import sys
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
 
-extensions += ['sphinx.ext.mathjax']
-
 # Get configuration information from setup.cfg
 try:
     from ConfigParser import ConfigParser


### PR DESCRIPTION
This is the error message when the documentation is built with sphinx v1.4.9:

```
Extension error:
sphinx.ext.mathjax: other math package is already loaded
```

The sphinx configuration in astropy_helpers already loads other math
packages depending on the sphinx version.