### PR TITLE
Use subok=True when broadcasting Quantity

### DIFF
--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -131,7 +131,7 @@ def _compute_gaussian_sigma_width(spectrum, region=None):
     centroid_result = centroid(spectrum, region)
 
     if flux.ndim > 1:
-        spectral_axis = np.broadcast_to(spectral_axis, flux.shape) * spectral_axis.unit
+        spectral_axis = np.broadcast_to(spectral_axis, flux.shape, subok=True)
         centroid_result = centroid_result[:, np.newaxis]
 
     dx = spectral_axis - centroid_result


### PR DESCRIPTION
A very minor change to the recently added analysis functions that allows `astropy.units.Quantity` to be broadcasted properly, and with less redundancy.

Not sure if this can be squeezed into the 0.4 release, but it's fairly inconsequential.