### PR TITLE
Cleanup RTD config files

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,0 +1,12 @@
+name: specutils
+
+channels:
+    - astropy
+
+dependencies:
+    - python>=3
+    - astropy>=2.0
+    - sphinx
+    - numpy
+    - scipy
+    - gwcs

--- a/docs/docs/rtd-pip-requirements
+++ b/docs/docs/rtd-pip-requirements
@@ -1,5 +1,0 @@
-numpy>=1.9
-numpydoc
-scipy
-gwcs
-astropy>=2.0

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,5 +1,0 @@
-numpy>=1.9
-numpydoc
-scipy
-gwcs
-astropy>=2.0

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,3 +1,5 @@
+conda:
+    file: .rtd-environment.yml
+
 python:
-    version: 3.6
     setup_py_install: true


### PR DESCRIPTION
The readthedocs builds are failing since b545a39e16e977cce16d554f93f2a491cf4e2294 with 

```
Error

Problem parsing YAML configuration. Invalid "python.version": expected one of (2, 2.7, 3, 3.5), got 3.6
```

This PR overhauls the config files to use the same layout as other astropy packages. Skip CI was used as these files are not tested, and rtd will only run anyway once this is merged.