### PR TITLE
Return quantity objects in pix2world and world2pix transformations

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -57,7 +57,7 @@ class OneDSpectrumMixin(object):
         """
         Returns a Quantity array with the values of the spectral axis.
         """
-        return self.wcs.pixel_to_world(np.arange(self.flux.shape[0]))
+        return self.wcs.pixel_to_world(np.arange(self.flux.shape[-1]))
 
     @property
     def spectral_axis_unit(self):

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -57,12 +57,7 @@ class OneDSpectrumMixin(object):
         """
         Returns a Quantity array with the values of the spectral axis.
         """
-        # Construct the spectral_axis array.
-        # TODO: Should applying the spectral axis unit occur in the adapter?
-        spectral_axis = self.wcs.pixel_to_world(
-            np.arange(self.flux.shape[-1])) * self.wcs.spectral_axis_unit
-
-        return spectral_axis
+        return self.wcs.pixel_to_world(np.arange(self.flux.shape[0]))
 
     @property
     def spectral_axis_unit(self):

--- a/specutils/tests/test_slicing.py
+++ b/specutils/tests/test_slicing.py
@@ -81,4 +81,4 @@ def test_slicing_with_fits():
 
     assert isinstance(spec_slice, Spectrum1D)
     assert spec_slice.flux.size == 4
-    assert np.allclose(spec_slice.wcs.pixel_to_world([6, 7, 8, 9]), spec.wcs.pixel_to_world([6, 7, 8, 9]))
+    assert (spec_slice.wcs.pixel_to_world([6, 7, 8, 9]) == spec.wcs.pixel_to_world([6, 7, 8, 9])).all()

--- a/specutils/tests/test_slicing.py
+++ b/specutils/tests/test_slicing.py
@@ -81,4 +81,4 @@ def test_slicing_with_fits():
 
     assert isinstance(spec_slice, Spectrum1D)
     assert spec_slice.flux.size == 4
-    assert (spec_slice.wcs.pixel_to_world([6, 7, 8, 9]) == spec.wcs.pixel_to_world([6, 7, 8, 9])).all()
+    assert np.allclose(spec_slice.wcs.pixel_to_world([6, 7, 8, 9]).value, spec.wcs.pixel_to_world([6, 7, 8, 9]).value)

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -122,6 +122,29 @@ def test_flux_unit_conversion():
     assert s.flux[0] == 26.0 * u.uJy
 
 
+def test_wcs_transformations():
+    # Test with a GWCS
+    spec = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm,
+                      flux=np.random.randn(49))
+
+    pix_axis = spec.wcs.world_to_pixel(np.arange(20, 30))
+    disp_axis = spec.wcs.pixel_to_world(np.arange(20, 30) * u.nm)
+
+    assert isinstance(pix_axis, np.ndarray)
+    assert isinstance(disp_axis, u.Quantity)
+
+    # Test with a FITS WCS
+    my_wcs = fitswcs.WCS(header={'CDELT1': 1, 'CRVAL1': 6562.8, 'CUNIT1': 'Angstrom',
+                                 'CTYPE1': 'WAVE', 'RESTFRQ': 1400000000, 'CRPIX1': 25})
+
+    spec = Spectrum1D(flux=[5,6,7] * u.Jy, wcs=my_wcs)
+
+    pix_axis = spec.wcs.world_to_pixel(np.arange(20, 30))
+    disp_axis = spec.wcs.pixel_to_world(np.arange(20, 30) * u.nm)
+
+    assert isinstance(pix_axis, np.ndarray)
+    assert isinstance(disp_axis, u.Quantity)
+
 def test_create_explicit_fitswcs():
     my_wcs = fitswcs.WCS(header={'CDELT1': 1, 'CRVAL1': 6562.8, 'CUNIT1': 'Angstrom',
                                  'CTYPE1': 'WAVE', 'RESTFRQ': 1400000000, 'CRPIX1': 25})

--- a/specutils/wcs/adapters/fitswcs_adapter.py
+++ b/specutils/wcs/adapters/fitswcs_adapter.py
@@ -45,7 +45,7 @@ class FITSWCSAdapter(WCSAdapter):
         """
         Method for performing the world to pixel transformations.
         """
-        return u.Quantity(self.axes.spectral.all_world2pix(world_array, 0)[0])
+        return self.axes.spectral.all_world2pix(world_array, 0)[0]
 
     def pixel_to_world(self, pixel_array):
         """

--- a/specutils/wcs/adapters/fitswcs_adapter.py
+++ b/specutils/wcs/adapters/fitswcs_adapter.py
@@ -1,10 +1,11 @@
+import astropy.units as u
 from astropy.wcs import (WCS, WCSSUB_CELESTIAL, WCSSUB_CUBEFACE,
                          WCSSUB_LATITUDE, WCSSUB_LONGITUDE, WCSSUB_SPECTRAL,
-                         WCSSUB_STOKES)
-from astropy.wcs import InvalidSubimageSpecificationError
+                         WCSSUB_STOKES, InvalidSubimageSpecificationError)
 
 # Use this once in specutils
-from ...utils.wcs_utils import convert_spectral_axis, determine_ctype_from_vconv
+from ...utils.wcs_utils import (convert_spectral_axis,
+                                determine_ctype_from_vconv)
 from ..wcs_adapter import WCSAdapter, WCSAxes
 
 __all__ = ['FITSWCSAdapter']
@@ -44,13 +45,14 @@ class FITSWCSAdapter(WCSAdapter):
         """
         Method for performing the world to pixel transformations.
         """
-        return self.axes.spectral.all_world2pix(world_array, 0)[0]
+        return u.Quantity(self.axes.spectral.all_world2pix(world_array, 0)[0])
 
     def pixel_to_world(self, pixel_array):
         """
         Method for performing the pixel to world transformations.
         """
-        return self.axes.spectral.all_pix2world(pixel_array, 0)[0]
+        return u.Quantity(self.axes.spectral.all_pix2world(pixel_array, 0)[0],
+                          self.spectral_axis_unit)
 
     @property
     def spec_axis(self):

--- a/specutils/wcs/adapters/gwcs_adapter.py
+++ b/specutils/wcs/adapters/gwcs_adapter.py
@@ -76,9 +76,10 @@ class GWCSAdapter(WCSAdapter):
         """
         Method for performing the world to pixel transformations.
         """
-        world_array = u.Quantity(world_array)
-        
-        return u.Quantity(self.wcs.invert(world_array), unit=world_array)
+        # Convert world array to the wcs unit for the conversion
+        world_array = u.Quantity(world_array, unit=self._wcs_unit)
+
+        return self.wcs.invert(world_array.value)
 
     def pixel_to_world(self, pixel_array):
         """

--- a/specutils/wcs/adapters/gwcs_adapter.py
+++ b/specutils/wcs/adapters/gwcs_adapter.py
@@ -76,9 +76,7 @@ class GWCSAdapter(WCSAdapter):
         """
         Method for performing the world to pixel transformations.
         """
-        return u.Quantity(self.wcs.invert(world_array),
-                          self._wcs_unit).to(
-            self._unit, equivalencies=u.spectral()).value
+        return u.Quantity(self.wcs.invert(world_array))
 
     def pixel_to_world(self, pixel_array):
         """
@@ -86,7 +84,7 @@ class GWCSAdapter(WCSAdapter):
         """
         return u.Quantity(self.wcs(pixel_array, with_bounding_box=False),
                           self._wcs_unit).to(
-            self._unit, equivalencies=u.spectral()).value
+            self.spectral_axis_unit, equivalencies=u.spectral())
 
     @property
     def spectral_axis_unit(self):

--- a/specutils/wcs/adapters/gwcs_adapter.py
+++ b/specutils/wcs/adapters/gwcs_adapter.py
@@ -76,7 +76,7 @@ class GWCSAdapter(WCSAdapter):
         """
         Method for performing the world to pixel transformations.
         """
-        return u.Quantity(self.wcs.invert(world_array))
+        return u.Quantity(self.wcs.invert(world_array.value), unit=world_array.unit)
 
     def pixel_to_world(self, pixel_array):
         """

--- a/specutils/wcs/adapters/gwcs_adapter.py
+++ b/specutils/wcs/adapters/gwcs_adapter.py
@@ -76,7 +76,9 @@ class GWCSAdapter(WCSAdapter):
         """
         Method for performing the world to pixel transformations.
         """
-        return u.Quantity(self.wcs.invert(world_array.value), unit=world_array.unit)
+        world_array = u.Quantity(world_array)
+        
+        return u.Quantity(self.wcs.invert(world_array), unit=world_array)
 
     def pixel_to_world(self, pixel_array):
         """


### PR DESCRIPTION
From a conversation with @eteq, `pixel_to_world` should return a `Quantity` object instead of the `Quantity` being created when the `spectral_axis` is evaluated in the `Spectrum1D` object.