### PR TITLE
Add width statistics

### DIFF
--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: specutils.analysis
+
 ==============
 Basic Analysis
 ==============
@@ -75,6 +77,61 @@ And if the spectrum contains a continuum, then it should be subtracted first:
     >>> continuum_flux = continuum_baseline(spec.spectral_axis.value) #doctest:+SKIP
     >>> continuum = Spectrum1D(spectral_axis=spec.spectral_axis, flux=continuum_flux) #doctest:+SKIP
     >>> c = centroid(spec-continuum, region=None) #doctest:+SKIP
+
+Width
+-----
+
+There are several width statistics that are provided by the
+`~specutils.analysis` submodule.
+
+The `~gaussian_sigma_width` function estimates the width of the spectrum by
+computing an approximation of the standard deviation.
+
+The `~gaussian_fwhm` function estimates the width of the spectrum at half max,
+again by computing an approximation of the standard deviation.
+
+Both of these functions assume that spectrum is approximately gaussian and that
+it is centered on the spectral axis.
+
+The function `~fwhm` provides an estimate of the full width of the spectrum at
+half max that does not assume the spectrum is gaussian or centered on the
+spectral axis. It locates the maximum, and then locates the value closest to
+half of the maximum on either side, and measures the distance between them.
+
+Consider the following noisy gaussian spectrum as an example:
+
+.. plot::
+   :include-source: true
+
+   >>> import numpy as np
+   >>> from astropy import units as u
+   >>> from astropy.modeling import models
+   >>> from specutils import Spectrum1D
+   >>> from specutils.analysis import gaussian_sigma_width
+   >>> np.random.seed(0)
+
+   >>> spectral_axis = np.linspace(0., 10., 200) * u.GHz
+   >>> # Note that the gaussian is centered on the spectral axis
+   >>> spectral_model = models.Gaussian1D(amplitude=3*u.Jy, mean=5*u.GHz, stddev=0.8*u.GHz)
+   >>> flux = spectral_model(spectral_axis)
+   >>> # Add noise
+   >>> flux += np.random.normal(0., 0.2, spectral_axis.shape) * u.Jy
+   >>> noisy_gaussian = Spectrum1D(spectral_axis=spectral_axis, flux=flux)
+
+   >>> import matplotlib.pyplot as plt
+   >>> plt.plot(noisy_gaussian.spectral_axis, noisy_gaussian.flux)
+
+Each of the width analysis functions are applied to this spectrum below:
+
+.. code-block:: python
+
+   >>> from specutils.analysis import gaussian_sigma_width, gaussian_fwhm, fwhm
+   >>> gaussian_sigma_width(noisy_gaussian)
+   <Quantity 1.59661941 GHz>
+   >>> gaussian_fwhm(noisy_gaussian)
+   <Quantity 1.87987569 GHz>
+   >>> fwhm(noisy_gaussian)
+   <Quantity 1.85929648 GHz>
 
 Reference/API
 -------------

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -85,7 +85,7 @@ There are several width statistics that are provided by the
 `~specutils.analysis` submodule.
 
 The `~gaussian_sigma_width` function estimates the width of the spectrum by
-computing an approximation of the standard deviation.
+computing a second-moment-based approximation of the standard deviation.
 
 The `~gaussian_fwhm` function estimates the width of the spectrum at half max,
 again by computing an approximation of the standard deviation.
@@ -125,12 +125,12 @@ Each of the width analysis functions are applied to this spectrum below:
 .. code-block:: python
 
    >>> from specutils.analysis import gaussian_sigma_width, gaussian_fwhm, fwhm
-   >>> gaussian_sigma_width(noisy_gaussian)
-   <Quantity 1.59661941 GHz>
-   >>> gaussian_fwhm(noisy_gaussian)
-   <Quantity 1.87987569 GHz>
-   >>> fwhm(noisy_gaussian)
-   <Quantity 1.85929648 GHz>
+   >>> gaussian_sigma_width(noisy_gaussian) # doctest: +FLOAT_CMP
+   <Quantity 0.93853592 GHz>
+   >>> gaussian_fwhm(noisy_gaussian) # doctest: +FLOAT_CMP
+   <Quantity 2.21008321 GHz>
+   >>> fwhm(noisy_gaussian) # doctest: +FLOAT_CMP
+   <Quantity 1.65829146 GHz>
 
 
 Reference/API

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -90,13 +90,12 @@ computing an approximation of the standard deviation.
 The `~gaussian_fwhm` function estimates the width of the spectrum at half max,
 again by computing an approximation of the standard deviation.
 
-Both of these functions assume that spectrum is approximately gaussian and that
-it is centered on the spectral axis.
+Both of these functions assume that spectrum is approximately gaussian.
 
 The function `~fwhm` provides an estimate of the full width of the spectrum at
-half max that does not assume the spectrum is gaussian or centered on the
-spectral axis. It locates the maximum, and then locates the value closest to
-half of the maximum on either side, and measures the distance between them.
+half max that does not assume the spectrum is gaussian. It locates the maximum,
+and then locates the value closest to half of the maximum on either side, and
+measures the distance between them.
 
 Consider the following noisy gaussian spectrum as an example:
 
@@ -112,7 +111,6 @@ Consider the following noisy gaussian spectrum as an example:
    >>> np.random.seed(0)
 
    >>> spectral_axis = np.linspace(0., 10., 200) * u.GHz
-   >>> # Note that the gaussian is centered on the spectral axis
    >>> spectral_model = models.Gaussian1D(amplitude=3*u.Jy, mean=5*u.GHz, stddev=0.8*u.GHz)
    >>> flux = spectral_model(spectral_axis)
    >>> # Add noise
@@ -134,38 +132,6 @@ Each of the width analysis functions are applied to this spectrum below:
    >>> fwhm(noisy_gaussian)
    <Quantity 1.85929648 GHz>
 
-For uncentered spectra, `~fwhm` will generally provide a more accurate value
-than either `~gaussian_sigma_width` or `~gaussian_fwhm`. Consider the following
-example:
-
-.. plot::
-   :include-source: true
-   :context:
-
-   >>> np.random.seed(0)
-
-   >>> spectral_axis = np.linspace(0., 10., 200) * u.GHz
-   >>> # Note that the spectrum is not centered on the spectral axis
-   >>> spectral_model = models.Gaussian1D(amplitude=3*u.Jy, mean=2*u.GHz, stddev=1.2*u.GHz)
-   >>> flux = spectral_model(spectral_axis)
-   >>> # Add noise
-   >>> flux += np.random.normal(0., 0.2, spectral_axis.shape) * u.Jy
-   >>> uncentered_gaussian = Spectrum1D(spectral_axis=spectral_axis, flux=flux)
-
-   >>> plt.clf() #doctest:+SKIP
-   >>> plt.plot(uncentered_gaussian.spectral_axis, uncentered_gaussian.flux) #doctest:+SKIP
-
-Note that in this case, the `~fwhm` estimate is reasonable, whereas the others
-are not:
-
-.. code-block:: python
-
-   >>> gaussian_sigma_width(uncentered_gaussian)
-   <Quantity 5.23511731 GHz>
-   >>> gaussian_fwhm(uncentered_gaussian)
-   <Quantity 6.16387959 GHz>
-   >>> fwhm(uncentered_gaussian)
-   <Quantity 2.7638191 GHz>
 
 Reference/API
 -------------

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -102,6 +102,7 @@ Consider the following noisy gaussian spectrum as an example:
 
 .. plot::
    :include-source: true
+   :context:
 
    >>> import numpy as np
    >>> from astropy import units as u
@@ -132,6 +133,39 @@ Each of the width analysis functions are applied to this spectrum below:
    <Quantity 1.87987569 GHz>
    >>> fwhm(noisy_gaussian)
    <Quantity 1.85929648 GHz>
+
+For uncentered spectra, `~fwhm` will generally provide a more accurate value
+than either `~gaussian_sigma_width` or `~gaussian_fwhm`. Consider the following
+example:
+
+.. plot::
+   :include-source: true
+   :context:
+
+   >>> np.random.seed(0)
+
+   >>> spectral_axis = np.linspace(0., 10., 200) * u.GHz
+   >>> # Note that the spectrum is not centered on the spectral axis
+   >>> spectral_model = models.Gaussian1D(amplitude=3*u.Jy, mean=2*u.GHz, stddev=1.2*u.GHz)
+   >>> flux = spectral_model(spectral_axis)
+   >>> # Add noise
+   >>> flux += np.random.normal(0., 0.2, spectral_axis.shape) * u.Jy
+   >>> uncentered_gaussian = Spectrum1D(spectral_axis=spectral_axis, flux=flux)
+
+   >>> plt.clf()
+   >>> plt.plot(uncentered_gaussian.spectral_axis, uncentered_gaussian.flux)
+
+Note that in this case, the `~fwhm` estimate is reasonable, whereas the others
+are not:
+
+.. code-block:: python
+
+   >>> gaussian_sigma_width(uncentered_gaussian)
+   <Quantity 5.23511731 GHz>
+   >>> gaussian_fwhm(uncentered_gaussian)
+   <Quantity 6.16387959 GHz>
+   >>> fwhm(uncentered_gaussian)
+   <Quantity 2.7638191 GHz>
 
 Reference/API
 -------------

--- a/docs/basic_analysis.rst
+++ b/docs/basic_analysis.rst
@@ -119,8 +119,8 @@ Consider the following noisy gaussian spectrum as an example:
    >>> flux += np.random.normal(0., 0.2, spectral_axis.shape) * u.Jy
    >>> noisy_gaussian = Spectrum1D(spectral_axis=spectral_axis, flux=flux)
 
-   >>> import matplotlib.pyplot as plt
-   >>> plt.plot(noisy_gaussian.spectral_axis, noisy_gaussian.flux)
+   >>> import matplotlib.pyplot as plt #doctest:+SKIP
+   >>> plt.plot(noisy_gaussian.spectral_axis, noisy_gaussian.flux) #doctest:+SKIP
 
 Each of the width analysis functions are applied to this spectrum below:
 
@@ -152,8 +152,8 @@ example:
    >>> flux += np.random.normal(0., 0.2, spectral_axis.shape) * u.Jy
    >>> uncentered_gaussian = Spectrum1D(spectral_axis=spectral_axis, flux=flux)
 
-   >>> plt.clf()
-   >>> plt.plot(uncentered_gaussian.spectral_axis, uncentered_gaussian.flux)
+   >>> plt.clf() #doctest:+SKIP
+   >>> plt.plot(uncentered_gaussian.spectral_axis, uncentered_gaussian.flux) #doctest:+SKIP
 
 Note that in this case, the `~fwhm` estimate is reasonable, whereas the others
 are not:

--- a/specutils/analysis/__init__.py
+++ b/specutils/analysis/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 from .equivalent_width import *  # noqa
 from .snr import snr  # noqa
 from .centroid import centroid  # noqa
-from .width import gaussian_sigma_width, gaussian_fwhm # noqa
+from .width import gaussian_sigma_width, gaussian_fwhm, fwhm # noqa

--- a/specutils/analysis/__init__.py
+++ b/specutils/analysis/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 from .equivalent_width import *  # noqa
 from .snr import snr  # noqa
 from .centroid import centroid  # noqa
-from .width import sigma_full_width # noqa
+from .width import sigma_full_width, full_width_half_max # noqa

--- a/specutils/analysis/__init__.py
+++ b/specutils/analysis/__init__.py
@@ -3,3 +3,4 @@ from __future__ import absolute_import
 from .equivalent_width import *  # noqa
 from .snr import snr  # noqa
 from .centroid import centroid  # noqa
+from .width import sigma # noqa

--- a/specutils/analysis/__init__.py
+++ b/specutils/analysis/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 from .equivalent_width import *  # noqa
 from .snr import snr  # noqa
 from .centroid import centroid  # noqa
-from .width import sigma_full_width, full_width_half_max # noqa
+from .width import gaussian_sigma_width, gaussian_fwhm # noqa

--- a/specutils/analysis/__init__.py
+++ b/specutils/analysis/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 from .equivalent_width import *  # noqa
 from .snr import snr  # noqa
 from .centroid import centroid  # noqa
-from .width import sigma # noqa
+from .width import sigma_full_width # noqa

--- a/specutils/analysis/centroid.py
+++ b/specutils/analysis/centroid.py
@@ -1,5 +1,7 @@
 import numpy as np
 from ..spectra import SpectralRegion
+from ..manipulation import extract_region
+
 
 __all__ = ['centroid']
 
@@ -68,7 +70,7 @@ def _centroid_single_region(spectrum, region=None):
     """
 
     if region is not None:
-        calc_spectrum = region.extract(spectrum)
+        calc_spectrum = extract_region(spectrum, region)
     else:
         calc_spectrum = spectrum
 

--- a/specutils/analysis/equivalent_width.py
+++ b/specutils/analysis/equivalent_width.py
@@ -17,7 +17,7 @@ def equivalent_width(spectrum):
 
     Returns
     -------
-    ew : float
+    ew : `~astropy.units.Quantity`
         Equivalent width calculation.
 
     TODO:  what frame of reference do you want the spectral_axis to be in ???

--- a/specutils/analysis/snr.py
+++ b/specutils/analysis/snr.py
@@ -21,7 +21,7 @@ def snr(spectrum, region=None):
 
     Returns
     -------
-    snr : float or list (based on region input)
+    snr : `~astropy.units.Quantity` or list (based on region input)
         Signal to noise ratio of the spectrum or within the regions
 
     Notes
@@ -63,7 +63,7 @@ def _snr_single_region(spectrum, region=None):
 
     Returns
     -------
-    snr : float or list (based on region input)
+    snr : `~astropy.units.Quantity` or list (based on region input)
         Signal to noise ratio of the spectrum or within the regions
 
     Notes

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -65,9 +65,13 @@ def gaussian_fwhm(spectrum, region=None):
 
 def fwhm(spectrum, region=None):
     """
-    Compute the true full width half max of the spectrum. This makes no
-    assumptions about the shape of the spectrum (e.g. whether it is Gaussian).
-    This will be calculated over the regions, if they are specified.
+    Compute the true full width half max of the spectrum.
+    
+    This makes no assumptions about the shape of the spectrum (e.g. whether it
+    is Gaussian). It finds the maximum of the spectrum, and then locates the
+    point closest to half max on either side of the maximum, and
+    measures the distance between them. This will be calculated over the
+    regions, if they are specified. 
 
     Parameters
     ----------

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -36,7 +36,7 @@ def sigma_full_width(spectrum, region=None):
 
     Returns
     -------
-    full_width : float or list (based on region input)
+    full_width : `~astropy.units.Quantity` or list (based on region input)
         Approximate full width of the signal
     """
     return _computation_wrapper(_compute_sigma_full_width, spectrum, region)
@@ -57,7 +57,7 @@ def full_width_half_max(spectrum, region=None):
 
     Returns
     -------
-    full_width_half_max : float or list (based on region input)
+    full_width_half_max : `~astropy.units.Quantity` or list (based on region input)
         Approximate full width of the signal at half max
     """
     return _computation_wrapper(_compute_full_width_half_max, spectrum, region)
@@ -77,7 +77,7 @@ def _compute_full_width_half_max(spectrum, region=None):
 
     Returns
     -------
-    full_width_half_max : float or list (based on region input)
+    full_width_half_max : `~astropy.units.Quantity` or list (based on region input)
         Approximate full width of the signal at half max
 
     Notes
@@ -115,7 +115,7 @@ def _compute_sigma_full_width(spectrum, region=None):
 
     Returns
     -------
-    full_width : float or list (based on region input)
+    full_width : `~astropy.units.Quantity` or list (based on region input)
         Approximate full width of the signal
 
     Notes

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -25,9 +25,11 @@ def _computation_wrapper(func, spectrum, region):
 
 def gaussian_sigma_width(spectrum, region=None):
     """
-    Estimate the width of the spectrum using a second-moment analysis, scaled
-    to match the sigma/standard deviation parameter of a standard Gaussian
-    profile. This will be calculated over the regions, if they are specified.
+    Estimate the width of the spectrum using a second-moment analysis.
+    
+    The value is scaled to match the sigma/standard deviation parameter of a
+    standard Gaussian profile. This will be calculated over the regions, if
+    they are specified.
 
     Parameters
     ----------
@@ -40,8 +42,8 @@ def gaussian_sigma_width(spectrum, region=None):
 
     Returns
     -------
-    full_width : `~astropy.units.Quantity` or list (based on region input)
-        Approximate full width of the signal
+    approx_sigma: `~astropy.units.Quantity` or list (based on region input)
+        Approximated sigma value of the spectrum
 
     Notes
     -----
@@ -53,9 +55,11 @@ def gaussian_sigma_width(spectrum, region=None):
 
 def gaussian_fwhm(spectrum, region=None):
     """
-    Estimate the width of the spectrum using a second-moment analysis scaled to
-    match the full width at half max of a standard Gaussian profile.  This will
-    be calculated over the regions, if they are specified.
+    Estimate the width of the spectrum using a second-moment analysis.
+    
+    The value is scaled to match the full width at half max of a standard
+    Gaussian profile.  This will be calculated over the regions, if they are
+    specified.
 
     Parameters
     ----------

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -23,8 +23,9 @@ def _computation_wrapper(func, spectrum, region):
 
 def gaussian_sigma_width(spectrum, region=None):
     """
-    Estimate the full width of the spectrum based on an approximate value of
-    sigma.  This will be calculated over the regions, if they are specified.
+    Estimate the width of the spectrum using a second-moment analysis, scaled
+    to match the sigma/standard deviation parameter of a standard Gaussian
+    profile. This will be calculated over the regions, if they are specified.
 
     Parameters
     ----------
@@ -32,7 +33,8 @@ def gaussian_sigma_width(spectrum, region=None):
         The spectrum object over which the width will be calculated.
 
     region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
-        Region within the spectrum to calculate the gaussian sigma width.
+        Region within the spectrum to calculate the gaussian sigma width. If
+        region is `None`, computation is performed over entire spectrum.
 
     Returns
     -------
@@ -44,8 +46,9 @@ def gaussian_sigma_width(spectrum, region=None):
 
 def gaussian_fwhm(spectrum, region=None):
     """
-    Estimate the full width half max of the spectrum assuming it is gaussian.
-    This will be calculated over the regions, if they are specified.
+    Estimate the width of the spectrum using a second-moment analysis scaled to
+    match the full width at half max of a standard Gaussian profile.  This will
+    be calculated over the regions, if they are specified.
 
     Parameters
     ----------
@@ -53,7 +56,8 @@ def gaussian_fwhm(spectrum, region=None):
         The spectrum object overwhich the width will be calculated.
 
     region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
-        Region within the spectrum to calculate the FWHM value.
+        Region within the spectrum to calculate the FWHM value. If region is
+        `None`, computation is performed over entire spectrum.
 
     Returns
     -------
@@ -79,7 +83,8 @@ def fwhm(spectrum, region=None):
         The spectrum object over which the width will be calculated.
 
     region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
-        Region within the spectrum to calculate the FWHM value.
+        Region within the spectrum to calculate the FWHM value. If region is
+        `None`, computation is performed over entire spectrum.
 
     Returns
     -------
@@ -118,9 +123,9 @@ def _compute_gaussian_fwhm(spectrum, region=None):
         calc_spectrum = spectrum
 
     flux = calc_spectrum.flux
-    spectrum = calc_spectrum.spectral_axis
+    spectral_axis = calc_spectrum.spectral_axis
 
-    dx = spectrum - np.mean(spectrum)
+    dx = spectral_axis - np.mean(spectral_axis)
     fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux, axis=-1) / np.sum(flux, axis=-1))
 
     return fwhm
@@ -163,7 +168,7 @@ def _arghalf(array, halfval):
     return np.abs(array - halfval).argmin()
 
 
-def _compute_single_fwhm(flux, spectrum):
+def _compute_single_fwhm(flux, spectral_axis):
 
     argmax = np.argmax(flux)
     halfval = flux[argmax] / 2
@@ -172,7 +177,7 @@ def _compute_single_fwhm(flux, spectrum):
     l_idx = _arghalf(flux[:argmax], halfval) if argmax > 0 else 0
     r_idx = _arghalf(flux[argmax+1:], halfval) + argmax+1 if argmax < max_idx else max_idx
 
-    return spectrum[r_idx] - spectrum[l_idx]
+    return spectral_axis[r_idx] - spectral_axis[l_idx]
 
 
 def _compute_fwhm(spectrum, region=None):
@@ -204,9 +209,9 @@ def _compute_fwhm(spectrum, region=None):
         calc_spectrum = spectrum
 
     flux = calc_spectrum.flux
-    spectrum = calc_spectrum.spectral_axis
+    spectral_axis = calc_spectrum.spectral_axis
 
     if flux.ndim > 1:
-        return [_compute_single_fwhm(x, spectrum) for x in flux]
+        return [_compute_single_fwhm(x, spectral_axis) for x in flux]
     else:
-        return _compute_single_fwhm(flux, spectrum)
+        return _compute_single_fwhm(flux, spectral_axis)

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -3,7 +3,7 @@ from astropy.stats.funcs import gaussian_fwhm_to_sigma
 from ..spectra import SpectralRegion
 
 
-__all__ = ['sigma_full_width', 'full_width_half_max']
+__all__ = ['gaussian_sigma_width', 'gaussian_fwhm']
 
 
 def _computation_wrapper(func, spectrum, region):
@@ -21,15 +21,15 @@ def _computation_wrapper(func, spectrum, region):
         return [func(spectrum, region=reg) for reg in region]
 
 
-def sigma_full_width(spectrum, region=None):
+def gaussian_sigma_width(spectrum, region=None):
     """
-    Calculate the full width of the spectrum based on an approximate value of
+    Estimate the full width of the spectrum based on an approximate value of
     sigma.  This will be calculated over the regions, if they are specified.
 
     Parameters
     ----------
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object overwhich the equivalent width will be calculated.
+        The spectrum object over which the width will be calculated.
 
     region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the gaussian sigma width.
@@ -39,50 +39,50 @@ def sigma_full_width(spectrum, region=None):
     full_width : `~astropy.units.Quantity` or list (based on region input)
         Approximate full width of the signal
     """
-    return _computation_wrapper(_compute_sigma_full_width, spectrum, region)
+    return _computation_wrapper(_compute_gaussian_sigma_width, spectrum, region)
 
 
-def full_width_half_max(spectrum, region=None):
+def gaussian_fwhm(spectrum, region=None):
     """
-    Calculate the full width half max of the spectrum.  This will be calculated
-    over the regions, if they are specified.
+    Estimate the full width half max of the spectrum assuming it is gaussian.
+    This will be calculated over the regions, if they are specified.
 
     Parameters
     ----------
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object overwhich the equivalent width will be calculated.
+        The spectrum object overwhich the width will be calculated.
 
     region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the FWHM value.
 
     Returns
     -------
-    full_width_half_max : `~astropy.units.Quantity` or list (based on region input)
+    gaussian_fwhm : `~astropy.units.Quantity` or list (based on region input)
         Approximate full width of the signal at half max
     """
-    return _computation_wrapper(_compute_full_width_half_max, spectrum, region)
+    return _computation_wrapper(_compute_gaussian_fwhm, spectrum, region)
 
 
-def _compute_full_width_half_max(spectrum, region=None):
+def _compute_gaussian_fwhm(spectrum, region=None):
     """
-    Calculate the full width of the spectrum at half max.
+    Estimate the full width of the spectrum at half max.
 
     Parameters
     ----------
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object overwhich the equivalent width will be calculated.
+        The spectrum object overwhich the width will be calculated.
 
     region: `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the FWHM value.
 
     Returns
     -------
-    full_width_half_max : `~astropy.units.Quantity` or list (based on region input)
+    gaussian_fwhm : `~astropy.units.Quantity` or list (based on region input)
         Approximate full width of the signal at half max
 
     Notes
     -----
-    This is a helper function for the above `full_width_half_max()` method.
+    This is a helper function for the above `gaussian_fwhm()` method.
 
     """
 
@@ -100,15 +100,15 @@ def _compute_full_width_half_max(spectrum, region=None):
     return fwhm
 
 
-def _compute_sigma_full_width(spectrum, region=None):
+def _compute_gaussian_sigma_width(spectrum, region=None):
     """
-    Calculate the full width of the spectrum based on an approximate value of
+    Estimate the full width of the spectrum based on an approximate value of
     sigma.
 
     Parameters
     ----------
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object overwhich the equivalent width will be calculated.
+        The spectrum object overwhich the width will be calculated.
 
     region: `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the gaussian sigma width.
@@ -120,11 +120,11 @@ def _compute_sigma_full_width(spectrum, region=None):
 
     Notes
     -----
-    This is a helper function for the above `sigma_full_width()` method.
+    This is a helper function for the above `gaussian_sigma_width()` method.
 
     """
 
-    fwhm = _compute_full_width_half_max(spectrum, region)
+    fwhm = _compute_gaussian_fwhm(spectrum, region)
     sigma = fwhm * gaussian_fwhm_to_sigma
 
     return sigma * 2

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -92,9 +92,9 @@ def _compute_full_width_half_max(spectrum, region=None):
         calc_spectrum = spectrum
 
     flux = calc_spectrum.flux
-    frequencies = calc_spectrum.frequency
+    spectrum = calc_spectrum.spectral_axis
 
-    dx = frequencies - np.mean(frequencies)
+    dx = spectrum - np.mean(spectrum)
     fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux, axis=-1) / np.sum(flux, axis=-1))
 
     return fwhm

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -1,6 +1,7 @@
 import numpy as np
 from astropy.stats.funcs import gaussian_sigma_to_fwhm
 from ..spectra import SpectralRegion
+from ..manipulation import extract_region
 from . import centroid
 
 
@@ -126,7 +127,7 @@ def _compute_gaussian_sigma_width(spectrum, region=None):
     """
 
     if region is not None:
-        calc_spectrum = region.extract(spectrum)
+        calc_spectrum = extract_region(spectrum, region)
     else:
         calc_spectrum = spectrum
 
@@ -164,7 +165,7 @@ def _compute_fwhm(spectrum, region=None):
     """
 
     if region is not None:
-        calc_spectrum = region.extract(spectrum)
+        calc_spectrum = extract_region(spectrum, region)
     else:
         calc_spectrum = spectrum
 

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -41,6 +41,11 @@ def gaussian_sigma_width(spectrum, region=None):
     -------
     full_width : `~astropy.units.Quantity` or list (based on region input)
         Approximate full width of the signal
+
+    Notes
+    -----
+    The spectrum should be continuum subtracted before being passed to this
+    function.
     """
     return _computation_wrapper(_compute_gaussian_sigma_width, spectrum, region)
 
@@ -64,6 +69,11 @@ def gaussian_fwhm(spectrum, region=None):
     -------
     gaussian_fwhm : `~astropy.units.Quantity` or list (based on region input)
         Approximate full width of the signal at half max
+
+    Notes
+    -----
+    The spectrum should be continuum subtracted before being passed to this
+    function.
     """
     return _computation_wrapper(_compute_gaussian_fwhm, spectrum, region)
 
@@ -91,31 +101,18 @@ def fwhm(spectrum, region=None):
     -------
     whm : `~astropy.units.Quantity` or list (based on region input)
         Full width of the signal at half max
+
+    Notes
+    -----
+    The spectrum should be continuum subtracted before being passed to this
+    function.
     """
     return _computation_wrapper(_compute_fwhm, spectrum, region)
 
 
 def _compute_gaussian_fwhm(spectrum, region=None):
     """
-    Estimate the full width of the spectrum at half max.
-
-    Parameters
-    ----------
-    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object overwhich the width will be calculated.
-
-    region: `~specutils.utils.SpectralRegion`
-        Region within the spectrum to calculate the FWHM value.
-
-    Returns
-    -------
-    gaussian_fwhm : `~astropy.units.Quantity` or list (based on region input)
-        Approximate full width of the signal at half max
-
-    Notes
-    -----
     This is a helper function for the above `gaussian_fwhm()` method.
-
     """
 
     fwhm = _compute_gaussian_sigma_width(spectrum, region) * gaussian_sigma_to_fwhm
@@ -125,26 +122,7 @@ def _compute_gaussian_fwhm(spectrum, region=None):
 
 def _compute_gaussian_sigma_width(spectrum, region=None):
     """
-    Estimate the full width of the spectrum based on an approximate value of
-    sigma.
-
-    Parameters
-    ----------
-    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object overwhich the width will be calculated.
-
-    region: `~specutils.utils.SpectralRegion`
-        Region within the spectrum to calculate the gaussian sigma width.
-
-    Returns
-    -------
-    full_width : `~astropy.units.Quantity` or list (based on region input)
-        Approximate full width of the signal
-
-    Notes
-    -----
     This is a helper function for the above `gaussian_sigma_width()` method.
-
     """
 
     if region is not None:
@@ -182,25 +160,7 @@ def _compute_single_fwhm(flux, spectral_axis):
 
 def _compute_fwhm(spectrum, region=None):
     """
-    Calculate the full width of the spectrum at half max.
-
-    Parameters
-    ----------
-    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object over which the width will be calculated.
-
-    region: `~specutils.utils.SpectralRegion`
-        Region within the spectrum to calculate FWHMh.
-
-    Returns
-    -------
-    fwhm : `~astropy.units.Quantity` or list (based on region input)
-        Computed full width of the signal at half max
-
-    Notes
-    -----
     This is a helper function for the above `fwhm()` method.
-
     """
 
     if region is not None:

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -1,0 +1,81 @@
+import numpy as np
+from astropy.stats.funcs import gaussian_fwhm_to_sigma
+from ..spectra import SpectralRegion
+
+__all__ = ['sigma']
+
+
+def sigma(spectrum, region=None):
+    """
+    Calculate the gaussian sigma width of the spectrum.  This will be
+    calculated over the regions, if they are specified.
+
+    Parameters
+    ----------
+    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
+        The spectrum object overwhich the equivalent width will be calculated.
+
+    region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+        Region within the spectrum to calculate the gaussian sigma width.
+
+    Returns
+    -------
+    snr : float or list (based on region input)
+        Signal to noise ratio of the spectrum or within the regions
+
+    Notes
+    -----
+    The spectrum will need to have the uncertainty defined in order
+    for the gaussian sigma width to be calculated.
+
+    """
+
+    # No region, therefore whole spectrum.
+    if region is None:
+        return _compute_sigma(spectrum)
+
+    # Single region
+    elif isinstance(region, SpectralRegion):
+        return _compute_sigma(spectrum, region=region)
+
+    # List of regions
+    elif isinstance(region, list):
+        return [_compute_sigma(spectrum, region=reg) for reg in region]
+
+
+def _compute_sigma(spectrum, region=None):
+    """
+    Calculate the gaussian sigma width of the spectrum.
+
+    Parameters
+    ----------
+    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
+        The spectrum object overwhich the equivalent width will be calculated.
+
+    region: `~specutils.utils.SpectralRegion`
+        Region within the spectrum to calculate the gaussian sigma width.
+
+    Returns
+    -------
+    snr : float or list (based on region input)
+        Signal to noise ratio of the spectrum or within the regions
+
+    Notes
+    -----
+    This is a helper function for the above `snr()` method.
+
+    """
+
+    if region is not None:
+        calc_spectrum = region.extract(spectrum)
+    else:
+        calc_spectrum = spectrum
+
+    flux = calc_spectrum.flux
+    frequencies = calc_spectrum.frequency
+
+    dx = frequencies - np.mean(frequencies)
+    fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux) / np.sum(flux))
+    sigma = fwhm * gaussian_fwhm_to_sigma
+
+    return sigma

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -76,7 +76,7 @@ def _compute_sigma_full_width(spectrum, region=None):
     frequencies = calc_spectrum.frequency
 
     dx = frequencies - np.mean(frequencies)
-    fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux) / np.sum(flux))
+    fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux, axis=-1) / np.sum(flux, axis=-1))
     sigma = fwhm * gaussian_fwhm_to_sigma
 
     return sigma * 2

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -2,13 +2,13 @@ import numpy as np
 from astropy.stats.funcs import gaussian_fwhm_to_sigma
 from ..spectra import SpectralRegion
 
-__all__ = ['sigma']
+__all__ = ['sigma_full_width']
 
 
-def sigma(spectrum, region=None):
+def sigma_full_width(spectrum, region=None):
     """
-    Calculate the gaussian sigma width of the spectrum.  This will be
-    calculated over the regions, if they are specified.
+    Calculate the full width of the spectrum based on an approximate value of
+    sigma.  This will be calculated over the regions, if they are specified.
 
     Parameters
     ----------
@@ -20,8 +20,8 @@ def sigma(spectrum, region=None):
 
     Returns
     -------
-    snr : float or list (based on region input)
-        Signal to noise ratio of the spectrum or within the regions
+    full_width : float or list (based on region input)
+        Approximate full width of the signal
 
     Notes
     -----
@@ -32,20 +32,21 @@ def sigma(spectrum, region=None):
 
     # No region, therefore whole spectrum.
     if region is None:
-        return _compute_sigma(spectrum)
+        return _compute_sigma_full_width(spectrum)
 
     # Single region
     elif isinstance(region, SpectralRegion):
-        return _compute_sigma(spectrum, region=region)
+        return _compute_sigma_full_width(spectrum, region=region)
 
     # List of regions
     elif isinstance(region, list):
-        return [_compute_sigma(spectrum, region=reg) for reg in region]
+        return [_compute_sigma_full_width(spectrum, region=reg) for reg in region]
 
 
-def _compute_sigma(spectrum, region=None):
+def _compute_sigma_full_width(spectrum, region=None):
     """
-    Calculate the gaussian sigma width of the spectrum.
+    Calculate the full width of the spectrum based on an approximate value of
+    sigma.
 
     Parameters
     ----------
@@ -57,12 +58,12 @@ def _compute_sigma(spectrum, region=None):
 
     Returns
     -------
-    snr : float or list (based on region input)
-        Signal to noise ratio of the spectrum or within the regions
+    full_width : float or list (based on region input)
+        Approximate full width of the signal
 
     Notes
     -----
-    This is a helper function for the above `snr()` method.
+    This is a helper function for the above `sigma_full_width()` method.
 
     """
 
@@ -78,4 +79,4 @@ def _compute_sigma(spectrum, region=None):
     fwhm = 2 * np.sqrt(np.sum((dx * dx) * flux) / np.sum(flux))
     sigma = fwhm * gaussian_fwhm_to_sigma
 
-    return sigma
+    return sigma * 2

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -146,21 +146,16 @@ def _compute_gaussian_sigma_width(spectrum, region=None):
     return sigma
 
 
-def _arghalf(array, halfval):
-    """
-    Find index of the item closest to the half max
-    """
-    return np.abs(array - halfval).argmin()
-
-
 def _compute_single_fwhm(flux, spectral_axis):
 
     argmax = np.argmax(flux)
     halfval = flux[argmax] / 2
 
-    max_idx = len(flux) - 1
-    l_idx = _arghalf(flux[:argmax], halfval) if argmax > 0 else 0
-    r_idx = _arghalf(flux[argmax+1:], halfval) + argmax+1 if argmax < max_idx else max_idx
+    left = flux[:argmax] <= halfval
+    right = flux[argmax+1:] <= halfval
+
+    l_idx = np.where(left == True)[0][-1]
+    r_idx = np.where(right == True)[0][0] + argmax
 
     return spectral_axis[r_idx] - spectral_axis[l_idx]
 

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -3,7 +3,7 @@ from astropy.stats.funcs import gaussian_fwhm_to_sigma
 from ..spectra import SpectralRegion
 
 
-__all__ = ['gaussian_sigma_width', 'gaussian_fwhm']
+__all__ = ['gaussian_sigma_width', 'gaussian_fwhm', 'fwhm']
 
 
 def _computation_wrapper(func, spectrum, region):
@@ -61,6 +61,28 @@ def gaussian_fwhm(spectrum, region=None):
         Approximate full width of the signal at half max
     """
     return _computation_wrapper(_compute_gaussian_fwhm, spectrum, region)
+
+
+def fwhm(spectrum, region=None):
+    """
+    Compute the true full width half max of the spectrum. This makes no
+    assumptions about the shape of the spectrum (e.g. whether it is Gaussian).
+    This will be calculated over the regions, if they are specified.
+
+    Parameters
+    ----------
+    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
+        The spectrum object over which the width will be calculated.
+
+    region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+        Region within the spectrum to calculate the FWHM value.
+
+    Returns
+    -------
+    whm : `~astropy.units.Quantity` or list (based on region input)
+        Full width of the signal at half max
+    """
+    return _computation_wrapper(_compute_fwhm, spectrum, region)
 
 
 def _compute_gaussian_fwhm(spectrum, region=None):
@@ -128,3 +150,59 @@ def _compute_gaussian_sigma_width(spectrum, region=None):
     sigma = fwhm * gaussian_fwhm_to_sigma
 
     return sigma * 2
+
+
+def _arghalf(array, halfval):
+    """
+    Find index of the item closest to the half max
+    """
+    return np.abs(array - halfval).argmin()
+
+
+def _compute_single_fwhm(flux, spectrum):
+
+    argmax = np.argmax(flux)
+    halfval = flux[argmax] / 2
+
+    max_idx = len(flux) - 1
+    l_idx = _arghalf(flux[:argmax], halfval) if argmax > 0 else 0
+    r_idx = _arghalf(flux[argmax+1:], halfval) + argmax+1 if argmax < max_idx else max_idx
+
+    return spectrum[r_idx] - spectrum[l_idx]
+
+
+def _compute_fwhm(spectrum, region=None):
+    """
+    Calculate the full width of the spectrum at half max.
+
+    Parameters
+    ----------
+    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
+        The spectrum object over which the width will be calculated.
+
+    region: `~specutils.utils.SpectralRegion`
+        Region within the spectrum to calculate FWHMh.
+
+    Returns
+    -------
+    fwhm : `~astropy.units.Quantity` or list (based on region input)
+        Computed full width of the signal at half max
+
+    Notes
+    -----
+    This is a helper function for the above `fwhm()` method.
+
+    """
+
+    if region is not None:
+        calc_spectrum = region.extract(spectrum)
+    else:
+        calc_spectrum = spectrum
+
+    flux = calc_spectrum.flux
+    spectrum = calc_spectrum.spectral_axis
+
+    if flux.ndim > 1:
+        return [_compute_single_fwhm(x, spectrum) for x in flux]
+    else:
+        return _compute_single_fwhm(flux, spectrum)

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -134,7 +134,13 @@ def _compute_gaussian_sigma_width(spectrum, region=None):
     flux = calc_spectrum.flux
     spectral_axis = calc_spectrum.spectral_axis
 
-    dx = spectral_axis - centroid(spectrum, region)
+    centroid_result = centroid(spectrum, region)
+
+    if flux.ndim > 1:
+        spectral_axis = np.broadcast_to(spectral_axis, flux.shape) * spectral_axis.unit
+        centroid_result = centroid_result[:, np.newaxis]
+
+    dx = spectral_axis - centroid_result
     sigma = np.sqrt(np.sum((dx * dx) * flux, axis=-1) / np.sum(flux, axis=-1))
 
     return sigma

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -297,3 +297,24 @@ def test_sigma_full_width_regions():
     for model, result in zip((g1, g2, g3), result_list):
         exp = model.stddev*2
         assert quantity.isclose(result, exp, atol=0.25*exp)
+
+
+@pytest.mark.xfail(reason="Bug in representation of multiple 1D spectra")
+def test_sigma_full_width_multi_spectrum():
+
+    np.random.seed(42)
+
+    frequencies = np.linspace(1, 100, 10000) * u.GHz
+    g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=10*u.GHz, stddev=0.8*u.GHz)
+    g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=2*u.GHz, stddev=0.3*u.GHz)
+    g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=70*u.GHz, stddev=10*u.GHz)
+
+    flux = np.ndarray((3, len(frequencies)))
+
+    flux[0] = g1(frequencies)
+    flux[1] = g2(frequencies)
+    flux[2] = g3(frequencies)
+
+    spectra = Spectrum1D(spectral_axis=frequencies, flux=flux)
+
+    results = sigma_full_width(spectra)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -343,6 +343,24 @@ def test_gaussian_fwhm():
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)
 
 
+@pytest.mark.xfail(reason='Currently gaussian fwhm is sensitive to position')
+def test_gaussian_fwhm_uncentered():
+
+    np.random.seed(42)
+
+    # Create a (centered) gaussian spectrum for testing
+    mean = 2
+    frequencies = np.linspace(1, 10, 100) * u.GHz
+    g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=mean*u.GHz, stddev=0.8*u.GHz)
+
+    spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies))
+
+    result = gaussian_fwhm(spectrum)
+
+    expected = g1.stddev * gaussian_sigma_to_fwhm
+    assert quantity_allclose(result, expected, atol=0.01*u.GHz)
+
+
 def test_fwhm():
 
     np.random.seed(42)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -9,8 +9,8 @@ from astropy.stats.funcs import gaussian_sigma_to_fwhm
 from astropy.tests.helper import quantity_allclose
 
 from ..spectra import Spectrum1D, SpectralRegion
-from ..analysis import (equivalent_width, snr, centroid, sigma_full_width,
-                        full_width_half_max)
+from ..analysis import (equivalent_width, snr, centroid, gaussian_sigma_width,
+                        gaussian_fwhm)
 from ..manipulation import noise_region_uncertainty
 from ..tests.spectral_examples import simulated_spectra
 
@@ -249,7 +249,7 @@ def test_centroid_multiple_flux(simulated_spectra):
     assert centroid_spec.unit == u.um
 
 
-def test_sigma_full_width():
+def test_gaussian_sigma_width():
 
     np.random.seed(42)
 
@@ -260,12 +260,12 @@ def test_sigma_full_width():
 
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies))
 
-    result = sigma_full_width(spectrum)
+    result = gaussian_sigma_width(spectrum)
 
     assert quantity_allclose(result, g1.stddev*2, atol=0.01*u.GHz)
 
 
-def test_sigma_full_width_regions():
+def test_gaussian_sigma_width_regions():
 
     np.random.seed(42)
 
@@ -278,31 +278,31 @@ def test_sigma_full_width_regions():
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=compound(frequencies))
 
     region1 = SpectralRegion(lower=5*u.GHz, upper=15*u.GHz)
-    result1 = sigma_full_width(spectrum, region=region1)
+    result1 = gaussian_sigma_width(spectrum, region=region1)
 
     exp1 = g1.stddev*2
     assert quantity_allclose(result1, exp1, atol=0.25*exp1)
 
     region2 = SpectralRegion(lower=1*u.GHz, upper=3*u.GHz)
-    result2 = sigma_full_width(spectrum, region=region2)
+    result2 = gaussian_sigma_width(spectrum, region=region2)
 
     exp2 = g2.stddev*2
     assert quantity_allclose(result2, exp2, atol=0.25*exp2)
 
     region3 = SpectralRegion(lower=40*u.GHz, upper=100*u.GHz)
-    result3 = sigma_full_width(spectrum, region=region3)
+    result3 = gaussian_sigma_width(spectrum, region=region3)
 
     exp3 = g3.stddev*2
     assert quantity_allclose(result3, exp3, atol=0.25*exp3)
 
     # Test using a list of regions
-    result_list = sigma_full_width(spectrum, region=[region1, region2, region3])
+    result_list = gaussian_sigma_width(spectrum, region=[region1, region2, region3])
     for model, result in zip((g1, g2, g3), result_list):
         exp = model.stddev*2
         assert quantity_allclose(result, exp, atol=0.25*exp)
 
 
-def test_sigma_full_width_multi_spectrum():
+def test_gaussian_sigma_width_multi_spectrum():
 
     np.random.seed(42)
 
@@ -319,14 +319,14 @@ def test_sigma_full_width_multi_spectrum():
 
     spectra = Spectrum1D(spectral_axis=frequencies, flux=flux)
 
-    results = sigma_full_width(spectra)
+    results = gaussian_sigma_width(spectra)
 
     expected = (g1.stddev*2, g2.stddev*2, g3.stddev*2)
     for result, exp in zip(results, expected):
         assert quantity_allclose(result, exp, atol=0.25*exp)
 
 
-def test_full_width_half_max():
+def test_gaussian_fwhm():
 
     np.random.seed(42)
 
@@ -337,7 +337,7 @@ def test_full_width_half_max():
 
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies))
 
-    result = full_width_half_max(spectrum)
+    result = gaussian_fwhm(spectrum)
 
     expected = g1.stddev * gaussian_sigma_to_fwhm
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -277,19 +277,19 @@ def test_gaussian_sigma_width_regions():
     compound = g1 + g2 + g3
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=compound(frequencies))
 
-    region1 = SpectralRegion(lower=5*u.GHz, upper=15*u.GHz)
+    region1 = SpectralRegion(5*u.GHz, 15*u.GHz)
     result1 = gaussian_sigma_width(spectrum, region=region1)
 
     exp1 = g1.stddev
     assert quantity_allclose(result1, exp1, atol=0.25*exp1)
 
-    region2 = SpectralRegion(lower=1*u.GHz, upper=3*u.GHz)
+    region2 = SpectralRegion(1*u.GHz, 3*u.GHz)
     result2 = gaussian_sigma_width(spectrum, region=region2)
 
     exp2 = g2.stddev
     assert quantity_allclose(result2, exp2, atol=0.25*exp2)
 
-    region3 = SpectralRegion(lower=40*u.GHz, upper=100*u.GHz)
+    region3 = SpectralRegion(40*u.GHz, 100*u.GHz)
     result3 = gaussian_sigma_width(spectrum, region=region3)
 
     exp3 = g3.stddev

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -343,13 +343,12 @@ def test_gaussian_fwhm():
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)
 
 
-@pytest.mark.xfail(reason='Currently gaussian fwhm is sensitive to position')
-def test_gaussian_fwhm_uncentered():
+@pytest.mark.parametrize('mean', range(3,8))
+def test_gaussian_fwhm_uncentered(mean):
 
     np.random.seed(42)
 
-    # Create a (centered) gaussian spectrum for testing
-    mean = 2
+    # Create an uncentered gaussian spectrum for testing
     frequencies = np.linspace(0, 10, 1000) * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=mean*u.GHz, stddev=0.8*u.GHz)
 
@@ -358,7 +357,7 @@ def test_gaussian_fwhm_uncentered():
     result = gaussian_fwhm(spectrum)
 
     expected = g1.stddev * gaussian_sigma_to_fwhm
-    assert quantity_allclose(result, expected, atol=0.01*u.GHz)
+    assert quantity_allclose(result, expected, atol=0.05*u.GHz)
 
 
 def test_fwhm():

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -6,6 +6,7 @@ from astropy.units import quantity
 from astropy.modeling import models
 from astropy.nddata import StdDevUncertainty
 from astropy.stats.funcs import gaussian_sigma_to_fwhm
+from astropy.tests.helper import quantity_allclose
 
 from ..spectra import Spectrum1D, SpectralRegion
 from ..analysis import (equivalent_width, snr, centroid, sigma_full_width,
@@ -261,7 +262,7 @@ def test_sigma_full_width():
 
     result = sigma_full_width(spectrum)
 
-    assert quantity.isclose(result, g1.stddev*2, atol=0.01*u.GHz)
+    assert quantity_allclose(result, g1.stddev*2, atol=0.01*u.GHz)
 
 
 def test_sigma_full_width_regions():
@@ -280,25 +281,25 @@ def test_sigma_full_width_regions():
     result1 = sigma_full_width(spectrum, region=region1)
 
     exp1 = g1.stddev*2
-    assert quantity.isclose(result1, exp1, atol=0.25*exp1)
+    assert quantity_allclose(result1, exp1, atol=0.25*exp1)
 
     region2 = SpectralRegion(lower=1*u.GHz, upper=3*u.GHz)
     result2 = sigma_full_width(spectrum, region=region2)
 
     exp2 = g2.stddev*2
-    assert quantity.isclose(result2, exp2, atol=0.25*exp2)
+    assert quantity_allclose(result2, exp2, atol=0.25*exp2)
 
     region3 = SpectralRegion(lower=40*u.GHz, upper=100*u.GHz)
     result3 = sigma_full_width(spectrum, region=region3)
 
     exp3 = g3.stddev*2
-    assert quantity.isclose(result3, exp3, atol=0.25*exp3)
+    assert quantity_allclose(result3, exp3, atol=0.25*exp3)
 
     # Test using a list of regions
     result_list = sigma_full_width(spectrum, region=[region1, region2, region3])
     for model, result in zip((g1, g2, g3), result_list):
         exp = model.stddev*2
-        assert quantity.isclose(result, exp, atol=0.25*exp)
+        assert quantity_allclose(result, exp, atol=0.25*exp)
 
 
 @pytest.mark.xfail(reason="Bug in representation of multiple 1D spectra")
@@ -336,4 +337,4 @@ def test_full_width_half_max():
     result = full_width_half_max(spectrum)
 
     expected = g1.stddev * gaussian_sigma_to_fwhm
-    assert quantity.isclose(result, expected, atol=0.01*u.GHz)
+    assert quantity_allclose(result, expected, atol=0.01*u.GHz)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -302,15 +302,14 @@ def test_sigma_full_width_regions():
         assert quantity_allclose(result, exp, atol=0.25*exp)
 
 
-@pytest.mark.xfail(reason="Bug in representation of multiple 1D spectra")
 def test_sigma_full_width_multi_spectrum():
 
     np.random.seed(42)
 
     frequencies = np.linspace(1, 100, 10000) * u.GHz
-    g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=10*u.GHz, stddev=0.8*u.GHz)
-    g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=2*u.GHz, stddev=0.3*u.GHz)
-    g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=70*u.GHz, stddev=10*u.GHz)
+    g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=0.8*u.GHz)
+    g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=5*u.GHz)
+    g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=10*u.GHz)
 
     flux = np.ndarray((3, len(frequencies)))
 
@@ -321,6 +320,10 @@ def test_sigma_full_width_multi_spectrum():
     spectra = Spectrum1D(spectral_axis=frequencies, flux=flux)
 
     results = sigma_full_width(spectra)
+
+    expected = (g1.stddev*2, g2.stddev*2, g3.stddev*2)
+    for result, exp in zip(results, expected):
+        assert quantity_allclose(result, exp, atol=0.25*exp)
 
 
 def test_full_width_half_max():

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -311,7 +311,7 @@ def test_gaussian_sigma_width_multi_spectrum():
     g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=5*u.GHz)
     g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=10*u.GHz)
 
-    flux = np.ndarray((3, len(frequencies)))
+    flux = np.ndarray((3, len(frequencies))) * u.Jy
 
     flux[0] = g1(frequencies)
     flux[1] = g2(frequencies)
@@ -388,7 +388,7 @@ def test_fwhm_multi_spectrum():
     g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=stddevs[1])
     g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=83*u.GHz, stddev=stddevs[2])
 
-    flux = np.ndarray((3, len(frequencies)))
+    flux = np.ndarray((3, len(frequencies))) * u.Jy
 
     flux[0] = g1(frequencies)
     flux[1] = g2(frequencies)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -255,7 +255,7 @@ def test_gaussian_sigma_width():
 
     # Create a (centered) gaussian spectrum for testing
     mean = 5
-    frequencies = np.linspace(1, mean*2, 100) * u.GHz
+    frequencies = np.linspace(0, mean*2, 100) * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=mean*u.GHz, stddev=0.8*u.GHz)
 
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies))
@@ -269,7 +269,7 @@ def test_gaussian_sigma_width_regions():
 
     np.random.seed(42)
 
-    frequencies = np.linspace(1, 100, 10000) * u.GHz
+    frequencies = np.linspace(0, 100, 10000) * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=10*u.GHz, stddev=0.8*u.GHz)
     g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=2*u.GHz, stddev=0.3*u.GHz)
     g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=70*u.GHz, stddev=10*u.GHz)
@@ -306,7 +306,7 @@ def test_gaussian_sigma_width_multi_spectrum():
 
     np.random.seed(42)
 
-    frequencies = np.linspace(1, 100, 10000) * u.GHz
+    frequencies = np.linspace(0, 100, 10000) * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=0.8*u.GHz)
     g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=5*u.GHz)
     g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=10*u.GHz)
@@ -332,7 +332,7 @@ def test_gaussian_fwhm():
 
     # Create a (centered) gaussian spectrum for testing
     mean = 5
-    frequencies = np.linspace(1, mean*2, 100) * u.GHz
+    frequencies = np.linspace(0, mean*2, 100) * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=mean*u.GHz, stddev=0.8*u.GHz)
 
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies))
@@ -350,7 +350,7 @@ def test_gaussian_fwhm_uncentered():
 
     # Create a (centered) gaussian spectrum for testing
     mean = 2
-    frequencies = np.linspace(1, 10, 100) * u.GHz
+    frequencies = np.linspace(0, 10, 1000) * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=mean*u.GHz, stddev=0.8*u.GHz)
 
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies))
@@ -366,7 +366,7 @@ def test_fwhm():
     np.random.seed(42)
 
     # Create an (uncentered) spectrum for testing
-    frequencies = np.linspace(1, 10, 1000) * u.GHz
+    frequencies = np.linspace(0, 10, 1000) * u.GHz
     stddev = 0.8*u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=2*u.GHz, stddev=stddev)
 
@@ -382,7 +382,7 @@ def test_fwhm_multi_spectrum():
 
     np.random.seed(42)
 
-    frequencies = np.linspace(1, 100, 10000) * u.GHz
+    frequencies = np.linspace(0, 100, 10000) * u.GHz
     stddevs = [0.8, 5, 10]*u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=5*u.GHz, stddev=stddevs[0])
     g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=50*u.GHz, stddev=stddevs[1])

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -262,7 +262,7 @@ def test_gaussian_sigma_width():
 
     result = gaussian_sigma_width(spectrum)
 
-    assert quantity_allclose(result, g1.stddev*2, atol=0.01*u.GHz)
+    assert quantity_allclose(result, g1.stddev, atol=0.01*u.GHz)
 
 
 def test_gaussian_sigma_width_regions():
@@ -280,25 +280,25 @@ def test_gaussian_sigma_width_regions():
     region1 = SpectralRegion(lower=5*u.GHz, upper=15*u.GHz)
     result1 = gaussian_sigma_width(spectrum, region=region1)
 
-    exp1 = g1.stddev*2
+    exp1 = g1.stddev
     assert quantity_allclose(result1, exp1, atol=0.25*exp1)
 
     region2 = SpectralRegion(lower=1*u.GHz, upper=3*u.GHz)
     result2 = gaussian_sigma_width(spectrum, region=region2)
 
-    exp2 = g2.stddev*2
+    exp2 = g2.stddev
     assert quantity_allclose(result2, exp2, atol=0.25*exp2)
 
     region3 = SpectralRegion(lower=40*u.GHz, upper=100*u.GHz)
     result3 = gaussian_sigma_width(spectrum, region=region3)
 
-    exp3 = g3.stddev*2
+    exp3 = g3.stddev
     assert quantity_allclose(result3, exp3, atol=0.25*exp3)
 
     # Test using a list of regions
     result_list = gaussian_sigma_width(spectrum, region=[region1, region2, region3])
     for model, result in zip((g1, g2, g3), result_list):
-        exp = model.stddev*2
+        exp = model.stddev
         assert quantity_allclose(result, exp, atol=0.25*exp)
 
 
@@ -321,7 +321,7 @@ def test_gaussian_sigma_width_multi_spectrum():
 
     results = gaussian_sigma_width(spectra)
 
-    expected = (g1.stddev*2, g2.stddev*2, g3.stddev*2)
+    expected = (g1.stddev, g2.stddev, g3.stddev)
     for result, exp in zip(results, expected):
         assert quantity_allclose(result, exp, atol=0.25*exp)
 

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -260,3 +260,40 @@ def test_sigma_full_width():
     result = sigma_full_width(spectrum)
 
     assert quantity.isclose(result, g1.stddev*2, atol=0.01*u.GHz)
+
+
+def test_sigma_full_width_regions():
+
+    np.random.seed(42)
+
+    frequencies = np.linspace(1, 100, 10000) * u.GHz
+    g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=10*u.GHz, stddev=0.8*u.GHz)
+    g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=2*u.GHz, stddev=0.3*u.GHz)
+    g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=70*u.GHz, stddev=10*u.GHz)
+
+    compound = g1 + g2 + g3
+    spectrum = Spectrum1D(spectral_axis=frequencies, flux=compound(frequencies))
+
+    region1 = SpectralRegion(lower=5*u.GHz, upper=15*u.GHz)
+    result1 = sigma_full_width(spectrum, region=region1)
+
+    exp1 = g1.stddev*2
+    assert quantity.isclose(result1, exp1, atol=0.25*exp1)
+
+    region2 = SpectralRegion(lower=1*u.GHz, upper=3*u.GHz)
+    result2 = sigma_full_width(spectrum, region=region2)
+
+    exp2 = g2.stddev*2
+    assert quantity.isclose(result2, exp2, atol=0.25*exp2)
+
+    region3 = SpectralRegion(lower=40*u.GHz, upper=100*u.GHz)
+    result3 = sigma_full_width(spectrum, region=region3)
+
+    exp3 = g3.stddev*2
+    assert quantity.isclose(result3, exp3, atol=0.25*exp3)
+
+    # Test using a list of regions
+    result_list = sigma_full_width(spectrum, region=[region1, region2, region3])
+    for model, result in zip((g1, g2, g3), result_list):
+        exp = model.stddev*2
+        assert quantity.isclose(result, exp, atol=0.25*exp)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -5,9 +5,11 @@ import astropy.units as u
 from astropy.units import quantity
 from astropy.modeling import models
 from astropy.nddata import StdDevUncertainty
+from astropy.stats.funcs import gaussian_sigma_to_fwhm
 
 from ..spectra import Spectrum1D, SpectralRegion
-from ..analysis import equivalent_width, snr, centroid, sigma_full_width
+from ..analysis import (equivalent_width, snr, centroid, sigma_full_width,
+                        full_width_half_max)
 from ..manipulation import noise_region_uncertainty
 from ..tests.spectral_examples import simulated_spectra
 
@@ -318,3 +320,20 @@ def test_sigma_full_width_multi_spectrum():
     spectra = Spectrum1D(spectral_axis=frequencies, flux=flux)
 
     results = sigma_full_width(spectra)
+
+
+def test_full_width_half_max():
+
+    np.random.seed(42)
+
+    # Create a (centered) gaussian spectrum for testing
+    mean = 5
+    frequencies = np.linspace(1, mean*2, 100) * u.GHz
+    g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=mean*u.GHz, stddev=0.8*u.GHz)
+
+    spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies))
+
+    result = full_width_half_max(spectrum)
+
+    expected = g1.stddev * gaussian_sigma_to_fwhm
+    assert quantity.isclose(result, expected, atol=0.01*u.GHz)


### PR DESCRIPTION
This implements full width half max and full width based on gaussian sigma. It resolves #238 and resolves #241.

~Currently it does not properly handle `Spectrum1D` objects with multiple spectra (see #280).~ This is no longer true thanks to #283.

**Update**
~This now resolves issue #268 as well.~ Issue #268 should be addressed in a separate PR since as @eteq pointed out below, `equivalent_width` doesn't really belong with the other "width" calculations.

While this PR does not directly address #266, I believe it will provide a useful starting point for refactoring analysis operations.