### PR TITLE
Readme update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,17 +12,20 @@ Specutils
     :target: http://www.astropy.org/
 
 Specutils is an `Astropy affiliated package <http://affiliated.astropy.org/>`_
- with the goal of providing a shared
-set of Python representations of astronomical spectra and basic tools to
-operate on these spectra. The effort is also meant to be a "hub", helping to
-unite the Python astronomical spectroscopy community around shared effort,
-much as Astropy is meant to for the wider astronomy Python ecosystem.
+with the goal of providing a shared set of Python representations of
+astronomical spectra and basic tools to operate on these spectra. The effort is
+also meant to be a "hub", helping to unite the Python astronomical spectroscopy
+community around shared effort, much as Astropy is meant to for the wider
+astronomy Python ecosystem.
 
-Note that Specutils is not intended as an all-in-one spectroscopic analysis or
-reduction tool. While it provides some basic analysis (following the Python
-philosophy of "batteries included"), it is also meant to facilitate connecting
-together disparate reduction pipelines and analysis tools through shared data
-representations.
+Note that Specutils is not intended to meet all possible spectroscopic analysis or
+reduction needs. While it provides some standard analysis functionality
+(following the  Python philosophy of "batteries included"), it is best thought
+of as a "tool box" that provides pieces of functionality that can be used to
+build a particular scientific workflow or higher-level analysis tool.  To that
+end, it is also meant to facilitate connecting together disparate reduction
+pipelines and analysis tools through shared Python representations of
+spectroscopic data.
 
 Getting Started with Specutils
 ------------------------------

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,8 @@ Specutils
 .. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
     :target: http://www.astropy.org/
 
-Specutils is an Astropy affiliated package with the goal of providing a shared
+Specutils is an `Astropy affiliated package <http://affiliated.astropy.org/>`_
+ with the goal of providing a shared
 set of Python representations of astronomical spectra and basic tools to
 operate on these spectra. The effort is also meant to be a "hub", helping to
 unite the Python astronomical spectroscopy community around shared effort,
@@ -22,6 +23,14 @@ reduction tool. While it provides some basic analysis (following the Python
 philosophy of "batteries included"), it is also meant to facilitate connecting
 together disparate reduction pipelines and analysis tools through shared data
 representations.
+
+Getting Started with Specutils
+------------------------------
+
+For details on installing and using Specutils, see the
+`specutils documentation <http://specutils.readthedocs.io/en/latest/>`_.
+
+Note that Specutils no longer supports Python 2.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,10 @@ Getting Started with Specutils
 For details on installing and using Specutils, see the
 `specutils documentation <http://specutils.readthedocs.io/en/latest/>`_.
 
-Note that Specutils no longer supports Python 2.
+Note that Specutils now only supports Python 3. While some functionality may
+continue to work on Python 2, it is not tested and support cannot be guaranteed
+(due to the sunsetting of Python 2 support by the Python and Astropy development
+teams).
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,8 @@ with the goal of providing a shared set of Python representations of
 astronomical spectra and basic tools to operate on these spectra. The effort is
 also meant to be a "hub", helping to unite the Python astronomical spectroscopy
 community around shared effort, much as Astropy is meant to for the wider
-astronomy Python ecosystem.
+astronomy Python ecosystem. This broader effort is outlined in the
+`APE13 document <https://github.com/astropy/astropy-APEs/blob/master/APE13.rst>`_.
 
 Note that Specutils is not intended to meet all possible spectroscopic analysis or
 reduction needs. While it provides some standard analysis functionality


### PR DESCRIPTION
This updates the README with a bit more accurate description of the specutils plan as it currently exists.

One particular bit it adds that might be new: a mention of the supported Python version.  I'm not sure we ever discussed this in detail... @nmearl @crawfordsm @keflavich - do you agree what I have here is fine (basically "only py3 supported, although some stuff may continue to work in py2")?