### PR TITLE
Change to specutils text in docs header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,8 +114,8 @@ release = package.__version__
 
 # Please update these texts to match the name of your package.
 html_theme_options = {
-    'logotext1': 'package',  # white,  semi-bold
-    'logotext2': '-template',  # orange, light
+    'logotext1': 'spec',  # white,  semi-bold
+    'logotext2': 'utils',  # orange, light
     'logotext3': ':docs'   # white,  light
     }
 


### PR DESCRIPTION
I noticed the docs still have the "package-template" header.  This PR should fix that.

Before:
![image](https://user-images.githubusercontent.com/346587/40402873-21e2f5ec-5e1c-11e8-8b87-f26a7f5e0fe6.png)

After:
![image](https://user-images.githubusercontent.com/346587/40402885-39c897de-5e1c-11e8-80ee-3f4c07952c4b.png)
