### PR TITLE
change SpectralRegion.from_center to be a classmethod

### DIFF
--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -29,8 +29,8 @@ class SpectralRegion:
 
     """
 
-    @staticmethod
-    def from_center(center=None, width=None):
+    @classmethod
+    def from_center(cls, center=None, width=None):
         """
         SpectralRegion class method that enables the definition of a `SpectralRegion`
         from the center and width rather than lower and upper bounds.
@@ -45,7 +45,7 @@ class SpectralRegion:
            The width of the spectral region.
         """
 
-        return SpectralRegion(center - width, center + width)
+        return cls(lower=center - width, upper=center + width)
 
     def __init__(self, *args):
         """


### PR DESCRIPTION
I just noticed `SpectralRegion.from_center` is a staticmethod.  This is a good example for where `classmethod` is better to use than `staticmethod`, because if the user makes a subclass of `SpectralRegion`, they'd want `from_center` to yield their subclass, not `SpectralRegion`.  This (minor) PR makes that possible.

Tagging @brechmos-stsci for review since I think he's the originator of this.

This is pretty trivial so I'm tentatively scheduling it for the imminent 0.4 release.