### PR TITLE
Fix photon_flux units

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -133,9 +133,13 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     @property
     def photon_flux(self):
         """
-        The flux, in units of photons per cm^2
+        The flux density of photons as a `~astropy.Quantity`, in units of
+        photons per cm^2 per second per spectral_axis unit
         """
-        return (self.flux / (self.energy /u.photon)).to(u.photon * u.cm**-2)
+        flux_in_spectral_axis_units = self.flux.to(u.W * u.cm**-2 * self.spectral_axis.unit**-1, u.spectral_density(self.spectral_axis))
+        photon_flux_density = flux_in_spectral_axis_units / (self.energy / u.photon)
+        return photon_flux_density.to(u.photon * u.cm**-2 * u.s**-1 *
+                                      self.spectral_axis.unit**-1)
 
     @lazyproperty
     def bin_edges(self):

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -121,28 +121,29 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     @property
     def frequency(self):
         """
-        The frequency as a `~astropy.Quantity` in units of GHz
+        The frequency as a `~astropy.units.Quantity` in units of GHz
         """
         return self.spectral_axis.to(u.GHz, u.spectral())
 
     @property
     def wavelength(self):
         """
-        The wavelength as a `~astropy.Quantity` in units of Angstroms
+        The wavelength as a `~astropy.units.Quantity` in units of Angstroms
         """
         return self.spectral_axis.to(u.AA, u.spectral())
 
     @property
     def energy(self):
         """
-        The energy of the spectral axis as a `~astropy.Quantity` in units of eV
+        The energy of the spectral axis as a `~astropy.units.Quantity` in units
+        of eV.
         """
         return self.spectral_axis.to(u.eV, u.spectral())
 
     @property
     def photon_flux(self):
         """
-        The flux density of photons as a `~astropy.Quantity`, in units of
+        The flux density of photons as a `~astropy.units.Quantity`, in units of
         photons per cm^2 per second per spectral_axis unit
         """
         flux_in_spectral_axis_units = self.flux.to(u.W * u.cm**-2 * self.spectral_axis.unit**-1, u.spectral_density(self.spectral_axis))

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -120,14 +120,23 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
 
     @property
     def frequency(self):
+        """
+        The frequency as a `~astropy.Quantity` in units of GHz
+        """
         return self.spectral_axis.to(u.GHz, u.spectral())
 
     @property
     def wavelength(self):
+        """
+        The wavelength as a `~astropy.Quantity` in units of Angstroms
+        """
         return self.spectral_axis.to(u.AA, u.spectral())
 
     @property
     def energy(self):
+        """
+        The energy of the spectral axis as a `~astropy.Quantity` in units of eV
+        """
         return self.spectral_axis.to(u.eV, u.spectral())
 
     @property

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -205,7 +205,7 @@ def test_energy_photon_flux():
                       flux=np.random.randn(10))
     assert spec.energy.size == 10
     assert spec.photon_flux.size == 10
-    assert spec.photon_flux.unit == u.photon * u.cm**-2
+    assert spec.photon_flux.unit == u.photon * u.cm**-2 * u.s**-1 * u.nm**-1
 
 
 def test_repr():


### PR DESCRIPTION
I realized the `photon_flux` expression was wrong - really the thing that makes sense here is a photon flux density - i.e. photon flux per unit spectral axis.  The only reason it seemed to work before was because Hz^-1 happens to conveniently be seconds, which made some things cancel out... but that's sweeping a lot under the rug.

Can someone who's willing to think about spectral units double-check my thinking here? (maybe @keflavich or @crawfordsm?)