### PR TITLE
convert absolute imports to relative

### DIFF
--- a/specutils/io/default_loaders/cube_reader.py
+++ b/specutils/io/default_loaders/cube_reader.py
@@ -14,8 +14,8 @@ from astropy.io import fits
 from astropy.units import Unit
 from astropy.wcs import WCS
 
-from specutils.io.registers import data_loader
-from specutils.spectra import Spectrum1D
+from ..registers import data_loader
+from ...spectra import Spectrum1D
 
 # Define an optional identifier. If made specific enough, this circumvents the
 # need to add `format="my-format"` in the `Spectrum1D.read` call.
@@ -61,7 +61,7 @@ def generic_fits(file_name, **kwargs):
         meta['ypos'] = iy
 
         # attach units (get it from header['BUNIT'] - what about 'JY/BEAM '
-        #  NOTE:  astropy doesn't support beam, but see comments in radio_beam 
+        #  NOTE:  astropy doesn't support beam, but see comments in radio_beam
         data = data * Unit("Jy")
 
 
@@ -72,16 +72,13 @@ def generic_fits(file_name, **kwargs):
         crval3 = wcs.wcs.crval[sp_axis-1]
         cdelt3 = wcs.wcs.cdelt[sp_axis-1]
         crpix3 = wcs.wcs.crpix[sp_axis-1]
-        
+
         freqs = np.arange(naxis3) + 1
         freqs = (freqs - crpix3) * cdelt3 + crval3
 
         freqs = freqs * cunit3
 
         # should wcs be transformed to a 1D case ?
-        
+
     return Spectrum1D(flux=data, wcs=wcs, meta=meta, spectral_axis=freqs)
     # return Spectrum1D(flux=data, wcs=wcs, meta=meta)     # this does not work yet
-
-
-

--- a/specutils/manipulation/estimate_uncertainty.py
+++ b/specutils/manipulation/estimate_uncertainty.py
@@ -1,5 +1,5 @@
 import numpy as np
-from specutils.spectra import Spectrum1D
+from ..spectra import Spectrum1D
 from astropy.nddata import StdDevUncertainty
 
 

--- a/specutils/tests/spectral_examples.py
+++ b/specutils/tests/spectral_examples.py
@@ -1,20 +1,20 @@
 import numpy as np
 import astropy.units as u
 from astropy.modeling import models
-from specutils.spectra import Spectrum1D
+from ..spectra import Spectrum1D
 import pytest
 
 
 class SpectraExamples(object):
     """
     The ``SpectralExamples`` class is a *container class* that has
-    several examples of simple spectra that are to be used in the tests 
+    several examples of simple spectra that are to be used in the tests
     (e.g., arithmetic tests, smoothing tests etc).
-    
-    The purpose of this being a test class instead of using a `Spectrum1D` 
-    directly is that it contains both the `Spectrum1D` object and the flux 
-    that was used to *create* the Spectrum.  That's for tests that ensure 
-    the simpler operations just on the flux arrays are carried through to 
+
+    The purpose of this being a test class instead of using a `Spectrum1D`
+    directly is that it contains both the `Spectrum1D` object and the flux
+    that was used to *create* the Spectrum.  That's for tests that ensure
+    the simpler operations just on the flux arrays are carried through to
     the `Spectrum1D` operations.
 
     Each of the spectra are created from a base noise-less spectrum
@@ -157,4 +157,3 @@ def simulated_spectra():
     """
 
     return SpectraExamples()
-

--- a/specutils/tests/test_continuum.py
+++ b/specutils/tests/test_continuum.py
@@ -2,8 +2,8 @@ import numpy as np
 
 import astropy.units as u
 
-from specutils.spectra.spectrum1d import Spectrum1D
-from specutils.fitting.continuum import fit_generic_continuum
+from ..spectra.spectrum1d import Spectrum1D
+from ..fitting.continuum import fit_generic_continuum
 
 
 def single_peak_continuum():

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -1,10 +1,10 @@
-from astropy.modeling import models, fitting
-import astropy.units as u
 import numpy as np
 
-from specutils.tests.spectral_examples import simulated_spectra
-from specutils.spectra import Spectrum1D, SpectralRegion
-from specutils.fitting import fit_lines
+import astropy.units as u
+from astropy.modeling import models
+
+from ..spectra import Spectrum1D, SpectralRegion
+from ..fitting import fit_lines
 
 
 def single_peak():


### PR DESCRIPTION
I noticed several absolute imports floating around specutils.  Generally speaking its best to be consistent and always use relative imports inside a package where possible, so this fixes those.

@brechmos-stsci, I think these are mostly you, so can you have a look and make sure these weren't in there for some specific reason I'm missing?