### PR TITLE
Fix failing rtd builds

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,0 +1,5 @@
+numpy>=1.9
+numpydoc
+scipy
+gwcs
+astropy>=3.0


### PR DESCRIPTION
Failing builds in read the docs seem to be due to a missing `rtd-pip-requirements` file that was removed (by accident?) some time ago. This PR adds the file back.