### PR TITLE
To flux no inplace

### DIFF
--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -83,9 +83,10 @@ class OneDSpectrumMixin(object):
         """
         return u.Quantity(self.data, unit=self.unit, copy=False)
 
-    def to_flux(self, unit, equivalencies=None, suppress_conversion=False):
+    def set_flux_unit(self, unit, equivalencies=None, suppress_conversion=False):
         """
-        Converts the flux data to the specified unit.
+        Converts the flux data to the specified unit.  This is an in-place
+        change to the object.
 
         Parameters
         ----------

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 
 import numpy as np
 from astropy.wcs import WCSSUB_SPECTRAL
@@ -83,7 +84,7 @@ class OneDSpectrumMixin(object):
         """
         return u.Quantity(self.data, unit=self.unit, copy=False)
 
-    def set_flux_unit(self, unit, equivalencies=None, suppress_conversion=False):
+    def new_flux_unit(self, unit, equivalencies=None, suppress_conversion=False):
         """
         Converts the flux data to the specified unit.  This is an in-place
         change to the object.
@@ -103,9 +104,10 @@ class OneDSpectrumMixin(object):
 
         Returns
         -------
-        `~astropy.units.Quantity`
-            The converted flux array.
+        `~astropy.units.Spectrum1D`
+            A new spectrum with the converted flux array
         """
+        new_spec = deepcopy(self)
         if not suppress_conversion:
             if equivalencies is None:
                 equivalencies = eq.spectral_density(self.spectral_axis)
@@ -113,12 +115,12 @@ class OneDSpectrumMixin(object):
             new_data = self.flux.to(
                 unit, equivalencies=equivalencies)
 
-            self._data = new_data.value
-            self._unit = new_data.unit
+            new_spec._data = new_data.value
+            new_spec._unit = new_data.unit
         else:
-            self._unit = u.Unit(unit)
+            new_spec._unit = u.Unit(unit)
 
-        return self.flux
+        return new_spec
 
     @property
     def velocity_convention(self):

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -104,7 +104,7 @@ class OneDSpectrumMixin(object):
 
         Returns
         -------
-        `~astropy.units.Spectrum1D`
+        `~specutils.Spectrum1D`
             A new spectrum with the converted flux array
         """
         new_spec = deepcopy(self)

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -101,24 +101,24 @@ def test_flux_unit_conversion():
 
     # Simple Unit Conversion
     s = Spectrum1D(flux=np.array([26.0, 44.5]) * u.Jy, spectral_axis=np.array([400, 500])*u.nm)
-    converted_value = s.to_flux(unit=u.uJy)[0]
+    converted_value = s.set_flux_unit(unit=u.uJy)[0]
     assert ((26.0 * u.Jy).to(u.uJy) == converted_value)
 
     # Make sure incompatible units raise UnitConversionError
     with pytest.raises(u.UnitConversionError):
-        converted_value = s.to_flux(unit=u.m)
+        converted_value = s.set_flux_unit(unit=u.m)
 
     # Pass custom equivalencies
     s = Spectrum1D(flux=np.array([26.0, 44.5]) * u.Jy, spectral_axis=np.array([400, 500]) * u.nm)
     eq = [[u.Jy, u.m,
           lambda x: np.full_like(np.array(x), 1000.0, dtype=np.double),
           lambda x: np.full_like(np.array(x), 0.001, dtype=np.double)]]
-    converted_value = s.to_flux(unit=u.m, equivalencies=eq)[0]
+    converted_value = s.set_flux_unit(unit=u.m, equivalencies=eq)[0]
     assert 1000.0 * u.m == converted_value
 
     # Check if suppressing the unit conversion works
     s = Spectrum1D(flux=np.array([26.0, 44.5]) * u.Jy, spectral_axis=np.array([400, 500]) * u.nm)
-    s.to_flux("uJy", suppress_conversion=True)
+    s.set_flux_unit("uJy", suppress_conversion=True)
     assert s.flux[0] == 26.0 * u.uJy
 
 
@@ -183,4 +183,3 @@ def test_energy_photon_flux():
     assert spec.energy.size == 10
     assert spec.photon_flux.size == 10
     assert spec.photon_flux.unit == u.photon * u.cm**-2
-

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -101,25 +101,25 @@ def test_flux_unit_conversion():
 
     # Simple Unit Conversion
     s = Spectrum1D(flux=np.array([26.0, 44.5]) * u.Jy, spectral_axis=np.array([400, 500])*u.nm)
-    converted_value = s.set_flux_unit(unit=u.uJy)[0]
-    assert ((26.0 * u.Jy).to(u.uJy) == converted_value)
+    converted_spec = s.new_flux_unit(unit=u.uJy)[0]
+    assert ((26.0 * u.Jy).to(u.uJy) == converted_spec.flux)
 
     # Make sure incompatible units raise UnitConversionError
     with pytest.raises(u.UnitConversionError):
-        converted_value = s.set_flux_unit(unit=u.m)
+        s.new_flux_unit(unit=u.m)
 
     # Pass custom equivalencies
     s = Spectrum1D(flux=np.array([26.0, 44.5]) * u.Jy, spectral_axis=np.array([400, 500]) * u.nm)
     eq = [[u.Jy, u.m,
           lambda x: np.full_like(np.array(x), 1000.0, dtype=np.double),
           lambda x: np.full_like(np.array(x), 0.001, dtype=np.double)]]
-    converted_value = s.set_flux_unit(unit=u.m, equivalencies=eq)[0]
-    assert 1000.0 * u.m == converted_value
+    converted_spec = s.new_flux_unit(unit=u.m, equivalencies=eq)[0]
+    assert 1000.0 * u.m == converted_spec.flux
 
     # Check if suppressing the unit conversion works
     s = Spectrum1D(flux=np.array([26.0, 44.5]) * u.Jy, spectral_axis=np.array([400, 500]) * u.nm)
-    s.set_flux_unit("uJy", suppress_conversion=True)
-    assert s.flux[0] == 26.0 * u.uJy
+    new_spec = s.new_flux_unit("uJy", suppress_conversion=True)
+    assert new_spec.flux[0] == 26.0 * u.uJy
 
 
 def test_create_explicit_fitswcs():


### PR DESCRIPTION
#196 made me realize a serious problem with `to_flux`: it's an in-place operation.  `to` in the astropy/units context always means "return a new converted object".  So `to_flux` is a *very* confusing thing to subject users to.

So to rectify it this PR gives two options:
1. (the first two commits): rename to `set_flux_unit` - that makes it clearer that you are doing an inplace operation on the spectrum object
2. (the third commit): changes the method to instead yield a *new* `Spectrum1D` object.  

The second one is my preference, as I think it's much safer - in-place changes always cause unexpected trouble, because it's another place you have to verify that things make sense. This implementation still has that problem to some extent, but at least it doesn't paint us into the corner of definitely allowing in-place changes in the public API.

cc @robelgeda @nmearl (note this is time-sensitive because we don't want `to_flux` to go into 0.4 and then get pulled again in 0.5)
