### PR TITLE
Update template stuff

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,0 +1,25 @@
+Copyright (c) 2017, Astropy-specutils Developers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+* Neither the name of the Astropy Team nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,3 +1,3 @@
 python:
-    version: 3.5
+    version: 3.6
     setup_py_install: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ license = BSD
 url = http://specutils.astropy.org/
 edit_on_github = False
 github_project = astropy/specutils
-install_requires = astropy six gwcs scipy
+install_requires = astropy, six, gwcs, scipy
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
 version = 0.1.dev
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,6 @@ edit_on_github = False
 github_project = astropy/specutils
 install_requires = astropy, six, gwcs, scipy
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.1.dev
+version = 0.3.1
 
 [entry_points]

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,16 @@ import glob
 import os
 import sys
 
+# Uncomment to enforce Python version check during package import.
+# Also uncomment python_requires below in setup().
+# Replace "packagename" in error message with your package name.
+# This is the same check as packagename/__init__.py but this one has to
+# happen before importing ah_bootstrap.
+#__minimum_python_version__ = '3.5'
+#if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
+#    sys.stderr.write("ERROR: packagename requires Python {} or later\n".format(__minimum_python_version__))
+#    sys.exit(1)
+
 import ah_bootstrap
 from setuptools import setup
 
@@ -30,11 +40,11 @@ conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 
-PACKAGENAME = metadata.get('package_name', 'packagename')
-DESCRIPTION = metadata.get('description', 'Astropy affiliated package')
-AUTHOR = metadata.get('author', '')
+PACKAGENAME = metadata.get('package_name', 'specutils')
+DESCRIPTION = metadata.get('description', 'packagename')
+AUTHOR = metadata.get('author', 'Astropy-specutils Developers')
 AUTHOR_EMAIL = metadata.get('author_email', '')
-LICENSE = metadata.get('license', 'unknown')
+LICENSE = metadata.get('license', 'BSD-3')
 URL = metadata.get('url', 'http://astropy.org')
 
 # order of priority for long_description:
@@ -66,7 +76,7 @@ else:
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-VERSION = metadata.get('version', '0.1.dev')
+VERSION = metadata.get('version', '0.0.dev0')
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION
@@ -126,7 +136,7 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      install_requires=metadata.get('install_requires', 'astropy').strip().split(),
+      install_requires=[s.strip() for s in metadata.get('install_requires', 'astropy').split(',')],
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,
@@ -136,5 +146,6 @@ setup(name=PACKAGENAME,
       zip_safe=False,
       use_2to3=False,
       entry_points=entry_points,
+#     python_requires='>=' + __minimum_python_version__,
       **package_info
 )


### PR DESCRIPTION
The PR adds the missing license file and will thus close #182. It also updates ``setup.py`` to the latest template version and updates the ``readthedocs`` python version to 3.6. 

closes #183