### PR TITLE
Fixing API references 

### DIFF
--- a/docs/smoothing.rst
+++ b/docs/smoothing.rst
@@ -2,10 +2,10 @@
 Spectral Smoothing
 ==================
 
-The spectral smoothing has two forms, 1) convolution based smoothing 
+The spectral smoothing has two forms, 1) convolution based smoothing
 using the `astropy.convolution` package and 2) median filter
 using the :func:`scipy.signal.medfilt`.  Each of these act on the flux
-of the :class:`~specutils.spectra.Spectrum1D` object.
+of the :class:`~specutils.Spectrum1D` object.
 
 .. note:: Specutils smoothing kernel widths and standard deviations are
              in units of pixels and not ``Quantity``.
@@ -13,12 +13,16 @@ of the :class:`~specutils.spectra.Spectrum1D` object.
 Convolution Based Smoothing
 ---------------------------
 
-While any kernel supported by `astropy.convolution` will work (using the `~specutils.manipulation.convolution_smooth` function), 
-several commonly-used kernels have convenience functions wrapping them to simplify the smoothing process into a simple 
-one-line operation.  Currently implemented are:
-:func:`~specutils.manipulation.box_smooth` (:class:`astropy.convolution.convolve.Box1DKernel`),  
-:func:`~specutils.manipulation.gaussian_smooth` (:class:`astropy.convolution.convolve.Gaussian1DKernel`),  
-and :func:`~specutils.manipulation.trapezoid_smooth` (:class:`astropy.convolution.convolve.Trapezoid1DKernel`).
+While any kernel supported by `astropy.convolution` will work (using the
+`~specutils.manipulation.convolution_smooth` function), several
+commonly-used kernels have convenience functions wrapping them to simplify
+the smoothing process into a simple one-line operation.  Currently
+implemented are: :func:`~specutils.manipulation.box_smooth`
+(:class:`~astropy.convolution.Box1DKernel`),
+:func:`~specutils.manipulation.gaussian_smooth`
+(:class:`~astropy.convolution.Gaussian1DKernel`), and
+:func:`~specutils.manipulation.trapezoid_smooth`
+(:class:`~astropy.convolution.Trapezoid1DKernel`).
 
 
 .. code-block:: python
@@ -45,8 +49,8 @@ and :func:`~specutils.manipulation.trapezoid_smooth` (:class:`astropy.convolutio
                 0.50453064, 0.46677128, 0.41125485, 0.34213489])
 
 
-Each of the specific smoothing methods create the appropriate `astropy.convolution.convolve` 
-kernel and then call a helper function :func:`~specutils.manipulation.convolution_smooth` 
+Each of the specific smoothing methods create the appropriate `astropy.convolution.convolve`
+kernel and then call a helper function :func:`~specutils.manipulation.convolution_smooth`
 that takes the spectrum and an astropy 1D kernel.  So, one could also do:
 
 .. code-block:: python
@@ -70,7 +74,7 @@ Median Smoothing
 ----------------
 
 The median based smoothing  is implemented using `scipy.signal.medfilt` and
-has a similar call structure to the convolution-based smoothing methods. This 
+has a similar call structure to the convolution-based smoothing methods. This
 method applys the median filter across the flux.
 
 Note: This method is not flux conserving.
@@ -80,9 +84,14 @@ Note: This method is not flux conserving.
     >>> from specutils import Spectrum1D
     >>> import astropy.units as u
     >>> import numpy as np
-    >>> from specutils.manipulation import median_smooth 
+    >>> from specutils.manipulation import median_smooth
 
     >>> spec1 = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm, flux=np.random.sample(49))
     >>> spec1_msmooth = median_smooth(spec1, width=3)
 
+
+Reference/API
+-------------
+
 .. automodapi:: specutils.manipulation
+    :no-heading:

--- a/specutils/manipulation/smoothing.py
+++ b/specutils/manipulation/smoothing.py
@@ -17,15 +17,15 @@ def convolution_smooth(spectrum, kernel):
 
     Parameters
     ----------
-    spectrum : `~specutils.spectra.Spectrum1D`
-        The `~specutils.spectra.Spectrum1D` object to which the smoothing will be applied.
+    spectrum : `~specutils.Spectrum1D`
+        The `~specutils.Spectrum1D` object to which the smoothing will be applied.
     kernel : `astropy.convolution.Kernel1D` subclass or array.
         The convolution based smoothing kernel - anything that `astropy.convolution.convolve` accepts.
 
     Returns
     -------
-    spectrum : `~specutils.spectra.Spectrum1D`
-        Output `~specutils.spectra.Spectrum1D` which is copy of the one passed in with the updated flux.
+    spectrum : `~specutils.Spectrum1D`
+        Output `~specutils.Spectrum1D` which is copy of the one passed in with the updated flux.
 
     Raises
     ------
@@ -45,27 +45,27 @@ def convolution_smooth(spectrum, kernel):
 
     # Return a new object with the smoothed flux.
     return Spectrum1D(flux=smoothed_flux, spectral_axis=spectrum.spectral_axis,
-                      wcs=spectrum.wcs, unit=spectrum.unit, 
-                      spectral_axis_unit=spectrum.spectral_axis_unit, 
+                      wcs=spectrum.wcs, unit=spectrum.unit,
+                      spectral_axis_unit=spectrum.spectral_axis_unit,
                       velocity_convention=spectrum.velocity_convention,
                       rest_value=spectrum.rest_value)
 
 
 def box_smooth(spectrum, width):
     """
-    Smooth a `~specutils.spectra.Spectrum1D` instance based on a `astropy.convolution.Box1DKernel` kernel.
+    Smooth a `~specutils.Spectrum1D` instance based on a `astropy.convolution.Box1DKernel` kernel.
 
     Parameters
     ----------
-    spectrum : `~specutils.spectra.Spectrum1D`
+    spectrum : `~specutils.Spectrum1D`
         The spectrum object to which the smoothing will be applied.
     width : number
         The width of the kernel, in pixels, as defined in `astropy.convolution.Box1DKernel`
 
     Returns
     -------
-    spectrum : `~specutils.spectra.Spectrum1D`
-        Output `~specutils.spectra.Spectrum1D` which a copy of the one passed in with the updated flux.
+    spectrum : `~specutils.Spectrum1D`
+        Output `~specutils.Spectrum1D` which a copy of the one passed in with the updated flux.
 
     Raises
     ------
@@ -87,19 +87,19 @@ def box_smooth(spectrum, width):
 
 def gaussian_smooth(spectrum, stddev):
     """
-    Smooth a `~specutils.spectra.Spectrum1D` instance based on a `astropy.convolution.Gaussian1DKernel`.
+    Smooth a `~specutils.Spectrum1D` instance based on a `astropy.convolution.Gaussian1DKernel`.
 
     Parameters
     ----------
-    spectrum : `~specutils.spectra.Spectrum1D`
+    spectrum : `~specutils.Spectrum1D`
         The spectrum object to which the smoothing will be applied.
     stddev : number
         The stddev of the kernel, in pixels, as defined in `astropy.convolution.Gaussian1DKernel`
 
     Returns
     -------
-    spectrum : `~specutils.spectra.Spectrum1D`
-        Output `~specutils.spectra.Spectrum1D` which is copy of the one passed in with the updated flux.
+    spectrum : `~specutils.Spectrum1D`
+        Output `~specutils.Spectrum1D` which is copy of the one passed in with the updated flux.
 
     Raises
     ------
@@ -125,15 +125,15 @@ def trapezoid_smooth(spectrum, width):
 
     Parameters
     ----------
-    spectrum : `~specutils.spectra.Spectrum1D`
-        The `~specutils.spectra.Spectrum1D` object to which the smoothing will be applied.
+    spectrum : `~specutils.Spectrum1D`
+        The `~specutils.Spectrum1D` object to which the smoothing will be applied.
     width : number
         The width of the kernel, in pixels, as defined in `astropy.convolution.Trapezoid1DKernel`
 
     Returns
     -------
-    spectrum : `~specutils.spectra.Spectrum1D`
-        Output `~specutils.spectra.Spectrum1D` which is copy of the one passed in with the updated flux.
+    spectrum : `~specutils.Spectrum1D`
+        Output `~specutils.Spectrum1D` which is copy of the one passed in with the updated flux.
 
     Raises
     ------
@@ -160,15 +160,15 @@ def median_smooth(spectrum, width):
 
     Parameters
     ----------
-    spectrum : `~specutils.spectra.Spectrum1D`
-        The `~specutils.spectra.Spectrum1D` object to which the smoothing will be applied.
+    spectrum : `~specutils.Spectrum1D`
+        The `~specutils.Spectrum1D` object to which the smoothing will be applied.
     width : number
         The width of the median filter in pixels.
 
     Returns
     -------
-    spectrum : `~specutils.spectra.Spectrum1D`
-        Output `~specutils.spectra.Spectrum1D` which is copy of the one passed in with the updated flux.
+    spectrum : `~specutils.Spectrum1D`
+        Output `~specutils.Spectrum1D` which is copy of the one passed in with the updated flux.
 
     Raises
     ------
@@ -192,7 +192,7 @@ def median_smooth(spectrum, width):
 
     # Return a new object with the smoothed flux.
     return Spectrum1D(flux=smoothed_flux, spectral_axis=spectrum.spectral_axis,
-                      wcs=spectrum.wcs, unit=spectrum.unit, 
-                      spectral_axis_unit=spectrum.spectral_axis_unit, 
+                      wcs=spectrum.wcs, unit=spectrum.unit,
+                      spectral_axis_unit=spectrum.spectral_axis_unit,
                       velocity_convention=spectrum.velocity_convention,
                       rest_value=spectrum.rest_value)


### PR DESCRIPTION
Currently the docs build is failing with various API docs linking issues.

The trick is to link using a path to the namespace a given class/function should be imported from and not a path for the underlying directory/file structure.