### PR TITLE
Weirdness with multidimensional Spectrum1D

### DIFF
--- a/specutils/analysis/__init__.py
+++ b/specutils/analysis/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .equivalent_width import *  # noqa
 from .snr import snr  # noqa
-from .width import sigma # noqa
+from .width import sigma_full_width # noqa

--- a/specutils/analysis/__init__.py
+++ b/specutils/analysis/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 
 from .equivalent_width import *  # noqa
 from .snr import snr  # noqa
+from .width import sigma # noqa

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -1,0 +1,81 @@
+import numpy as np
+from astropy.stats.funcs import gaussian_fwhm_to_sigma
+from ..spectra import SpectralRegion
+
+__all__ = ['sigma']
+
+
+def sigma(spectrum, region=None):
+    """
+    Calculate the gaussian sigma width of the spectrum.  This will be
+    calculated over the regions, if they are specified.
+
+    Parameters
+    ----------
+    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
+        The spectrum object overwhich the equivalent width will be calculated.
+
+    region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+        Region within the spectrum to calculate the gaussian sigma width.
+
+    Returns
+    -------
+    snr : float or list (based on region input)
+        Signal to noise ratio of the spectrum or within the regions
+
+    Notes
+    -----
+    The spectrum will need to have the uncertainty defined in order
+    for the gaussian sigma width to be calculated.
+
+    """
+
+    # No region, therefore whole spectrum.
+    if region is None:
+        return _compute_sigma(spectrum)
+
+    # Single region
+    elif isinstance(region, SpectralRegion):
+        return _compute_sigma(spectrum, region=region)
+
+    # List of regions
+    elif isinstance(region, list):
+        return [_compute_sigma(spectrum, region=reg) for reg in region]
+
+
+def _compute_sigma(spectrum, region=None):
+    """
+    Calculate the gaussian sigma width of the spectrum.
+
+    Parameters
+    ----------
+    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
+        The spectrum object overwhich the equivalent width will be calculated.
+
+    region: `~specutils.utils.SpectralRegion`
+        Region within the spectrum to calculate the gaussian sigma width.
+
+    Returns
+    -------
+    snr : float or list (based on region input)
+        Signal to noise ratio of the spectrum or within the regions
+
+    Notes
+    -----
+    This is a helper function for the above `snr()` method.
+
+    """
+
+    if region is not None:
+        calc_spectrum = region.extract(spectrum)
+    else:
+        calc_spectrum = spectrum
+
+    flux = calc_spectrum.flux
+    frequencies = calc_spectrum.frequency
+
+    dx = frequencies - np.mean(frequencies)
+    fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux) / np.sum(flux))
+    sigma = fwhm * gaussian_fwhm_to_sigma
+
+    return sigma

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -76,7 +76,7 @@ def _compute_sigma_full_width(spectrum, region=None):
     frequencies = calc_spectrum.frequency
 
     dx = frequencies - np.mean(frequencies)
-    fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux) / np.sum(flux))
+    fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux, axis=-1) / np.sum(flux, axis=-1))
     sigma = fwhm * gaussian_fwhm_to_sigma
 
     return sigma * 2

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -2,13 +2,13 @@ import numpy as np
 from astropy.stats.funcs import gaussian_fwhm_to_sigma
 from ..spectra import SpectralRegion
 
-__all__ = ['sigma']
+__all__ = ['sigma_full_width']
 
 
-def sigma(spectrum, region=None):
+def sigma_full_width(spectrum, region=None):
     """
-    Calculate the gaussian sigma width of the spectrum.  This will be
-    calculated over the regions, if they are specified.
+    Calculate the full width of the spectrum based on an approximate value of
+    sigma.  This will be calculated over the regions, if they are specified.
 
     Parameters
     ----------
@@ -20,8 +20,8 @@ def sigma(spectrum, region=None):
 
     Returns
     -------
-    snr : float or list (based on region input)
-        Signal to noise ratio of the spectrum or within the regions
+    full_width : float or list (based on region input)
+        Approximate full width of the signal
 
     Notes
     -----
@@ -32,20 +32,21 @@ def sigma(spectrum, region=None):
 
     # No region, therefore whole spectrum.
     if region is None:
-        return _compute_sigma(spectrum)
+        return _compute_sigma_full_width(spectrum)
 
     # Single region
     elif isinstance(region, SpectralRegion):
-        return _compute_sigma(spectrum, region=region)
+        return _compute_sigma_full_width(spectrum, region=region)
 
     # List of regions
     elif isinstance(region, list):
-        return [_compute_sigma(spectrum, region=reg) for reg in region]
+        return [_compute_sigma_full_width(spectrum, region=reg) for reg in region]
 
 
-def _compute_sigma(spectrum, region=None):
+def _compute_sigma_full_width(spectrum, region=None):
     """
-    Calculate the gaussian sigma width of the spectrum.
+    Calculate the full width of the spectrum based on an approximate value of
+    sigma.
 
     Parameters
     ----------
@@ -57,12 +58,12 @@ def _compute_sigma(spectrum, region=None):
 
     Returns
     -------
-    snr : float or list (based on region input)
-        Signal to noise ratio of the spectrum or within the regions
+    full_width : float or list (based on region input)
+        Approximate full width of the signal
 
     Notes
     -----
-    This is a helper function for the above `snr()` method.
+    This is a helper function for the above `sigma_full_width()` method.
 
     """
 
@@ -78,4 +79,4 @@ def _compute_sigma(spectrum, region=None):
     fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux) / np.sum(flux))
     sigma = fwhm * gaussian_fwhm_to_sigma
 
-    return sigma
+    return sigma * 2

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -254,3 +254,24 @@ def test_sigma_full_width_regions():
     for model, result in zip((g1, g2, g3), result_list):
         exp = model.stddev*2
         assert quantity.isclose(result, exp, atol=0.25*exp)
+
+
+@pytest.mark.xfail(reason="Bug in representation of multiple 1D spectra")
+def test_sigma_full_width_multi_spectrum():
+
+    np.random.seed(42)
+
+    frequencies = np.linspace(1, 100, 10000) * u.GHz
+    g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=10*u.GHz, stddev=0.8*u.GHz)
+    g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=2*u.GHz, stddev=0.3*u.GHz)
+    g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=70*u.GHz, stddev=10*u.GHz)
+
+    flux = np.ndarray((3, len(frequencies)))
+
+    flux[0] = g1(frequencies)
+    flux[1] = g2(frequencies)
+    flux[2] = g3(frequencies)
+
+    spectra = Spectrum1D(spectral_axis=frequencies, flux=flux)
+
+    results = sigma_full_width(spectra)


### PR DESCRIPTION
The documentation says that I should be able to have multiple spectra that all use the same spectral axis in a `Spectrum1D` object. Naively, I would expect to be able to do this:

```python
frequencies = np.linspace(1, 10, 20) * u.um
flux = np.ndarray((3, 20)) * u.Jy
s1 = Spectrum1D(spectral_axis=frequencies, flux=flux)
```

However, the following assertions will fail:

```python
assert frequencies == s1.spectral_axis
assert len(frequencies) == s1.spectral_axis
```

This is highly unintuitive.

Doing the following *will* preserve the dimensions of the spectral axis:

```python
frequencies = np.linspace(1, 10, 20) * u.um
flux = np.ndarray((3, 20)) * u.Jy
s1 = Spectrum1D(spectral_axis=frequencies, flux=flux.T)
```

But this doesn't make any sense to me. It also has the consequence of making internal computations have to perform some unnecessary contortions.

Is this a bug or am I just misunderstanding how this is supposed to work?