### PR TITLE
Improve __repr__ and __str__ methods

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -220,8 +220,13 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         return result
 
     def __repr__(self):
-        return "<Spectrum1D(flux={}, spectral_axis={})>".format(
-            repr(self.flux), repr(self.spectral_axis))
+        if self.wcs:
+            result = "<Spectrum1D(flux={}, spectral_axis={})>".format(
+                repr(self.flux), repr(self.spectral_axis))
+        else:
+            result = "<Spectrum1D(flux={})>".format(repr(self.flux))
+        return result
+
 
     def spectral_resolution(self, true_dispersion, delta_dispersion, axis=-1):
         """Evaluate the probability distribution of the spectral resolution.

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -206,9 +206,16 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         # Handle case of single value flux
         if self.flux.ndim == 1 and self.flux.size == 1:
             return result + "flux:   {}".format(self.flux)
-        result += "flux:           range: {:.5} ... {:.5}\n".format(
-            self.flux[0], self.flux[-1])
-        result += "spectral axis:  range: {:.5} ... {:.5}".format(
+        # Handle case of multiple flux arrays
+        if self.flux.ndim > 1:
+            for i, flux in enumerate(self.flux):
+                result += "flux{:2}:           range: {:.5} ... {:.5}\n".format(
+                    i, flux[0], flux[-1])
+        else:
+            result += "flux:             range: {:.5} ... {:.5}\n".format(
+                self.flux[0], self.flux[-1])
+        # Add information about spectral axis
+        result += "spectral axis:    range: {:.5} ... {:.5}".format(
             self.spectral_axis[0], self.spectral_axis[-1])
         return result
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -204,7 +204,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     def _format_array_summary(self, label, array):
         mean = np.mean(array)
         s = "{:17} [ {:.5}, ..., {:.5} ],  mean={:.5}"
-        return s.format(label, array[0], array[-1], mean)
+        return s.format(label+':', array[0], array[-1], mean)
 
     def __str__(self):
         result = "Spectrum1D "
@@ -225,7 +225,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         result += self._format_array_summary('spectral axis', self.spectral_axis)
         # Add information about uncertainties if available
         if self.uncertainty:
-            result += "\nuncertainty:      [ {}, ..., {} ]\n".format(
+            result += "\nuncertainty:      [ {}, ..., {} ]".format(
                 self.uncertainty[0], self.uncertainty[-1])
         return result
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -202,11 +202,14 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             other, compare_wcs=lambda o1, o2: self._compare_wcs(self, other))
 
     def __str__(self):
-        result = "Spectrum1D\n"
+        result = "Spectrum1D "
         # Handle case of single value flux
-        if self.flux.ndim == 1 and self.flux.size == 1:
+        if self.flux.ndim == 0:
+            result += "(length=1)\n"
             return result + "flux:   {}".format(self.flux)
+
         # Handle case of multiple flux arrays
+        result += "(length={})\n".format(len(self.spectral_axis))
         if self.flux.ndim > 1:
             for i, flux in enumerate(self.flux):
                 result += "flux{:2}:           range: {:.5} ... {:.5}\n".format(

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -201,6 +201,11 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         return self.divide(
             other, compare_wcs=lambda o1, o2: self._compare_wcs(self, other))
 
+    def _format_array_summary(self, label, array):
+        mean = np.mean(array)
+        s = "{:17} [ {:.5}, ..., {:.5} ],  mean={:.5}"
+        return s.format(label, array[0], array[-1], mean)
+
     def __str__(self):
         result = "Spectrum1D "
         # Handle case of single value flux
@@ -212,17 +217,15 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         result += "(length={})\n".format(len(self.spectral_axis))
         if self.flux.ndim > 1:
             for i, flux in enumerate(self.flux):
-                result += "flux{:2}:           range: {:.5} ... {:.5}\n".format(
-                    i, flux[0], flux[-1])
+                label = 'flux{:2}'.format(i)
+                result += self._format_array_summary(label, flux) + '\n'
         else:
-            result += "flux:             range: {:.5} ... {:.5}\n".format(
-                self.flux[0], self.flux[-1])
+            result += self._format_array_summary('flux', self.flux) + '\n'
         # Add information about spectral axis
-        result += "spectral axis:    range: {:.5} ... {:.5}\n".format(
-            self.spectral_axis[0], self.spectral_axis[-1])
+        result += self._format_array_summary('spectral axis', self.spectral_axis)
         # Add information about uncertainties if available
         if self.uncertainty:
-            result += "uncertainty:      range: {} ... {}\n".format(
+            result += "\nuncertainty:      [ {}, ..., {} ]\n".format(
                 self.uncertainty[0], self.uncertainty[-1])
         return result
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -201,6 +201,21 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         return self.divide(
             other, compare_wcs=lambda o1, o2: self._compare_wcs(self, other))
 
+    def __str__(self):
+        result = "Spectrum1D\n"
+        # Handle case of single value flux
+        if self.flux.ndim == 1 and self.flux.size == 1:
+            return result + "flux:   {}".format(self.flux)
+        result += "flux:           range: {:.5} ... {:.5}\n".format(
+            self.flux[0], self.flux[-1])
+        result += "spectral axis:  range: {:.5} ... {:.5}".format(
+            self.spectral_axis[0], self.spectral_axis[-1])
+        return result
+
+    def __repr__(self):
+        return "<Spectrum1D(flux={}, spectral_axis={})>".format(
+            repr(self.flux), repr(self.spectral_axis))
+
     def spectral_resolution(self, true_dispersion, delta_dispersion, axis=-1):
         """Evaluate the probability distribution of the spectral resolution.
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -218,8 +218,12 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             result += "flux:             range: {:.5} ... {:.5}\n".format(
                 self.flux[0], self.flux[-1])
         # Add information about spectral axis
-        result += "spectral axis:    range: {:.5} ... {:.5}".format(
+        result += "spectral axis:    range: {:.5} ... {:.5}\n".format(
             self.spectral_axis[0], self.spectral_axis[-1])
+        # Add information about uncertainties if available
+        if self.uncertainty:
+            result += "uncertainty:      range: {} ... {}\n".format(
+                self.uncertainty[0], self.uncertainty[-1])
         return result
 
     def __repr__(self):

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -183,3 +183,59 @@ def test_energy_photon_flux():
     assert spec.energy.size == 10
     assert spec.photon_flux.size == 10
     assert spec.photon_flux.unit == u.photon * u.cm**-2
+
+
+def test_repr():
+    spec_with_wcs = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
+                               flux=np.random.random(10))
+    result = repr(spec_with_wcs)
+    assert result.startswith('<Spectrum1D(flux=<Quantity [')
+    assert 'spectral_axis=<Quantity [' in result
+
+    spec_without_wcs = Spectrum1D(np.random.random(10))
+    result = repr(spec_without_wcs)
+    assert result == '<Spectrum1D(flux={})>'.format(repr(spec_without_wcs.flux))
+
+
+def test_str():
+    spec = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
+                               flux=np.random.random(10))
+    result = str(spec)
+    # Sanity check for contents of string representation
+    assert result.startswith('Spectrum1D (length={})'.format(len(spec.flux)))
+    lines = result.split('\n')
+    flux = spec.flux
+    sa = spec.spectral_axis
+    assert len(lines) == 3
+    assert lines[1].startswith('flux:')
+    assert '[ {:.5}, ..., {:.5} ]'.format(flux[0], flux[-1]) in lines[1]
+    assert 'mean={:.5}'.format(np.mean(flux)) in lines[1]
+    assert lines[2].startswith('spectral axis:')
+    assert '[ {:.5}, ..., {:.5} ]'.format(sa[0], sa[-1]) in lines[2]
+    assert 'mean={:5}'.format(np.mean(sa)) in lines[2]
+
+    # Test string representation with uncertainty
+    spec_with_uncertainty = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10)
+                                       * u.nm, flux=np.random.random(10),
+                                       uncertainty=np.random.random(10))
+    result = str(spec_with_uncertainty)
+    lines = result.split('\n')
+    unc = spec_with_uncertainty.uncertainty
+    print(spec_with_uncertainty)
+    assert len(lines) == 4
+    assert lines[3].startswith('uncertainty')
+    assert '[ {}, ..., {} ]'.format(unc[0], unc[-1]) in lines[3]
+
+    # Test string representation with multiple flux
+    spec_multi_flux = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
+                                 flux=np.random.random((3,10)))
+    result = str(spec_multi_flux)
+    lines = result.split('\n')
+    assert len(lines) == 5
+    for i, line in enumerate(lines[1:4]):
+        assert line.startswith('flux{:2}:'.format(i))
+
+    # Test string representation with single-dimensional flux
+    spec_single_flux = Spectrum1D(1)
+    result = str(spec_single_flux)
+    assert result == 'Spectrum1D (length=1)\nflux:   {}'.format(spec_single_flux.flux)


### PR DESCRIPTION
This resolves #278. This is mainly intended as a starting point for discussion since I'm sure there are lots of opinions about what kind of information should be included, especially in `__str__`. So feel free to provide copious feedback (🤐).

Here's an example of a spectrum with multiple flux arrays:

```python
>>> spectrum = Spectrum1D( ... )
>>> spectrum # uses __repr__
<Spectrum1D(flux=<Quantity [[1.86332659e-05, 1.86437500e-05, 1.86542398e-05, ...,
            1.64917456e-08, 1.64801541e-08, 1.64685706e-08],
           [2.50581063e+00, 2.50582417e+00, 2.50583770e+00, ...,
            2.86800793e+00, 2.86800019e+00, 2.86799245e+00],
           [7.92755317e+00, 7.92770803e+00, 7.92786288e+00, ...,
            9.19637290e-01, 9.19579706e-01, 9.19522124e-01]] Jy>, 
           spectral_axis=<Quantity [ 1.     ,  1.00009,  1.00018, ...,  9.99982,  9.99991, 10.     ] GHz>)>

>>> print(spectrum) # uses __str__
Spectrum1D
flux 0:           range: 1.8633e-05 Jy ... 1.6469e-08 Jy
flux 1:           range: 2.5058 Jy ... 2.868 Jy
flux 2:           range: 7.9276 Jy ... 0.91952 Jy
spectral axis:    range: 1.0 GHz ... 10.0 GHz
```

The philosophy followed here is that `__repr__` should sort of mirror the call that was used to construct the object in the first place, whereas `__str__` can provide more "informative" output.