### PR TITLE
replaced test data access to standard

### DIFF
--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -5,6 +5,7 @@ import numpy as np
 import os
 import pytest
 from astropy.nddata import StdDevUncertainty
+from astropy.utils.data import get_pkg_data_filename
 
 from ..spectra.spectrum1d import Spectrum1D
 
@@ -113,8 +114,7 @@ def test_create_with_uncertainty():
 
 
 def test_read_linear_solution():
-    file_path = os.path.join(os.path.dirname(__file__),
-                             'data/L5g_0355+11_Cruz09.fits')
+    file_path = get_pkg_data_filename('data/L5g_0355+11_Cruz09.fits')
 
     spec = Spectrum1D.read(file_path, format='wcs1d-fits')
 
@@ -125,4 +125,3 @@ def test_read_linear_solution():
 
     assert spec.flux.size == spec.data.size
     assert spec.spectral_axis.size == spec.data.size
-


### PR DESCRIPTION
replaced the use of `os.path.join(os.path.dirname(__file__)....` to `get_pkg_data_filename`