### PR TITLE
Flux Units: Equivalencies and Suppress Conversion

### DIFF
--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -87,6 +87,10 @@ class OneDSpectrumMixin(object):
             Custom equivalencies to apply to conversions.
             Set to spectral_density by default.
 
+        suppress_conversion : bool
+            Set to true if updating the unit without
+            converting data values.
+
         Returns
         -------
         ~`astropy.units.Quantity`


### PR DESCRIPTION
Adds the ability to specify the equivalencies used for flux conversions and change the flux units without converting the data values. Issue #197 