### PR TITLE
make flux property non-copying

### DIFF
--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -81,7 +81,7 @@ class OneDSpectrumMixin(object):
         `~astropy.units.Quantity`
             Spectral data as a quantity.
         """
-        return u.Quantity(self.data, unit=self.unit)
+        return u.Quantity(self.data, unit=self.unit, copy=False)
 
     def to_flux(self, unit, equivalencies=None, suppress_conversion=False):
         """


### PR DESCRIPTION
This may at first seem trivial, but it turns out to have major performance implications.  As the experiments below demonstrate, anywhere from a 2x to 50x speedup for typical spectrum sizes.


```
>>> unit = uu.Jy
>>> data = np.random.randn(2048)
>>> %timeit u.Quantity(data, unit)
5.75 µs ± 36.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
>>> %timeit u.Quantity(data, unit, copy=False)
3.63 µs ± 46.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

>>> datam = np.random.randn(2048, 100)
>>> %timeit u.Quantity(datam, unit)
117 µs ± 13.6 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
>>> %timeit u.Quantity(datam, unit, copy=False)
3.64 µs ± 29.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```