### PR TITLE
Better message if uncertainty is not defined for Spectrum1D

### DIFF
--- a/specutils/analysis/snr.py
+++ b/specutils/analysis/snr.py
@@ -30,6 +30,9 @@ def snr(spectrum, region=None):
 
     """
 
+    if spectrum.uncertainty is None:
+        raise Exception("Spectrum1D currently requires the uncertainty be defined.")
+
     # No region, therefore whole spectrum.
     if region is None:
         return _snr_single_region(spectrum)

--- a/specutils/analysis/snr.py
+++ b/specutils/analysis/snr.py
@@ -30,7 +30,7 @@ def snr(spectrum, region=None):
 
     """
 
-    if spectrum.uncertainty is None:
+    if not hasattr(spectrum, 'uncertainty') or spectrum.uncertainty is None:
         raise Exception("Spectrum1D currently requires the uncertainty be defined.")
 
     # No region, therefore whole spectrum.

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -67,6 +67,20 @@ def test_snr(simulated_spectra):
     assert np.allclose(spec_snr.value, spec_snr_expected.value)
 
 
+def test_snr_no_uncertainty(simulated_spectra):
+    """
+    Test the simple version of the spectral SNR.
+    """
+
+    #
+    #  Set up the data and add the uncertainty and calculate the expected SNR
+    #
+
+    spectrum = simulated_spectra.s1_um_mJy_e1
+
+    with pytest.raises(Exception) as e_info:
+        _ = snr(spectrum)
+
 def test_snr_multiple_flux(simulated_spectra):
     """
     Test the simple version of the spectral SNR, with multiple flux per single dispersion.


### PR DESCRIPTION
There was not a check, previously, to see if the uncertainty is defined. If not, then raise a specific exception that states it is required.

Fixes #282