### PR TITLE
Make extract support pixel/other spectral units

### DIFF
--- a/docs/spectral_regions.rst
+++ b/docs/spectral_regions.rst
@@ -3,15 +3,14 @@ Spectral Regions
 ================
 
 A spectral region may be defined and may encompass one, or more,
-sub-regions. They are independent of a `~specutils.Spectrum1D`
-object.  There, one may define a spectral region and it may be used
-on `~specutils.Spectrum1D` objects of different dispersion
-sampling.
+sub-regions. They are defined independently of a `~specutils.Spectrum1D`
+object in the sense that spectral regions like "near the Halpha line rest
+wavelength" have meaning independent of the details of a particular spectrum.
 
-Spectral regions can be defined either as a single region by passing 
-two `~astropy.units.Quantity`'s or by passing a list of 2-tuples.  By
-definition the `~specutils.SpectralRegion` will be ordered
-based on the lower bound of each 2-tuple.
+Spectral regions can be defined either as a single region by passing
+two `~astropy.units.Quantity`'s or by passing a list of 2-tuples. Note that
+the units of these quantites can be any valid spectral unit *or* ``u.pixel``
+(which indicates to use indexing directly).
 
 .. code-block:: python
 
@@ -126,7 +125,7 @@ There is also the ability to iterate:
     SpectralRegion: 1.3 um - 1.5 um
 
 
-And, lastly, there is the ability to invert a `~specutils.SpectralRegion` given a 
+And, lastly, there is the ability to invert a `~specutils.SpectralRegion` given a
 lower and upper bound. For example, if a set of ranges are defined each defining a range
 around lines, then calling invert will return a `~specutils.SpectralRegion` that
 defines the baseline/noise regions:
@@ -168,6 +167,30 @@ An example of a single sub-region `~specutils.SpectralRegion`:
     >>> sub_spectrum.spectral_axis
     <Quantity [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20.,
                21., 22.] nm>
+
+
+Extraction also correctly interprets different kinds of spectral region units
+as would be expected:
+
+.. code-block:: python
+
+    >>> from astropy import units as u
+    >>> import numpy as np
+    >>> from specutils import Spectrum1D, SpectralRegion
+    >>> from specutils.manipulation import extract_region
+
+    >>> spectrum = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm, flux=np.random.sample(49)*u.Jy)
+    >>> region_angstroms = SpectralRegion(80*u.AA, 220*u.AA)
+    >>> sub_spectrum = extract_region(spectrum, region_angstroms)
+    >>> sub_spectrum.spectral_axis
+    <Quantity [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20.,
+               21., 22.] nm>
+    >>> region_pixels = SpectralRegion(7.5*u.pixel, 21.5*u.pixel)
+    >>> sub_spectrum = extract_region(spectrum, region_pixels)
+    >>> sub_spectrum.spectral_axis
+    <Quantity [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20.,
+               21., 22.] nm>
+
 
 
 An example of a multiple sub-region `~specutils.SpectralRegion`:

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -3,6 +3,7 @@ import pytest
 
 import astropy.units as u
 from astropy.nddata import StdDevUncertainty
+from astropy.tests.helper import quantity_allclose
 
 from ..spectra import Spectrum1D, SpectralRegion
 from ..manipulation import extract_region
@@ -10,15 +11,7 @@ from .spectral_examples import simulated_spectra
 
 
 def test_region_simple(simulated_spectra):
-    """
-    Test the simple version of the spectral SNR.
-    """
-
     np.random.seed(42)
-
-    #
-    #  Set up the data and add the uncertainty and calculate the expected SNR
-    #
 
     spectrum = simulated_spectra.s1_um_mJy_e1
     uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
@@ -38,18 +31,8 @@ def test_region_simple(simulated_spectra):
 
     assert np.allclose(sub_spectrum.flux.value, sub_spectrum_flux_expected)
 
+
 def test_region_ghz(simulated_spectra):
-    """
-    Test the simple version of the spectral SNR.
-    """
-
-    np.random.seed(42)
-
-    #
-    #  Set up the data and add the uncertainty and calculate the expected SNR
-    #
-
-    spectrum = simulated_spectra.s1_um_mJy_e1
     spectrum = Spectrum1D(flux=simulated_spectra.s1_um_mJy_e1,
                           spectral_axis=simulated_spectra.s1_um_mJy_e1.frequency)
 
@@ -67,16 +50,9 @@ def test_region_ghz(simulated_spectra):
 
     assert np.allclose(sub_spectrum.flux.value, sub_spectrum_flux_expected)
 
+
 def test_region_simple_check_ends(simulated_spectra):
-    """
-    Test the simple version of the spectral SNR.
-    """
-
     np.random.seed(42)
-
-    #
-    #  Set up the data and add the uncertainty and calculate the expected SNR
-    #
 
     spectrum = Spectrum1D(spectral_axis=np.linspace(1, 25, 25)*u.um, flux=np.random.random(25)*u.Jy)
     region = SpectralRegion(8*u.um, 15*u.um)
@@ -88,10 +64,6 @@ def test_region_simple_check_ends(simulated_spectra):
 
 
 def test_region_empty(simulated_spectra):
-    """
-    Test the simple version of the spectral SNR.
-    """
-
     np.random.seed(42)
 
     # Region past upper range of spectrum
@@ -118,15 +90,7 @@ def test_region_empty(simulated_spectra):
 
 
 def test_region_two_sub(simulated_spectra):
-    """
-    Test the simple version of the spectral SNR.
-    """
-
     np.random.seed(42)
-
-    #
-    #  Set up the data and add the uncertainty and calculate the expected SNR
-    #
 
     spectrum = simulated_spectra.s1_um_mJy_e1
     uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
@@ -156,3 +120,26 @@ def test_region_two_sub(simulated_spectra):
 
     assert np.allclose(sub_spectra[0].flux.value, sub_spectrum_0_flux_expected)
     assert np.allclose(sub_spectra[1].flux.value, sub_spectrum_1_flux_expected)
+
+
+def test_extract_region_pixels():
+    spectrum = Spectrum1D(spectral_axis=np.linspace(4000, 10000, 25)*u.AA,
+                          flux=np.arange(25)*u.Jy)
+    region = SpectralRegion(10*u.pixel, 12*u.pixel)
+
+    extracted = extract_region(spectrum, region)
+
+    assert quantity_allclose(extracted.flux, [10, 11]*u.Jy)
+
+
+def test_extract_region_mismatched_units():
+    spectrum = Spectrum1D(spectral_axis=np.arange(25)*u.nm,
+                          flux=np.arange(25)*u.Jy)
+
+    region = SpectralRegion(100*u.AA, 119*u.AA)
+
+    extracted = extract_region(spectrum, region)
+
+    print(extracted.flux)
+
+    assert quantity_allclose(extracted.flux, [10, 11]*u.Jy)


### PR DESCRIPTION
While looking at some examples I just realized very last minute that the extraction machinery does not support pixel or unit-other-than-spectral-axis selection.  This PR fixes that.

cc @brechmos-stsci 