### PR TITLE
Centroid calculation

### DIFF
--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -70,7 +70,7 @@ And if the spectrum contains a continuum, then it should be subtracted first:
     >>> from specutils.analysis import centroid
 
     >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=(10+np.random.randn(50))*u.Jy)
-    >>> continuum_baseline = fit_generic_continuum(spec)
+    >>> continuum_baseline = fit_generic_continuum(spec) #doctest:+SKIP
     >>> continuum_flux = continuum_baseline(spec.spectral_axis.value)
     >>> continuum = Spectrum1D(spectral_axis=spec.spectral_axis, flux=continuum_flux)
     >>> c = centroid(spec-continuum, region=None) #doctest:+SKIP

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -42,6 +42,23 @@ Currently, specutils supports basic signal-to-noise ratio calculations.
     >>> snr(spec) #doctest:+SKIP
     <Quantity 149.97247134>
 
+Centroid
+--------
+
+Currently, specutils supports basic centroid calculations.
+
+.. code-block:: python
+
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from specutils.spectra import Spectrum1D
+    >>> from astropy.nddata import StdDevUncertainty
+    >>> from specutils.analysis import centroid
+
+    >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=(3+np.random.randn(50))*u.Jy)
+    >>> centroid(spec) #doctest:+SKIP
+    <Quantity 24.39045495 Angstrom>
+
 Reference/API
 -------------
 .. automodapi:: specutils.analysis

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -71,8 +71,7 @@ And if the spectrum contains a continuum, then it should be subtracted first:
 
     >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=(3+np.random.randn(50))*u.Jy)
     >>> continuum_baseline = continuum(spec)
-    >>> centroid(spec-continuum_baseline) #doctest:+SKIP
-    <Quantity 23.39045495 Angstrom>
+    >>> c = centroid(spec-continuum_baseline) #doctest:+SKIP
 
 Reference/API
 -------------

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -56,7 +56,7 @@ Currently, specutils supports basic centroid calculations.
     >>> from specutils.analysis import centroid
 
     >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=(3+np.random.randn(50))*u.Jy)
-    >>> centroid(spec) #doctest:+SKIP
+    >>> centroid(spec, region=None) #doctest:+SKIP
     <Quantity 24.39045495 Angstrom>
 
 And if the spectrum contains a continuum, then it should be subtracted first:
@@ -66,11 +66,14 @@ And if the spectrum contains a continuum, then it should be subtracted first:
     >>> import astropy.units as u
     >>> from specutils.spectra import Spectrum1D
     >>> from astropy.nddata import StdDevUncertainty
+    >>> from specutils.fitting import fit_generic_continuum
     >>> from specutils.analysis import centroid
 
-    >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=(3+np.random.randn(50))*u.Jy)
-    >>> continuum_baseline = continuum(spec)
-    >>> c = centroid(spec-continuum_baseline) #doctest:+SKIP
+    >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=(10+np.random.randn(50))*u.Jy)
+    >>> continuum_baseline = fit_generic_continuum(spec)
+    >>> continuum_flux = continuum_baseline(spec.spectral_axis.value)
+    >>> continuum = Spectrum1D(spectral_axis=spec.spectral_axis, flux=continuum_flux)
+    >>> c = centroid(spec-continuum, region=None) #doctest:+SKIP
 
 Reference/API
 -------------

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -66,7 +66,6 @@ And if the spectrum contains a continuum, then it should be subtracted first:
     >>> import astropy.units as u
     >>> from specutils.spectra import Spectrum1D
     >>> from astropy.nddata import StdDevUncertainty
-    >>> from specutils.fitting import continuum
     >>> from specutils.analysis import centroid
 
     >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=(3+np.random.randn(50))*u.Jy)

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -59,6 +59,21 @@ Currently, specutils supports basic centroid calculations.
     >>> centroid(spec) #doctest:+SKIP
     <Quantity 24.39045495 Angstrom>
 
+And if the spectrum contains a continuum, then it should be subtracted first:
+.. code-block:: python
+
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from specutils.spectra import Spectrum1D
+    >>> from astropy.nddata import StdDevUncertainty
+    >>> from specutils.fitting import continuum
+    >>> from specutils.analysis import centroid
+
+    >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=(3+np.random.randn(50))*u.Jy)
+    >>> continuum_baseline = continuum(spec)
+    >>> centroid(spec-continuum_baseline) #doctest:+SKIP
+    <Quantity 23.39045495 Angstrom>
+
 Reference/API
 -------------
 .. automodapi:: specutils.analysis

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -71,8 +71,8 @@ And if the spectrum contains a continuum, then it should be subtracted first:
 
     >>> spec = Spectrum1D(spectral_axis=np.arange(50), flux=(10+np.random.randn(50))*u.Jy)
     >>> continuum_baseline = fit_generic_continuum(spec) #doctest:+SKIP
-    >>> continuum_flux = continuum_baseline(spec.spectral_axis.value)
-    >>> continuum = Spectrum1D(spectral_axis=spec.spectral_axis, flux=continuum_flux)
+    >>> continuum_flux = continuum_baseline(spec.spectral_axis.value) #doctest:+SKIP
+    >>> continuum = Spectrum1D(spectral_axis=spec.spectral_axis, flux=continuum_flux) #doctest:+SKIP
     >>> c = centroid(spec-continuum, region=None) #doctest:+SKIP
 
 Reference/API

--- a/specutils/analysis/__init__.py
+++ b/specutils/analysis/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 
 from .equivalent_width import *  # noqa
 from .snr import snr  # noqa
+from .centroid import centroid  # noqa

--- a/specutils/analysis/centroid.py
+++ b/specutils/analysis/centroid.py
@@ -81,4 +81,4 @@ def _centroid_single_region(spectrum, region=None):
 
     # the axis=0 will enable this to run on single-dispersion, single-flux
     # and single-dispersion, multiple-flux
-    return np.sum(flux * dispersion, axis=0) / np.sum(calc_spectrum.spectral_axis, axis=0)
+    return np.sum(flux * dispersion, axis=0) / np.sum(flux, axis=0)

--- a/specutils/analysis/centroid.py
+++ b/specutils/analysis/centroid.py
@@ -1,0 +1,84 @@
+import numpy as np
+from ..spectra import SpectralRegion
+
+__all__ = ['centroid']
+
+
+def centroid(spectrum, region=None):
+    """
+    Calculate the centroid of the spectrum based on the flux and uncertainty
+    in the spectrum. This will be calculated over the regions, if they
+    are specified.
+
+    Parameters
+    ----------
+    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
+        The spectrum object overwhich the equivalent width will be calculated.
+
+    region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+        Region within the spectrum to calculate the centroid.
+
+    Returns
+    -------
+    centroid : float or list (based on region input)
+        Signal to noise ratio of the spectrum or within the regions
+
+    Notes
+    -----
+    The spectrum will need to be continuum subtracted before calling
+    this method.
+
+    """
+
+    # No region, therefore whole spectrum.
+    if region is None:
+        return _centroid_single_region(spectrum)
+
+    # Single region
+    elif isinstance(region, SpectralRegion):
+        return _ntroid(spectrum, region=region)
+
+    # List of regions
+    elif isinstance(region, list):
+        return [_centroid_single_region(spectrum, region=reg)
+                for reg in region]
+
+
+def _centroid_single_region(spectrum, region=None):
+    """
+    Calculate the centroid of the spectrum based on the flux and uncertainty
+    in the spectrum.
+
+    Parameters
+    ----------
+    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
+        The spectrum object overwhich the equivalent width will be calculated.
+
+    region: `~specutils.utils.SpectralRegion`
+        Region within the spectrum to calculate the centroid.
+
+    Returns
+    -------
+    centroid : float or list (based on region input)
+        Centroid of the spectrum or within the regions
+
+    Notes
+    -----
+    This is a helper function for the above `centroid()` method.
+
+    """
+
+    if region is not None:
+        calc_spectrum = region.extract(spectrum)
+    else:
+        calc_spectrum = spectrum
+
+    flux = calc_spectrum.flux
+    dispersion = calc_spectrum.spectral_axis
+
+    if len(flux.shape) > 1:
+        dispersion = np.tile(dispersion[np.newaxis].T, [1, flux.shape[1]])
+
+    # the axis=0 will enable this to run on single-dispersion, single-flux
+    # and single-dispersion, multiple-flux
+    return np.sum(flux * dispersion, axis=0) / np.sum(calc_spectrum.spectral_axis, axis=0)

--- a/specutils/analysis/centroid.py
+++ b/specutils/analysis/centroid.py
@@ -36,7 +36,7 @@ def centroid(spectrum, region=None):
 
     # Single region
     elif isinstance(region, SpectralRegion):
-        return _ntroid(spectrum, region=region)
+        return _centroid_single_region(spectrum, region=region)
 
     # List of regions
     elif isinstance(region, list):
@@ -69,7 +69,10 @@ def _centroid_single_region(spectrum, region=None):
     """
 
     if region is not None:
+        print('original spectrum is {}'.format(spectrum.spectral_axis))
         calc_spectrum = region.extract(spectrum)
+        print('extracted region is {}'.format(calc_spectrum))
+        print('extracted region is {}'.format(calc_spectrum.spectral_axis))
     else:
         calc_spectrum = spectrum
 

--- a/specutils/analysis/centroid.py
+++ b/specutils/analysis/centroid.py
@@ -4,11 +4,9 @@ from ..spectra import SpectralRegion
 __all__ = ['centroid']
 
 
-def centroid(spectrum, region=None):
+def centroid(spectrum, region):
     """
-    Calculate the centroid of the spectrum based on the flux and uncertainty
-    in the spectrum. This will be calculated over the regions, if they
-    are specified.
+    Calculate the centroid of a region, or regions, of the spectrum.
 
     Parameters
     ----------

--- a/specutils/analysis/centroid.py
+++ b/specutils/analysis/centroid.py
@@ -13,7 +13,7 @@ def centroid(spectrum, region=None):
     Parameters
     ----------
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object overwhich the equivalent width will be calculated.
+        The spectrum object overwhich the centroid will be calculated.
 
     region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the centroid.
@@ -21,12 +21,13 @@ def centroid(spectrum, region=None):
     Returns
     -------
     centroid : float or list (based on region input)
-        Signal to noise ratio of the spectrum or within the regions
+        Centroid of the spectrum or within the regions
 
     Notes
     -----
     The spectrum will need to be continuum subtracted before calling
-    this method.
+    this method. See the 
+    `analysis documentation <https://specutils.readthedocs.io/en/latest/basic_analysis.html>`_ for more information.
 
     """
 
@@ -52,7 +53,7 @@ def _centroid_single_region(spectrum, region=None):
     Parameters
     ----------
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object overwhich the equivalent width will be calculated.
+        The spectrum object overwhich the centroid will be calculated.
 
     region: `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the centroid.

--- a/specutils/analysis/centroid.py
+++ b/specutils/analysis/centroid.py
@@ -68,10 +68,7 @@ def _centroid_single_region(spectrum, region=None):
     """
 
     if region is not None:
-        print('original spectrum is {}'.format(spectrum.spectral_axis))
         calc_spectrum = region.extract(spectrum)
-        print('extracted region is {}'.format(calc_spectrum))
-        print('extracted region is {}'.format(calc_spectrum.spectral_axis))
     else:
         calc_spectrum = spectrum
 
@@ -79,8 +76,8 @@ def _centroid_single_region(spectrum, region=None):
     dispersion = calc_spectrum.spectral_axis
 
     if len(flux.shape) > 1:
-        dispersion = np.tile(dispersion[np.newaxis].T, [1, flux.shape[1]])
+        dispersion = np.tile(dispersion, [flux.shape[0], 1])
 
-    # the axis=0 will enable this to run on single-dispersion, single-flux
+    # the axis=-1 will enable this to run on single-dispersion, single-flux
     # and single-dispersion, multiple-flux
-    return np.sum(flux * dispersion, axis=0) / np.sum(flux, axis=0)
+    return np.sum(flux * dispersion, axis=-1) / np.sum(flux, axis=-1)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -237,6 +237,21 @@ def test_centroid(simulated_spectra):
     assert np.allclose(spec_centroid.value, spec_centroid_expected.value)
 
 
+def test_inverted_centroid(simulated_spectra):
+    """
+    Ensures the centroid calculation also works for *inverted* spectra - i.e.
+    continuum-subtracted absorption lines.
+    """
+    spectrum = simulated_spectra.s1_um_mJy_e1
+    spec_centroid_expected = (np.sum(spectrum.flux * spectrum.spectral_axis) /
+                              np.sum(spectrum.flux))
+
+    spectrum_inverted = Spectrum1D(spectral_axis=spectrum.spectral_axis,
+                                   flux=-spectrum.flux)
+    spec_centroid_inverted = centroid(spectrum_inverted, None)
+    assert np.allclose(spec_centroid_inverted.value, spec_centroid_expected.value)
+
+
 def test_snr_multiple_flux(simulated_spectra):
     """
     Test the simple version of the spectral SNR, with multiple flux per single dispersion.
@@ -255,6 +270,12 @@ def test_snr_multiple_flux(simulated_spectra):
 
     assert np.allclose(centroid_spec.value, np.array([5.39321967, 3.6856305 , 3.09779811, 4.99442161, 4.50267016]))
     assert centroid_spec.unit == u.um
+
+    # spec_inverted = Spectrum1D(spectral_axis=spec.spectral_axis,
+    #                                flux=-spec.flux)
+    # spec_centroid_inverted = centroid(spec_inverted, None, invert=True)
+    # assert np.allclose(spec_centroid_inverted.value, spec_centroid_expected_inverted.value)
+
 
 
 @pytest.mark.xfail

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -43,7 +43,7 @@ def test_snr(simulated_spectra):
     """
 
     np.random.seed(42)
-    
+
     #
     #  Set up the data and add the uncertainty and calculate the expected SNR
     #
@@ -231,7 +231,7 @@ def test_centroid(simulated_spectra):
     # SNR of the whole spectrum
     #
 
-    spec_centroid = centroid(spectrum)
+    spec_centroid = centroid(spectrum, None)
 
     assert isinstance(spec_centroid, u.Quantity)
     assert np.allclose(spec_centroid.value, spec_centroid_expected.value)
@@ -251,7 +251,7 @@ def test_snr_multiple_flux(simulated_spectra):
     spec = Spectrum1D(spectral_axis=np.arange(10) * u.um,
                       flux=np.random.sample((10, 5)) * u.Jy)
 
-    centroid_spec = centroid(spec)
+    centroid_spec = centroid(spec, None)
 
     assert np.allclose(centroid_spec.value, np.array([5.39321967, 3.6856305 , 3.09779811, 4.99442161, 4.50267016]))
     assert centroid_spec.unit == u.um
@@ -305,7 +305,7 @@ def test_snr_two_regions(simulated_spectra):
     #
 
     regions = [SpectralRegion(0.52*u.um, 0.59*u.um), SpectralRegion(0.8*u.um, 0.9*u.um)]
-    
+
     #
     #  Set up the data
     #

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -225,7 +225,7 @@ def test_centroid(simulated_spectra):
     wavelengths = spectrum.spectral_axis
     flux = spectrum.flux
 
-    spec_centroid_expected = np.sum(flux * wavelengths) / np.sum(wavelengths)
+    spec_centroid_expected = np.sum(flux * wavelengths) / np.sum(flux)
 
     #
     # SNR of the whole spectrum
@@ -253,7 +253,8 @@ def test_snr_multiple_flux(simulated_spectra):
 
     centroid_spec = centroid(spec)
 
-    assert np.allclose(centroid_spec.value, np.array([0.5191939 , 0.31976068, 0.30832925, 0.65393441, 0.36912737]))
+    assert np.allclose(centroid_spec.value, np.array([5.39321967, 3.6856305 , 3.09779811, 4.99442161, 4.50267016]))
+    assert centroid_spec.unit == u.um
 
 
 # def test_snr_single_region(simulated_spectra):

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -205,7 +205,6 @@ def test_snr_single_region_with_noise_region(simulated_spectra):
 
     assert np.allclose(spec_snr.value, spec_snr_expected.value)
 
-# --
 
 def test_centroid(simulated_spectra):
     """
@@ -252,7 +251,7 @@ def test_inverted_centroid(simulated_spectra):
     assert np.allclose(spec_centroid_inverted.value, spec_centroid_expected.value)
 
 
-def test_snr_multiple_flux(simulated_spectra):
+def test_centroid_multiple_flux(simulated_spectra):
     """
     Test the simple version of the spectral SNR, with multiple flux per single dispersion.
     """
@@ -270,86 +269,3 @@ def test_snr_multiple_flux(simulated_spectra):
 
     assert np.allclose(centroid_spec.value, np.array([4.46190995, 4.17223565, 4.37778249, 4.51595259, 4.7429066]))
     assert centroid_spec.unit == u.um
-
-    # spec_inverted = Spectrum1D(spectral_axis=spec.spectral_axis,
-    #                                flux=-spec.flux)
-    # spec_centroid_inverted = centroid(spec_inverted, None, invert=True)
-    # assert np.allclose(spec_centroid_inverted.value, spec_centroid_expected_inverted.value)
-
-
-
-@pytest.mark.xfail
-def test_snr_single_region(simulated_spectra):
-    """
-    Test the simple version of the spectral SNR over a region of the spectrum.
-    """
-
-    np.random.seed(42)
-
-    region = SpectralRegion(0.52*u.um, 0.59*u.um)
-
-    #
-    #  Set up the data
-    #
-
-    spectrum = simulated_spectra.s1_um_mJy_e1
-    uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
-    spectrum.uncertainty = uncertainty
-
-    wavelengths = spectrum.spectral_axis
-    flux = spectrum.flux
-
-    l = np.nonzero(wavelengths > region.lower)[0][0]
-    r = np.nonzero(wavelengths < region.upper)[0][-1]
-
-    spec_snr_expected = np.mean(flux[l:r] / (uncertainty.array[l:r]*uncertainty.unit))
-
-    #
-    # SNR of the whole spectrum
-    #
-
-    spec_snr = snr(spectrum, region)
-
-    assert np.allclose(spec_snr.value, spec_snr_expected.value)
-
-
-@pytest.mark.xfail
-def test_snr_two_regions(simulated_spectra):
-    """
-    Test the simple version of the spectral SNR within two regions.
-    """
-
-    np.random.seed(42)
-
-    #
-    # Set the regions over which the SNR is calculated
-    #
-
-    regions = [SpectralRegion(0.52*u.um, 0.59*u.um), SpectralRegion(0.8*u.um, 0.9*u.um)]
-
-    #
-    #  Set up the data
-    #
-
-    spectrum = simulated_spectra.s1_um_mJy_e1
-    uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.Jy)
-    spectrum.uncertainty = uncertainty
-
-    wavelengths = spectrum.spectral_axis
-    flux = spectrum.flux
-
-    spec_snr_expected = []
-    for region in regions:
-
-        l = np.nonzero(wavelengths>region.lower)[0][0]
-        r = np.nonzero(wavelengths<region.upper)[0][-1]
-
-        spec_snr_expected.append(np.mean(flux[l:r] / (uncertainty.array[l:r]*uncertainty.unit)))
-
-    #
-    # SNR of the whole spectrum
-    #
-
-    spec_snr = snr(spectrum, regions)
-
-    assert np.allclose(spec_snr, spec_snr_expected)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -257,76 +257,78 @@ def test_snr_multiple_flux(simulated_spectra):
     assert centroid_spec.unit == u.um
 
 
-# def test_snr_single_region(simulated_spectra):
-#     """
-#     Test the simple version of the spectral SNR over a region of the spectrum.
-#     """
-# 
-#     np.random.seed(42)
-# 
-#     region = SpectralRegion(0.52*u.um, 0.59*u.um)
-# 
-#     #
-#     #  Set up the data
-#     #
-# 
-#     spectrum = simulated_spectra.s1_um_mJy_e1
-#     uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
-#     spectrum.uncertainty = uncertainty
-# 
-#     wavelengths = spectrum.spectral_axis
-#     flux = spectrum.flux
-# 
-#     l = np.nonzero(wavelengths>region.lower)[0][0]
-#     r = np.nonzero(wavelengths<region.upper)[0][-1]
-# 
-#     spec_snr_expected = np.mean(flux[l:r] / (uncertainty.array[l:r]*uncertainty.unit))
-# 
-#     #
-#     # SNR of the whole spectrum
-#     #
-# 
-#     spec_snr = snr(spectrum, region)
-# 
-#     assert np.allclose(spec_snr.value, spec_snr_expected.value)
-# 
-# 
-# def test_snr_two_regions(simulated_spectra):
-#     """
-#     Test the simple version of the spectral SNR within two regions.
-#     """
-# 
-#     np.random.seed(42)
-# 
-#     #
-#     # Set the regions over which the SNR is calculated
-#     #
-# 
-#     regions = [SpectralRegion(0.52*u.um, 0.59*u.um), SpectralRegion(0.8*u.um, 0.9*u.um)]
-#     
-#     #
-#     #  Set up the data
-#     #
-# 
-#     spectrum = simulated_spectra.s1_um_mJy_e1
-#     uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.Jy)
-#     spectrum.uncertainty = uncertainty
-# 
-#     wavelengths = spectrum.spectral_axis
-#     flux = spectrum.flux
-# 
-#     spec_snr_expected = []
-#     for region in regions:
-# 
-#         l = np.nonzero(wavelengths>region.lower)[0][0]
-#         r = np.nonzero(wavelengths<region.upper)[0][-1]
-# 
-#         spec_snr_expected.append(np.mean(flux[l:r] / (uncertainty.array[l:r]*uncertainty.unit)))
-# 
-#     #
-#     # SNR of the whole spectrum
-#     #
-# 
-#     spec_snr = snr(spectrum, regions)
-# 
-#     assert np.allclose(spec_snr, spec_snr_expected)
+@pytest.mark.xfail
+def test_snr_single_region(simulated_spectra):
+    """
+    Test the simple version of the spectral SNR over a region of the spectrum.
+    """
+
+    np.random.seed(42)
+
+    region = SpectralRegion(0.52*u.um, 0.59*u.um)
+
+    #
+    #  Set up the data
+    #
+
+    spectrum = simulated_spectra.s1_um_mJy_e1
+    uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
+    spectrum.uncertainty = uncertainty
+
+    wavelengths = spectrum.spectral_axis
+    flux = spectrum.flux
+
+    l = np.nonzero(wavelengths>region.lower)[0][0]
+    r = np.nonzero(wavelengths<region.upper)[0][-1]
+
+    spec_snr_expected = np.mean(flux[l:r] / (uncertainty.array[l:r]*uncertainty.unit))
+
+    #
+    # SNR of the whole spectrum
+    #
+
+    spec_snr = snr(spectrum, region)
+
+    assert np.allclose(spec_snr.value, spec_snr_expected.value)
+
+
+@pytest.mark.xfail
+def test_snr_two_regions(simulated_spectra):
+    """
+    Test the simple version of the spectral SNR within two regions.
+    """
+
+    np.random.seed(42)
+
+    #
+    # Set the regions over which the SNR is calculated
+    #
+
+    regions = [SpectralRegion(0.52*u.um, 0.59*u.um), SpectralRegion(0.8*u.um, 0.9*u.um)]
+    
+    #
+    #  Set up the data
+    #
+
+    spectrum = simulated_spectra.s1_um_mJy_e1
+    uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.Jy)
+    spectrum.uncertainty = uncertainty
+
+    wavelengths = spectrum.spectral_axis
+    flux = spectrum.flux
+
+    spec_snr_expected = []
+    for region in regions:
+
+        l = np.nonzero(wavelengths>region.lower)[0][0]
+        r = np.nonzero(wavelengths<region.upper)[0][-1]
+
+        spec_snr_expected.append(np.mean(flux[l:r] / (uncertainty.array[l:r]*uncertainty.unit)))
+
+    #
+    # SNR of the whole spectrum
+    #
+
+    spec_snr = snr(spectrum, regions)
+
+    assert np.allclose(spec_snr, spec_snr_expected)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -299,8 +299,8 @@ def test_snr_single_region(simulated_spectra):
     wavelengths = spectrum.spectral_axis
     flux = spectrum.flux
 
-    l = np.nonzero(wavelengths>region.lower)[0][0]
-    r = np.nonzero(wavelengths<region.upper)[0][-1]
+    l = np.nonzero(wavelengths > region.lower)[0][0]
+    r = np.nonzero(wavelengths < region.upper)[0][-1]
 
     spec_snr_expected = np.mean(flux[l:r] / (uncertainty.array[l:r]*uncertainty.unit))
 

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -264,11 +264,11 @@ def test_snr_multiple_flux(simulated_spectra):
     np.random.seed(42)
 
     spec = Spectrum1D(spectral_axis=np.arange(10) * u.um,
-                      flux=np.random.sample((10, 5)) * u.Jy)
+                      flux=np.random.sample((5, 10)) * u.Jy)
 
     centroid_spec = centroid(spec, None)
 
-    assert np.allclose(centroid_spec.value, np.array([5.39321967, 3.6856305 , 3.09779811, 4.99442161, 4.50267016]))
+    assert np.allclose(centroid_spec.value, np.array([4.46190995, 4.17223565, 4.37778249, 4.51595259, 4.7429066]))
     assert centroid_spec.unit == u.um
 
     # spec_inverted = Spectrum1D(spectral_axis=spec.spectral_axis,


### PR DESCRIPTION
Calculate the centroid of a spectrum.  This follows the same format of the SNR code structure and will work for regions with in the spectrum as well as a Spectrum1D object that is many-flux, one-dispersion.

Fixes #236

(work in progress: few more code changes possibly needed, couple more tests and documentation).