### PR TITLE
#280: Fix incorrect flux shape in ndim wcs solutions

### DIFF
--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -60,7 +60,7 @@ class OneDSpectrumMixin(object):
         # Construct the spectral_axis array.
         # TODO: Should applying the spectral axis unit occur in the adapter?
         spectral_axis = self.wcs.pixel_to_world(
-            np.arange(self.flux.shape[0])) * self.wcs.spectral_axis_unit
+            np.arange(self.flux.shape[-1])) * self.wcs.spectral_axis_unit
 
         return spectral_axis
 


### PR DESCRIPTION
Fixes an issue where the leading index in the shape tuple of the flux values would be used to generate the size of the spectral axis when generating from the wcs.