### PR TITLE
Fix equivalency in world2pix gwcs transform

### DIFF
--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -139,6 +139,9 @@ def test_wcs_transformations():
     assert isinstance(pix_axis, np.ndarray)
     assert isinstance(disp_axis, u.Quantity)
 
+    # Test transform with different unit
+    spec.wcs.world_to_pixel(np.arange(20, 30) * u.GHz)
+
     # Test with a FITS WCS
     my_wcs = fitswcs.WCS(header={'CDELT1': 1, 'CRVAL1': 6562.8, 'CUNIT1': 'Angstrom',
                                  'CTYPE1': 'WAVE', 'RESTFRQ': 1400000000, 'CRPIX1': 25})

--- a/specutils/wcs/adapters/gwcs_adapter.py
+++ b/specutils/wcs/adapters/gwcs_adapter.py
@@ -77,7 +77,8 @@ class GWCSAdapter(WCSAdapter):
         Method for performing the world to pixel transformations.
         """
         # Convert world array to the wcs unit for the conversion
-        world_array = u.Quantity(world_array, unit=self._wcs_unit)
+        world_array = u.Quantity(world_array, unit=self._wcs_unit,
+                                 equivalencies=u.spectral())
 
         return self.wcs.invert(world_array.value)
 

--- a/specutils/wcs/adapters/gwcs_adapter.py
+++ b/specutils/wcs/adapters/gwcs_adapter.py
@@ -77,8 +77,8 @@ class GWCSAdapter(WCSAdapter):
         Method for performing the world to pixel transformations.
         """
         # Convert world array to the wcs unit for the conversion
-        world_array = u.Quantity(world_array, unit=self._wcs_unit,
-                                 equivalencies=u.spectral())
+        with u.set_enabled_equivalencies(u.spectral()):
+            world_array = u.Quantity(world_array, unit=self._wcs_unit)
 
         return self.wcs.invert(world_array.value)
 


### PR DESCRIPTION
Fixes #322, the case where the `world_array` in a `world_to_pixel` transform is not a simple conversion to the gwcs unit.