### PR TITLE
Add region test

### DIFF
--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -143,6 +143,13 @@ def test_region_two_sub(simulated_spectra):
     assert quantity_allclose(sub_spectra[0].flux, sub_spectrum_0_flux_expected)
     assert quantity_allclose(sub_spectra[1].flux, sub_spectrum_1_flux_expected)
 
+    # also ensure this works if the multi-region is expressed as a single
+    # Quantity
+    region2 = SpectralRegion([(0.6, 0.8), (0.86, 0.89)]*u.um)
+    sub_spectra2 = extract_region(spectrum, region2)
+    assert quantity_allclose(sub_spectra[0].flux, sub_spectra2[0].flux)
+    assert quantity_allclose(sub_spectra[1].flux, sub_spectra2[1].flux)
+
 
 def test_extract_region_pixels():
     spectrum = Spectrum1D(spectral_axis=np.linspace(4000, 10000, 25)*u.AA,

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -10,6 +10,8 @@ from ..manipulation import extract_region
 from ..manipulation.utils import linear_exciser
 from .spectral_examples import simulated_spectra
 
+from astropy.tests.helper import quantity_allclose
+
 
 def test_region_simple(simulated_spectra):
     np.random.seed(42)
@@ -30,7 +32,7 @@ def test_region_simple(simulated_spectra):
              1528.52281708, 1592.74392861, 1568.74162534, 1435.29407808, 1536.68040935,
              1157.33825995, 1136.12679394,  999.92394692, 1038.61546167, 1011.60297294])
 
-    assert np.allclose(sub_spectrum.flux.value, sub_spectrum_flux_expected)
+    assert quantity_allclose(sub_spectrum.flux.value, sub_spectrum_flux_expected)
 
 
 def test_region_ghz(simulated_spectra):
@@ -41,15 +43,16 @@ def test_region_ghz(simulated_spectra):
 
     sub_spectrum = extract_region(spectrum, region)
 
-    sub_spectrum_flux_expected = np.array(
-            [1605.71612173, 1651.41650744, 2057.65798618, 2066.73502361, 1955.75832537,
+    sub_spectrum_flux_expected =  [
+             1605.71612173, 1651.41650744, 2057.65798618, 2066.73502361, 1955.75832537,
              1670.52711471, 1491.10034446, 1637.08084112, 1471.28982259, 1299.19484483,
              1423.11195734, 1226.74494917, 1572.31888312, 1311.50503403, 1474.05051673,
              1335.39944397, 1420.61880528, 1433.18623759, 1290.26966668, 1605.67341284,
              1528.52281708, 1592.74392861, 1568.74162534, 1435.29407808, 1536.68040935,
-             1157.33825995, 1136.12679394,  999.92394692, 1038.61546167, 1011.60297294])
+             1157.33825995, 1136.12679394,  999.92394692, 1038.61546167, 1011.60297294
+             ]*u.mJy
 
-    assert np.allclose(sub_spectrum.flux.value, sub_spectrum_flux_expected)
+    assert quantity_allclose(sub_spectrum.flux, sub_spectrum_flux_expected)
 
 
 def test_region_simple_check_ends(simulated_spectra):
@@ -119,25 +122,26 @@ def test_region_two_sub(simulated_spectra):
     sub_spectra = extract_region(spectrum, region)
 
     # Confirm the end points of the subspectra are correct
-    assert np.allclose(sub_spectra[0].spectral_axis.value[[0, -1]],
-                       np.array([0.6035353535353536, 0.793939393939394]))
+    assert quantity_allclose(sub_spectra[0].spectral_axis[[0, -1]],
+                       [0.6035353535353536, 0.793939393939394]*u.um)
 
-    assert np.allclose(sub_spectra[1].spectral_axis.value[[0, -1]],
-                       np.array([0.8661616161616162, 0.8858585858585859]))
+    assert quantity_allclose(sub_spectra[1].spectral_axis[[0, -1]],
+                       [0.8661616161616162, 0.8858585858585859]*u.um)
 
-    sub_spectrum_0_flux_expected = np.array(
-            [1605.71612173, 1651.41650744, 2057.65798618, 2066.73502361, 1955.75832537,
+    sub_spectrum_0_flux_expected = [
+             1605.71612173, 1651.41650744, 2057.65798618, 2066.73502361, 1955.75832537,
              1670.52711471, 1491.10034446, 1637.08084112, 1471.28982259, 1299.19484483,
              1423.11195734, 1226.74494917, 1572.31888312, 1311.50503403, 1474.05051673,
              1335.39944397, 1420.61880528, 1433.18623759, 1290.26966668, 1605.67341284,
              1528.52281708, 1592.74392861, 1568.74162534, 1435.29407808, 1536.68040935,
-             1157.33825995, 1136.12679394,  999.92394692, 1038.61546167, 1011.60297294])
+             1157.33825995, 1136.12679394,  999.92394692, 1038.61546167, 1011.60297294
+             ]*u.mJy
 
-    sub_spectrum_1_flux_expected = np.array(
-            [1337.65312465, 1263.48914109, 1589.81797876, 1548.46068415])
+    sub_spectrum_1_flux_expected = [1337.65312465, 1263.48914109,
+                                    1589.81797876, 1548.46068415]*u.mJy
 
-    assert np.allclose(sub_spectra[0].flux.value, sub_spectrum_0_flux_expected)
-    assert np.allclose(sub_spectra[1].flux.value, sub_spectrum_1_flux_expected)
+    assert quantity_allclose(sub_spectra[0].flux, sub_spectrum_0_flux_expected)
+    assert quantity_allclose(sub_spectra[1].flux, sub_spectrum_1_flux_expected)
 
 
 def test_extract_region_pixels():


### PR DESCRIPTION
Not urgent because it works in master, but this both adds a test that you can make a SpectralRegion from a multi-dimensional quantity (39b81bc) and does some minor cleanup to the test file here that I noticed on the way