### PR TITLE
Implement slicing fix for FITSWCS

### DIFF
--- a/specutils/tests/test_slicing.py
+++ b/specutils/tests/test_slicing.py
@@ -1,4 +1,5 @@
 import astropy.units as u
+import astropy.wcs as fitswcs
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -71,3 +72,13 @@ def test_slicing():
     assert sub_spec.frequency.unit == u.GHz
     assert np.allclose(sub_spec.frequency.value, np.array([74948.1145, 59958.4916, 49965.40966667, 42827.494]))
 
+def test_slicing_with_fits():
+    my_wcs = fitswcs.WCS(header={'CDELT1': 1, 'CRVAL1': 6562.8, 'CUNIT1': 'Angstrom',
+                                 'CTYPE1': 'WAVE', 'RESTFRQ': 1400000000, 'CRPIX1': 25})
+
+    spec = Spectrum1D(flux=[5, 6, 7, 8, 9, 10] * u.Jy, wcs=my_wcs)
+    spec_slice = spec[1:5]
+
+    assert isinstance(spec_slice, Spectrum1D)
+    assert spec_slice.flux.size == 4
+    assert np.allclose(spec_slice.wcs.pixel_to_world([6, 7, 8, 9]), spec.wcs.pixel_to_world([6, 7, 8, 9]))

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -1,8 +1,9 @@
+import os
+
 import astropy.units as u
 import astropy.wcs as fitswcs
 import gwcs
 import numpy as np
-import os
 import pytest
 from astropy.nddata import StdDevUncertainty
 from astropy.utils.data import get_pkg_data_filename

--- a/specutils/wcs/adapters/fitswcs_adapter.py
+++ b/specutils/wcs/adapters/fitswcs_adapter.py
@@ -36,6 +36,10 @@ class FITSWCSAdapter(WCSAdapter):
         if self.axes.spectral.naxis == 0:
             self.axes = self.axes._replace(spectral=self.wcs.sub([self.spec_axis + 1]))
 
+    def __getitem__(self, item):
+        """Pass slicing information to the internal `FITSWCS` object."""
+        return self.wcs[item]
+
     def world_to_pixel(self, world_array):
         """
         Method for performing the world to pixel transformations.

--- a/specutils/wcs/adapters/gwcs_adapter.py
+++ b/specutils/wcs/adapters/gwcs_adapter.py
@@ -41,10 +41,10 @@ class GWCSAdapter(WCSAdapter):
         but the spectral dispersion result was not.
 
         There is code slightly downstream that sets the *number* of entries
-        in the dispersion axis, this is just need to shift to the correct
+        in the dispersion axis, this is just needed to shift to the correct
         starting element.
 
-        When WCS gets the abillity to do slicing then we might be able to
+        When WCS gets the ability to do slicing then we might be able to
         remove this code.
         """
 

--- a/specutils/wcs/wcs_adapter.py
+++ b/specutils/wcs/wcs_adapter.py
@@ -103,6 +103,10 @@ class WCSAdapter(metaclass=type('WCSAdapterMetaProxy',
     def with_spectral_unit(self):
         pass
 
+    @abc.abstractmethod
+    def __getitem__(self, item):
+        pass
+
     def __repr__(self):
         return "<Identity Transform WCS: pixel - {} transformation>".format(
             self.spectral_axis_unit)


### PR DESCRIPTION
Also including making `__getitem__` abstract in the adapter base class for any future implementations.