### PR TITLE
Implement splice routine in specutils

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -58,7 +58,7 @@ Defining WCS
 
 Specutils always maintains a WCS object whether it is passed explicitly by the
 user, or is created dynamically by specutils itself. In the latter case, the
-user need not be awrae that the WCS object is being used, and is can interact
+user need not be aware that the WCS object is being used, and is can interact
 with the :class:~`specutils.spectra.Spectrum1D` object as if it were only a simple
 data container.
 
@@ -116,8 +116,8 @@ Multi-dimensional Data Sets
 
 Specutils supports the case where the user may have an `(n_spectra, n_pix)`
 shaped data set where each `n_spectra` element provides a different flux data
-array and so `flux` and `uncertainty` may be multidimensional as long as the last
-dimension matches the shape of spectral_axis This is meant to allow fast operations on
+array. Therefore `flux` and `uncertainty` may be multidimensional as long as the last
+dimension matches the shape of spectral_axis. This is meant to allow fast operations on
 collections of spectra that share the same `spectral_axis`. While it may seem to
 conflict with the “1D” in the class name, this name scheme is meant to
 communicate the presence of a single common spectral axis.

--- a/specutils/analysis/resample.py
+++ b/specutils/analysis/resample.py
@@ -1,0 +1,208 @@
+import logging
+import os
+
+import numpy as np
+import astropy.units as u
+
+__all__ = ['Resample']
+
+
+class Resample(object):
+    """
+    Resample model which can be used with compound model objects.
+    """
+
+    u.quantity_input(new_dispersion=['speed', 'length'])
+    def __init__(self, new_dispersion):
+        self._new_dispersion = new_dispersion
+        self._disp_unit = self._new_dispersion.unit
+
+    def __call__(self, x, y):
+        _remat = resample(x, self._new_dispersion)
+
+        return np.dot(_remat, y)
+
+
+def resample(orig_lamb, fin_lamb, unit=None, force=None, **kwargs):
+    """
+    Abstraction function to decide whether to use uniform or non-uniform
+    resampling functions.
+
+    Parameters
+    ----------
+    orig_lamb : ndarray
+        Original dispersion grid.
+    fin_lamb : ndarray
+        Final dispersion grid.
+    kwargs : dict
+        Extra keyword arguments to pass to functions.
+
+    Returns
+    -------
+    resample_mat : ndarray
+        The resampling matrix to be applied to data arrays.
+    """
+
+    orig_lamb = u.Quantity(orig_lamb, unit=unit)
+    fin_lamb = u.Quantity(fin_lamb, unit=unit)
+
+    orig_space = (orig_lamb[1:] - orig_lamb[:-1]).value
+    fin_space = (fin_lamb[1:] - fin_lamb[:-1]).value
+
+    if np.allclose(orig_space, orig_space[0]) and np.allclose(fin_space, fin_space[0]):
+        logging.info("Re-sampling: original and final grids are uniform.")
+        mat = _uniform_matrix(orig_lamb, fin_lamb)
+    else:
+        logging.info("Re-sampling: original and final grids are non-uniform.")
+        mat = _nonuniform_matrix(orig_lamb, fin_lamb, **kwargs)
+
+    return mat
+
+
+def _uniform_matrix(orig_lamb, fin_lamb):
+    """
+    Create a re-sampling matrix to be used in re-sampling spectra in a way
+    that conserves flux. This is adapted from code created by the SEAGal
+    Group.
+    .. note:: This method assumes uniform grids.
+    Parameters
+    ----------
+    orig_lamb : ndarray
+        The original dispersion array.
+    fin_lamb : ndarray
+        The desired dispersion array.
+    Returns
+    -------
+    resample_mat : ndarray
+        An [[N_{fin_lamb}, M_{orig_lamb}]] matrix.
+    """
+
+    # Get step size
+    delta_orig = orig_lamb[1] - orig_lamb[0]
+    delta_fin = fin_lamb[1] - fin_lamb[0]
+
+    n_orig_lamb = len(orig_lamb)
+    n_fin_lamb = len(fin_lamb)
+
+    # Lower bin and upper bin edges
+    orig_low = orig_lamb - delta_orig * 0.5
+    orig_upp = orig_lamb + delta_orig * 0.5
+    fin_low = fin_lamb - delta_fin * 0.5
+    fin_upp = fin_lamb + delta_fin * 0.5
+
+    # Create re-sampling matrix
+    resamp_mat = np.zeros(shape=(n_fin_lamb, n_orig_lamb))
+
+    for i in range(n_fin_lamb):
+        # Calculate the contribution of each original bin to the
+        # resampled bin
+        l_inf = np.where(orig_low > fin_low[i], orig_low, fin_low[i])
+        l_sup = np.where(orig_upp < fin_upp[i], orig_upp, fin_upp[i])
+
+        # Interval overlap of each original bin for current resampled
+        # bin; negatives clipped
+        dl = (l_sup - l_inf).clip(0)
+
+        # This will only happen at the edges of lorig.
+        # Discard resampled bin if it's not fully covered (> 99%) by the
+        #  original bin -- only happens at the edges of the original bins
+        if 0 < dl.sum() < 0.99 * delta_fin.value:
+            dl = 0 * orig_lamb
+
+        resamp_mat[i, :] = dl
+
+    resamp_mat = resamp_mat / delta_fin
+
+    return resamp_mat
+
+
+def _nonuniform_matrix(orig_lamb, fin_lamb, extrapolate=False):
+    """
+    Compute re-sampling matrix R_o2r, useful to convert a spectrum sampled at
+    wavelengths lorig to a new grid lresamp. Here, there is no necessity to
+    have constant gris as on :func:`_uniform_matrix`. This is adapted from code
+    created by the SEAGal Group.
+    .. warning:: lorig and lresam MUST be on ascending order!
+    Parameters
+    ----------
+    orig_lamb : array_like
+        Original spectrum lambda array.
+    fin_lamb : array_like
+        Spectrum lambda array in which the spectrum should be sampled.
+    extrapolate : boolean, optional
+        Extrapolate values, i.e. values for fin_lamb < orig_lamb[0] are set to
+        match orig_lamb[0] and values for fin_lamb > orig_lamb[-1] are set to
+        match orig_lamb[-1].
+    Returns
+    -------
+    resample_mat : ndarray
+        Resample matrix.
+    """
+    matrix = np.zeros(shape=(len(fin_lamb), len(orig_lamb)))
+
+    # Define lambda ranges (low, upp) for original and resampled.
+    lo_low = np.zeros(len(orig_lamb))
+    lo_low[1:] = (orig_lamb[1:] + orig_lamb[:-1]) / 2
+    lo_low[0] = orig_lamb[0] - (orig_lamb[1] - orig_lamb[0]) / 2
+
+    lo_upp = np.zeros(len(orig_lamb))
+    lo_upp[:-1] = lo_low[1:]
+    lo_upp[-1] = orig_lamb[-1] + (orig_lamb[-1] - orig_lamb[-2]) / 2
+
+    lr_low = np.zeros(len(fin_lamb))
+    lr_low[1:] = (fin_lamb[1:] + fin_lamb[:-1]) / 2
+    lr_low[0] = fin_lamb[0] - (fin_lamb[1] - fin_lamb[0]) / 2
+
+    lr_upp = np.zeros(len(fin_lamb))
+    lr_upp[:-1] = lr_low[1:]
+    lr_upp[-1] = fin_lamb[-1] + (fin_lamb[-1] - fin_lamb[-2]) / 2
+
+    # Iterate over resampled fin_lamb vector
+    for i in range(len(fin_lamb)):
+
+        # Find in which bins fin_lamb bin within orig_lamb bin
+        bins_resamp = np.where((lr_low[i] < lo_upp) & (lr_upp[i] > lo_low))[0]
+
+        # On these bins, eval fraction of resampled bin is within original bin.
+        for j in bins_resamp:
+            aux = 0
+
+            d_lr = lr_upp[i] - lr_low[i]
+            d_lo = lo_upp[j] - lo_low[j]
+            d_ir = lo_upp[j] - lr_low[i]  # common section on the right
+            d_il = lr_upp[i] - lo_low[j]  # common section on the left
+
+            # Case 1: resampling window is smaller than or equal to the
+            # original window. This is where the bug was: if an original bin
+            # is all inside the resampled bin, then all flux should go into it,
+            # not then d_lr/d_lo fraction.
+            if (lr_low[i] > lo_low[j]) & (lr_upp[i] < lo_upp[j]):
+                aux += 1.
+
+            # Case 2: resampling window is larger than the original window.
+            if (lr_low[i] < lo_low[j]) & (lr_upp[i] > lo_upp[j]):
+                aux += d_lo / d_lr
+
+            # Case 3: resampling window is on the right of the original window.
+            if (lr_low[i] > lo_low[j]) & (lr_upp[i] > lo_upp[j]):
+                aux += d_ir / d_lr
+
+            # Case 4: resampling window is on the left of the original window.
+            if (lr_low[i] < lo_low[j]) & (lr_upp[i] < lo_upp[j]):
+                aux += d_il / d_lr
+
+            matrix[i, j] += aux
+
+    # Fix extremes: extrapolate if needed
+    if extrapolate:
+        bins_extrapl = np.where((lr_low < lo_low[0]))[0]
+        bins_extrapr = np.where((lr_upp > lo_upp[-1]))[0]
+
+        if len(bins_extrapl) > 0 and len(bins_extrapr) > 0:
+            io_extrapl = np.where((lo_low >= lr_low[bins_extrapl[0]]))[0][0]
+            io_extrapr = np.where((lo_upp <= lr_upp[bins_extrapr[0]]))[0][-1]
+
+            matrix[bins_extrapl, io_extrapl] = 1.
+            matrix[bins_extrapr, io_extrapr] = 1.
+
+    return matrix

--- a/specutils/analysis/splice.py
+++ b/specutils/analysis/splice.py
@@ -8,7 +8,7 @@ class Splice(object):
     def __init__(self, spacing='coarse'):
         if not spacing in ['coarse', 'fine']:
             raise ValueError("Attribute 'spacing' must be one of 'coarse' or 'fine'.")
-            
+
         self._spacing = spacing
 
     def __call__(self, spec_array):

--- a/specutils/analysis/splice.py
+++ b/specutils/analysis/splice.py
@@ -1,0 +1,54 @@
+import numpy as np
+import logging
+from .resample import Resample
+from ..spectra import Spectrum1D
+
+
+class Splice(object):
+    def __init__(self, spacing='coarse'):
+        if not spacing in ['coarse', 'fine']:
+            raise ValueError("Attribute 'spacing' must be one of 'coarse' or 'fine'.")
+            
+        self._spacing = spacing
+
+    def __call__(self, spec_array):
+        # Cache resampled Spectrum1D objects
+        resamp_specs = []
+
+        # Get the appropriate new bin size for the out dispersion
+        fin_disp = None
+        min_disp = min([spec.wavelength[0] for spec in spec_array])
+        max_disp = max([spec.wavelength[-1] for spec in spec_array])
+
+        for spec in spec_array:
+            if self._spacing == 'coarse':
+                if fin_disp is None or np.mean(np.diff(spec.wavelength)) > np.mean(np.diff(fin_disp)):
+                    fin_disp = spec.wavelength
+                    logging.info("Increasing bin width to {}.".format(np.mean(np.diff(spec.wavelength))))
+            elif self._spacing == 'fine':
+                if fin_disp is None or np.mean(np.diff(spec.wavelength)) < np.mean(np.diff(fin_disp)):
+                    fin_disp = spec.wavelength
+                    logging.info("Decreasing bin width to {}.".format(np.mean(np.diff(spec.wavelength))))
+
+        fin_disp = np.arange(min_disp.value, max_disp.value, np.mean(np.diff(fin_disp.value))) * fin_disp.unit
+
+        # Define the resample instance
+        resample = Resample(fin_disp)
+
+        for spec in spec_array:
+            weights = spec.meta.get('weights')
+
+            if weights is None:
+                weights = np.ones(spec.flux.shape)
+
+            flux = resample(spec.wavelength, spec.flux)
+            uncert = spec.uncertainty.__class__(resample(spec.wavelength,
+                                                         spec.uncertainty.array))
+            wave = fin_disp
+            weights = resample(spec.wavelength, weights)
+
+            resamp_specs.append(Spectrum1D(flux=flux, uncertainty=uncert,
+                                           spectral_axis=wave, meta={'weights': weights}))
+
+        return (np.sum([spec * spec.meta['weights'] for spec in resamp_specs], axis=0) /
+                np.sum([spec.meta['weights'] for spec in resamp_specs], axis=0))

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -79,6 +79,12 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         elif wcs is not None:
             if not issubclass(wcs.__class__, WCSAdapter):
                 wcs = WCSWrapper(wcs)
+        elif isinstance(flux, float) or isinstance(flux, int) or isinstance(flux, np.ndarray):
+            # In the case where the arithmetic operation is being performed with
+            # a single float, int, or array object, just go ahead and ignore wcs
+            # requirements
+            super(Spectrum1D, self).__init__(data=flux)
+            return
         else:
             # If not wcs and no spectral axis has been given, raise an error
             raise LookupError("No WCS object or spectral axis information has "
@@ -131,6 +137,11 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         """
         NNData arithmetic callable to determine if two wcs's are compatible.
         """
+        # If the other operand is a simple number or array, allow the operations
+        if (isinstance(other_operand, float) or isinstance(other_operand, int)
+            or isinstance(other_operand, np.ndarray)):
+            return True
+
         # First check if units are equivalent, if so, create a new spectrum
         # object with spectral axis in compatible units
         other_wcs = other_operand.wcs.with_spectral_unit(
@@ -169,7 +180,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         return self.subtract(
             other, compare_wcs=lambda o1, o2: self._compare_wcs(self, other))
 
-    def __mult__(self, other):
+    def __mul__(self, other):
         return self.multiply(
             other, compare_wcs=lambda o1, o2: self._compare_wcs(self, other))
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -64,13 +64,10 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             super(Spectrum1D, self).__init__(flux)
             return
 
-        # Attempt to parse the WCS. If no WCS object is given, try instead to
-        # parse a given wavelength array. This is put into a GWCS object to
+        # Attempt to parse the spectral axis. If none is given, try instead to
+        # parse a given wcs. This is put into a GWCS object to
         # then be used behind-the-scenes for all specutils operations.
-        if wcs is not None:
-            if not issubclass(wcs.__class__, WCSAdapter):
-                wcs = WCSWrapper(wcs)
-        elif spectral_axis is not None:
+        if spectral_axis is not None:
             if not isinstance(spectral_axis, u.Quantity):
                 spectral_axis = u.Quantity(spectral_axis,
                                            unit=spectral_axis_unit or u.AA)
@@ -79,6 +76,9 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
                                 "{}".format(spectral_axis.unit))
 
             wcs = WCSWrapper.from_array(spectral_axis)
+        elif wcs is not None:
+            if not issubclass(wcs.__class__, WCSAdapter):
+                wcs = WCSWrapper(wcs)
         else:
             # If not wcs and no spectral axis has been given, raise an error
             raise LookupError("No WCS object or spectral axis information has "

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -1,0 +1,39 @@
+import numpy as np
+from .spectrum1d import Spectrum1D
+
+
+class SpectrumCollection(np.ndarray):
+
+    def __new__(subtype, shape, buffer=None, offset=0,
+                strides=None, order=None, *args, **kwargs):
+        obj = super(SpectrumCollection, subtype).__new__(subtype, shape, Spectrum1D,
+                                                buffer, offset, strides,
+                                                order)
+        return obj
+
+    def __array_finalize__(self, obj):
+        # ``self`` is a new object resulting from
+        # ndarray.__new__(InfoArray, ...), therefore it only has
+        # attributes that the ndarray.__new__ constructor gave it -
+        # i.e. those of a standard ndarray.
+        #
+        # We could have got to the ndarray.__new__ call in 3 ways:
+        # From an explicit constructor - e.g. InfoArray():
+        #    obj is None
+        #    (we're in the middle of the InfoArray.__new__
+        #    constructor, and self.info will be set when we return to
+        #    InfoArray.__new__)
+        if obj is None: return
+        # From view casting - e.g arr.view(InfoArray):
+        #    obj is arr
+        #    (type(obj) can be InfoArray)
+        # From new-from-template - e.g infoarr[:3]
+        #    type(obj) is InfoArray
+        #
+        # Note that it is here, rather than in the __new__ method,
+        # that we set the default value for 'info', because this
+        # method sees all creation of default objects - with the
+        # InfoArray.__new__ constructor, but also with
+        # arr.view(InfoArray).
+        self.info = getattr(obj, 'info', None)
+        # We do not need to return anything

--- a/specutils/wcs/adapters/fitswcs_adapter.py
+++ b/specutils/wcs/adapters/fitswcs_adapter.py
@@ -39,7 +39,7 @@ class FITSWCSAdapter(WCSAdapter):
         """
         Method for performing the pixel to world transformations.
         """
-        return self.axes.spectral.all_pix2world(pixel_array, 0)[0]
+        return self.axes.spectral.all_world2pixel(pixel_array, 0)[0]
 
     @property
     def spectral_axis_unit(self):

--- a/specutils/wcs/wcs_wrapper.py
+++ b/specutils/wcs/wcs_wrapper.py
@@ -59,7 +59,7 @@ class WCSWrapper:
         forward_transform.inverse = Tabular1D(array.value, np.arange(len(array)))
 
         tabular_gwcs = gwcs.wcs.WCS(forward_transform=forward_transform,
-                                    input_frame=coord_frame, 
+                                    input_frame=coord_frame,
                                     output_frame=spec_frame)
 
         return WCSWrapper(wcs=tabular_gwcs)


### PR DESCRIPTION
In an effort to update oft asked for pyraf routines, this is a re-implementation of the splice function.

- [x] Calculate average in overlap regions.
- [x] Allow specifying whether to use coarsest or finest grid in output.
- [x] Allow arbitrary weights (currently defined in the `meta` dict of the `Spectrum1D` object).
- [ ] Ensure uncertainty propagation is implementation correctly.
- [ ] Make sure that non-uniform grid resampling works with `Spectrum1D` object.
- [ ] Write documentation.
- [ ] Write tests.