### PR TITLE
Stop testing against ancient versions of numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ env:
 
     matrix:
         # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
 matrix:
@@ -72,8 +70,6 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.5
-        - os: linux
           env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts
         - os: linux
           env: NUMPY_VERSION=1.11
@@ -84,6 +80,10 @@ matrix:
         - os: linux
           env: NUMPY_VERSION=prerelease
                EVENT_TYPE='pull_request push cron'
+
+        # Try development version of Astropy
+        - os: linux
+          env: ASTROPY_VERSION=dev
 
         # Do a PEP8 test with pycodestyle
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ env:
 
     matrix:
         # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
 matrix:
 
@@ -72,11 +72,13 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.4
-        - os: linux
           env: PYTHON_VERSION=3.5
         - os: linux
+          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts
+        - os: linux
           env: NUMPY_VERSION=1.11
+        - os: linux
+          env: PYTHON_VERSION=3.7
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,9 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
+          env: PYTHON_VERSION=3.4
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
+          env: PYTHON_VERSION=3.5
         - os: linux
           env: NUMPY_VERSION=1.11
 


### PR DESCRIPTION
This is an attempt to resolve some travis errors that are cropping up on recent tests. It's worth asking whether we need to be testing on Py3.4 at all, especially since recent versions of `gwcs` explicitly do not support anything earlier than 3.5.