### PR TITLE
Use more config options from the template

### DIFF
--- a/docs/arithmetic.rst
+++ b/docs/arithmetic.rst
@@ -71,3 +71,8 @@ Arithmetic operations also support the propagation of unceratinty information.
                    0.12725778, 0.06720435, 0.06568154, 0.06233969,
                    0.04384698, 0.10648737])
 
+
+Reference/API
+-------------
+.. automodapi:: specutils.spectra.spectrum_mixin
+    :no-heading:

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -4,7 +4,7 @@ Basic Analysis
 
 The specutils package comes with a few basic spectral analytic functions.
 More extensive and involve analysis techniques will be available in another
-package, `specreduce`.
+package, `specreduce <https://github.com/astropy/specreduce>`_.
 
 Specutils supports some built-in callable functions for basic calculations
 over the given spectrum object.
@@ -23,3 +23,9 @@ Currently, specutils supports basic equivalent width calculations.
     >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=np.random.randn(50))
     >>> equivalent_width(spec) #doctest:+SKIP
     <Quantity 24.16006697 Angstrom>
+
+
+Reference/API
+-------------
+.. automodapi:: specutils.analysis
+    :no-heading:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@
 
 import datetime
 import os
+import six
 import sys
 
 try:
@@ -179,3 +180,28 @@ if eval(setup_cfg.get('edit_on_github')):
 # -- Resolving issue number to links in changelog -----------------------------
 github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_project'])
 
+# -- Turn on nitpicky mode for sphinx (to warn about references not found) ----
+#
+nitpicky = True
+nitpick_ignore = []
+
+# Some warnings are impossible to suppress, and you can list specific references
+# that should be ignored in a nitpick-exceptions file which should be inside
+# the docs/ directory. The format of the file should be:
+#
+# <type> <class>
+#
+# for example:
+#
+# py:class astropy.io.votable.tree.Element
+# py:class astropy.io.votable.tree.SimpleElement
+# py:class astropy.io.votable.tree.SimpleElementWithContent
+#
+# Uncomment the following lines to enable the exceptions:
+#
+# for line in open('nitpick-exceptions'):
+#     if line.strip() == "" or line.startswith("#"):
+#         continue
+#     dtype, target = line.split(None, 1)
+#     target = target.strip()
+#     nitpick_ignore.append((dtype, six.u(target)))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,13 @@ highlight_language = 'python3'
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.2'
 
+# We don't have references to `h5py` ... no need to load the intersphinx mapping file.
+del intersphinx_mapping['h5py']
+del intersphinx_mapping['matplotlib']
+
+# Extend astropy intersphinx_mapping with packages we use here
+intersphinx_mapping['gwcs'] = ('http://gwcs.readthedocs.io/en/latest/', None)
+
 # To perform a Sphinx version check that needs to be more specific than
 # major.minor, call `check_sphinx_version("x.y.z")` here.
 # check_sphinx_version("1.2.1")

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -7,16 +7,16 @@ Loading From a File
 
 Specutils leverages the astropy io registry to provide an interface for conveniently
 loading data from files. To create a custom loader, the user must define it in
-a separate python file and place the file in their `~/.specutils` directory.
+a separate python file and place the file in their ``~/.specutils`` directory.
 
 
 Creating a Custom Loader
 ------------------------
 
-Defining a custom loader consists of importing the `data_loader` decorator from
-specutils and attaching it to a function that knows how to parse the user's data.
-The return object of this function must be a :class:`~specutils.spectra.Spectrum1D`
-object.
+Defining a custom loader consists of importing the
+`~specutils.io.registers.data_loader` decorator from specutils and attaching
+it to a function that knows how to parse the user's data.  The return object
+of this function must be a :class:`~specutils.Spectrum1D` object.
 
 Optionally, the user may define an identifier function. This function acts to
 ensure that the data file being loaded is compatible with the loader function.
@@ -37,7 +37,7 @@ ensure that the data file being loaded is compatible with the loader function.
     from specutils import Spectrum1D
 
     # Define an optional identifier. If made specific enough, this circumvents the
-    # need to add `format="my-format"` in the `Spectrum1D.read` call.
+    # need to add ``format="my-format"`` in the ``Spectrum1D.read`` call.
     def identify_generic_fits(origin, *args, **kwargs):
         return (isinstance(args[0], six.string_types) and
                 os.path.splitext(args[0].lower())[1] == '.fits')
@@ -60,9 +60,9 @@ ensure that the data file being loaded is compatible with the loader function.
         return Spectrum1D(flux=data, wcs=wcs, uncertainty=uncertainty, meta=meta)
 
 
-After placing this python file in the user's `~/.specutils` directory, it can
-be utilized by referencing its name in the `read` method of the :class:`~specutils.spectra.Spectrum1D`
-class
+After placing this python file in the user's ``~/.specutils`` directory, it
+can be utilized by referencing its name in the ``read`` method of the
+:class:`~specutils.Spectrum1D` class
 
 .. code-block:: python
 
@@ -76,7 +76,7 @@ Creating a Custom Writer
 
 Similar to creating a custom loader, a custom data writer may also be defined.
 This again will be done in a separate python file and placed in the user's
-`~/.specutils` directory to be loaded into the astropy io registry.
+``~/.specutils`` directory to be loaded into the astropy io registry.
 
 .. code-block:: python
 
@@ -96,8 +96,8 @@ This again will be done in a separate python file and placed in the user's
         tab.write(file_name, format="fits")
 
 The custom writer can be used by passing the name of the custom writer to the
-`format` argument of the `write` method on the
-:class:`~specutils.spectra.Spectrum1D`.
+``format`` argument of the ``write`` method on the
+:class:`~specutils.Spectrum1D`.
 
 .. code-block:: python
 
@@ -105,3 +105,9 @@ The custom writer can be used by passing the name of the custom writer to the
                       spectral_axis=np.arange(100) * u.AA)
 
     spec.write("my_output.fits", format="fits-writer")
+
+
+Reference/API
+-------------
+.. automodapi:: specutils.io.registers
+    :no-heading:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -75,7 +75,7 @@ Defining WCS
 Specutils always maintains a WCS object whether it is passed explicitly by the
 user, or is created dynamically by specutils itself. In the latter case, the
 user need not be awrae that the WCS object is being used, and is can interact
-with the :class:`~specutils.spectra.Spectrum1D` object as if it were only a simple
+with the :class:`~specutils.Spectrum1D` object as if it were only a simple
 data container.
 
 Currently, specutils understands two WCS formats: FITSWCS and GWCS. When a user
@@ -107,11 +107,11 @@ Providing a FITSWCS
 Including Uncertainties
 -----------------------
 
-The :class:`~specutils.spectra.Spectrum1D` class supports uncertainties, and
-arithmetic operations performed with :class:`~specutils.spectra.Spectrum1D`
+The :class:`~specutils.Spectrum1D` class supports uncertainties, and
+arithmetic operations performed with :class:`~specutils.Spectrum1D`
 objects will propagate uncertainties.
 
-Uncertainties are a special subclass of :class:`~astropy.nddata.NData`, and their
+Uncertainties are a special subclass of :class:`~astropy.nddata.NDData`, and their
 propagation rules are implemented at the class level. Therefore, users must
 specify the uncertainty type at creation time
 
@@ -126,19 +126,18 @@ specify the uncertainty type at creation time
              :class:`~astropy.nddata.UnknownUncertainty` object which will not
              propagate uncertainties in arithmetic operations.
 
-.. seealso:: modules :py:mod:`~astropy.nddata.nduncertainty`
-
 
 Multi-dimensional Data Sets
 ---------------------------
 
-Specutils supports the case where the user may have an `(n_spectra, n_pix)`
-shaped data set where each `n_spectra` element provides a different flux data
-array and so `flux` and `uncertainty` may be multidimensional as long as the last
-dimension matches the shape of spectral_axis This is meant to allow fast operations on
-collections of spectra that share the same `spectral_axis`. While it may seem to
-conflict with the “1D” in the class name, this name scheme is meant to
-communicate the presence of a single common spectral axis.
+Specutils supports the case where the user may have an ``(n_spectra, n_pix)``
+shaped data set where each ``n_spectra`` element provides a different flux
+data array and so ``flux`` and ``uncertainty`` may be multidimensional as
+long as the last dimension matches the shape of spectral_axis This is meant
+to allow fast operations on collections of spectra that share the same
+``spectral_axis``. While it may seem to conflict with the “1D” in the class
+name, this name scheme is meant to communicate the presence of a single
+common spectral axis.
 
 The case where each flux data array is related to a *different* spectral
 axis is currently **not** supported, but is planned for a later update.

--- a/docs/high-level_API.rst
+++ b/docs/high-level_API.rst
@@ -6,3 +6,4 @@ These are the functions and classes available in the top-level
 
 .. automodapi:: specutils
     :no-heading:
+    :no-inheritance-diagram:

--- a/docs/high-level_API.rst
+++ b/docs/high-level_API.rst
@@ -1,0 +1,8 @@
+API Reference
+=============
+
+These are the functions and classes available in the top-level
+``specutils`` namespace.
+
+.. automodapi:: specutils
+    :no-heading:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,9 +29,15 @@ Using specutils
    basic_analysis
    arithmetic
 
+.. toctree::
+    :maxdepth: 1
+
+    high-level_API.rst
+
 
 Get Involved
 ------------
+
 
 Please see :doc:`contributing` for information on bug reporting and
 contributing to the specutils project.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,6 @@ edit_on_github = False
 github_project = astropy/specutils
 install_requires = astropy, six, gwcs, scipy
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.3.1
+version = 0.3.1.dev0
 
 [entry_points]

--- a/specutils/conftest.py
+++ b/specutils/conftest.py
@@ -8,31 +8,33 @@ from astropy.tests.pytest_plugins import *
 ## exceptions
 enable_deprecations_as_exceptions()
 
-## Uncomment and customize the following lines to add/remove entries from
-## the list of packages for which version numbers are displayed when running
-## the tests. Making it pass for KeyError is essential in some cases when
-## the package uses other astropy affiliated packages.
-# try:
-#     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-#     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
-#     del PYTEST_HEADER_MODULES['h5py']
-# except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
-#     pass
+# Uncomment and customize the following lines to add/remove entries from
+# the list of packages for which version numbers are displayed when running
+# the tests. Making it pass for KeyError is essential in some cases when
+# the package uses other astropy affiliated packages.
+try:
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['gwcs'] = 'gwcs'
+    del PYTEST_HEADER_MODULES['h5py']
+    del PYTEST_HEADER_MODULES['Pandas']
+    del PYTEST_HEADER_MODULES['Matplotlib']
+except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
+    pass
 
-## Uncomment the following lines to display the version number of the
-## package rather than the version number of Astropy in the top line when
-## running the tests.
-# import os
-#
-## This is to figure out the affiliated package version, rather than
-## using Astropy's
-# try:
-#     from .version import version
-# except ImportError:
-#     version = 'dev'
-#
-# try:
-#     packagename = os.path.basename(os.path.dirname(__file__))
-#     TESTED_VERSIONS[packagename] = version
-# except NameError:   # Needed to support Astropy <= 1.0.0
-#     pass
+# Uncomment the following lines to display the version number of the
+# package rather than the version number of Astropy in the top line when
+# running the tests.
+import os
+
+# This is to figure out the affiliated package version, rather than
+# using Astropy's
+try:
+    from .version import version
+except ImportError:
+    version = 'dev'
+
+try:
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version
+except NameError:   # Needed to support Astropy <= 1.0.0
+    pass

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -8,6 +8,9 @@ from astropy.io import registry as io_registry
 from ..spectra.spectrum1d import Spectrum1D
 
 
+__all__ = ['data_loader', 'custom_writer']
+
+
 def data_loader(label, identifier=None, dtype=Spectrum1D):
     """
     Wraps a function that can be added to an `~astropy.io.registry` for custom

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -10,6 +10,8 @@ from .spectrum_mixin import OneDSpectrumMixin
 
 __all__ = ['Spectrum1D']
 
+__doctest_skip__ = ['Spectrum1D.spectral_resolution']
+
 
 class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     """

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -19,26 +19,26 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     ----------
     flux : `numpy.ndarray`-like or `astropy.units.Quantity` or astropy.nddata.NDData`-like
         The flux data for this spectrum.
-    spectral_axis : `numpy.ndarray`-like or `astropy.units.Quanitty`
+    spectral_axis : `numpy.ndarray`-like or `astropy.units.Quantity`
         Dispersion information with the same shape as the last (or only)
         dimension of flux.
-    wcs : `astropy.wcs.WCS` or `gwcs.WCS`
+    wcs : `astropy.wcs.WCS` or `gwcs.wcs.WCS`
         WCS information object.
     unit : str or `astropy.units.Unit`
         The unit for the flux data. Must be parseable by `astropy.units.Unit`.
-        If `flux` is supplied as a `astropy.units.Quantity`, this
+        If ``flux`` is supplied as a `~astropy.units.Quantity`, this
         is superceded by the defined unit.
     spectral_axis_unit : str or `astropy.units.Unit`
         The unit for the spectral axis. Must be parseable by `astropy.units.Unit`.
-        If `spectral_axis` is supplied as a `astropy.units.Quantity`, this
+        If ``spectral_axis`` is supplied as a `~astropy.units.Quantity`, this
         is superceded by the defined unit.
     velocity_convention : {"doppler_relativistic", "doppler_optical", "doppler_radio"}
         Convention used for velocity conversions.
-    rest_value : ~`astropy.units.Quantity`
+    rest_value : `~astropy.units.Quantity`
         Any quantity supported by the standard spectral equivalencies
         (wavelength, energy, frequency, wave number). Describes the rest value
         of the spectral axis for use with velocity conversions.
-    uncertainty : ~`astropy.nddata.NDUncertainty`
+    uncertainty : `~astropy.nddata.NDUncertainty`
         Contains uncertainty information along with propagation rules for
         spectrum arithmetic. Can take a unit, but if none is given, will use
         the unit defined in the flux.
@@ -195,29 +195,32 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     def spectral_resolution(self, true_dispersion, delta_dispersion, axis=-1):
         """Evaluate the probability distribution of the spectral resolution.
 
-        For example, to tabulate a binned resolution function at 6000A
-        covering +/-10A in 0.2A steps::
+        Examples
+        --------
 
-        R = spectrum1d.spectral_resolution(
-        ... 6000 * u.Angstrom, np.linspace(-10, 10, 51) * u.Angstrom)
-        assert R.shape == (50,)
-        assert np.allclose(R.sum(), 1.)
+        To tabulate a binned resolution function at 6000A covering +/-10A in
+        0.2A steps:
+
+        >>> R = spectrum1d.spectral_resolution(
+        ...     6000 * u.Angstrom, np.linspace(-10, 10, 51) * u.Angstrom)
+        >>> assert R.shape == (50,)
+        >>> assert np.allclose(R.sum(), 1.)
 
         To build a sparse resolution matrix for true wavelengths 4000-8000A
-        in 0.1A steps::
+        in 0.1A steps:
 
-        R = spectrum1d.spectral_resolution(
-        ... np.linspace(4000, 8000, 40001)[:, np.newaxis] * u.Angstrom,
-        ... np.linspace(-10, +10, 201) * u.Angstrom)
-        assert R.shape == (40000, 200)
-        assert np.allclose(R.sum(axis=1), 1.)
+        >>> R = spectrum1d.spectral_resolution(
+        ...     np.linspace(4000, 8000, 40001)[:, np.newaxis] * u.Angstrom,
+        ...     np.linspace(-10, +10, 201) * u.Angstrom)
+        >>> assert R.shape == (40000, 200)
+        >>> assert np.allclose(R.sum(axis=1), 1.)
 
         Parameters
         ----------
-        true_dispersion : ~`astropy.units.Quantity`
+        true_dispersion : `~astropy.units.Quantity`
             True value(s) of dispersion for which the resolution should be
             evaluated.
-        delta_dispersion : ~`astropy.units.Quantity`
+        delta_dispersion : `~astropy.units.Quantity`
             Array of (observed - true) dispersion bin edges to integrate the
             resolution probability density over.
         axis : int
@@ -231,5 +234,6 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             Array of dimensionless probabilities calculated as the integral of
             P(observed | true) over each bin in (observed - true). The output
             shape is the result of broadcasting the input shapes.
+
         """
         pass

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -12,6 +12,8 @@ DOPPLER_CONVENTIONS['radio'] = u.doppler_radio
 DOPPLER_CONVENTIONS['optical'] = u.doppler_optical
 DOPPLER_CONVENTIONS['relativistic'] = u.doppler_relativistic
 
+__all__ = ['OneDSpectrumMixin']
+
 
 class OneDSpectrumMixin(object):
     @property
@@ -69,7 +71,7 @@ class OneDSpectrumMixin(object):
 
         Returns
         -------
-        ~`astropy.units.Quantity`
+        `~astropy.units.Quantity`
             Spectral data as a quantity.
         """
         return u.Quantity(self.data, unit=self.unit)
@@ -80,7 +82,7 @@ class OneDSpectrumMixin(object):
 
         Parameters
         ----------
-        unit : str or ~`astropy.units.Unit`
+        unit : str or `~astropy.units.Unit`
             The unit to conver the flux array to.
 
         equivalencies : list of equivalencies
@@ -93,7 +95,7 @@ class OneDSpectrumMixin(object):
 
         Returns
         -------
-        ~`astropy.units.Quantity`
+        `~astropy.units.Quantity`
             The converted flux array.
         """
         if not suppress_conversion:


### PR DESCRIPTION
This PR makes use more features provided by the package template:

* sphinx nitpicking, failing docs build for non existing API/intersphinx links, and fix the currently failing ones 
* cleanup test header to show the relevant version numbers
* add several API docs
* change version number to have a dev suffix