### PR TITLE
Documentation fixes

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -57,9 +57,9 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `specutils` for local development.
+Ready to contribute? Here's how to set up :ref:`specutils <specutils>` for local development.
 
-1. Fork the `specutils` repo on GitHub.
+1. Fork the :ref:`specutils <specutils>` repo on GitHub.
 2. Clone your fork locally::
 
     $ git clone git@github.com:your_name_here/specutils.git

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@
 Specutils Documentation
 ***********************
 
-.. py:function:: specutils
+.. _specutils:
 
 .. image:: img/logo.png
 
@@ -28,8 +28,8 @@ guiding document for spectroscopic development in the Astropy Project.
     development stage that some interfaces may change if user feedback and
     experience warrants it.
 
-Getting started with `specutils`
-================================
+Getting started with :ref:`specutils <specutils>`
+=================================================
 
 As a basic example, consider an emission line galaxy spectrum from the
 `SDSS <https://www.sdss.org/>`_.  We will use this as a proxy for a spectrum you
@@ -97,11 +97,11 @@ containing the line:
 
 
 While there are other tools and spectral representations detailed more below,
-this gives a test of the sort of analysis `specutils` enables.
+this gives a test of the sort of analysis :ref:`specutils <specutils>` enables.
 
 
-Using `specutils`
-=================
+Using :ref:`specutils <specutils>`
+==================================
 
 For more details on usage of specutils, see the sections listed below.
 

--- a/docs/manipulation.rst
+++ b/docs/manipulation.rst
@@ -2,19 +2,21 @@
 Manipulating Spectra
 ====================
 
-While there are myriad ways you might want to alter a spectrum, `specutils`
-provides some specific functionality that is commonly used in astronomy.  These
-tools are detailed here, but it is important to bear in mind that this is *not*
-intended to be exhaustive - the point of `specutils` is to provide a framework
-you can use to do your data analysis.  Hence the functionality described here is
-best thought of as pieces you might string together with your own functionality
-to build a tailor-made spectral analysis environment.
+While there are myriad ways you might want to alter a spectrum,
+:ref:`specutils <specutils>` provides some specific functionality that
+is commonly used in astronomy.  These tools are detailed here, but it
+is important to bear in mind that this is *not* intended to be
+exhaustive - the point of :ref:`specutils <specutils>` is to provide a
+framework you can use to do your data analysis.  Hence the
+functionality described here is best thought of as pieces you might
+string together with your own functionality to build a tailor-made
+spectral analysis environment.
 
-In general, however, `specutils` is designed around the idea that spectral
-manipulations generally yield *new* spectrum objects, rather than in-place
-operations.  This is not a true restriction, but is a guideline that is
-recommended primarily to keep you from accidentally modifying a spectrum you
-didn't mean to change.
+In general, however, :ref:`specutils <specutils>` is designed around
+the idea that spectral manipulations generally yield *new* spectrum
+objects, rather than in-place operations.  This is not a true
+restriction, but is a guideline that is recommended primarily to keep
+you from accidentally modifying a spectrum you didn't mean to change.
 
 Smoothing
 ---------
@@ -104,12 +106,13 @@ Note: This method is not flux conserving.
 Uncertainty Estimation
 ----------------------
 
-Some of the machinery in `specutils` (e.g. `~specutils.analysis.snr`) requires
-an uncertainty to be present.  While some data reduction pipelines generate this
-as part of the reduction process, sometimes it's necessary to estimate the
-uncertainty in a spectrum using the spectral data itself. Currently `specutils`
-provides the straightforward `~specutils.manipulation.noise_region_uncertainty`
-function.
+Some of the machinery in :ref:`specutils <specutils>` (e.g.
+`~specutils.analysis.snr`) requires an uncertainty to be present.
+While some data reduction pipelines generate this as part of the
+reduction process, sometimes it's necessary to estimate the
+uncertainty in a spectrum using the spectral data itself. Currently
+:ref:`specutils <specutils>` provides the straightforward
+`~specutils.manipulation.noise_region_uncertainty` function.
 
 First we build a spectrum like that used in :doc:`analysis`, but without a
 known uncertainty:

--- a/specutils/manipulation/estimate_uncertainty.py
+++ b/specutils/manipulation/estimate_uncertainty.py
@@ -18,22 +18,21 @@ def noise_region_uncertainty(spectrum, spectral_region, noise_func=np.std):
     Parameters
     ----------
 
-    spectrum: `~specutils.spectra.Spectrum1D
+    spectrum : `~specutils.Spectrum1D`
         The spectrum to which we want to set the uncertainty.
 
-    spectral_region: `~specutils.spectra.SpectralRegion`
+    spectral_region : `~specutils.SpectralRegion`
         The region to use to calculate the standard deviation.
 
-    noise_func: callable
+    noise_func : callable
         A function which takes the (1D) flux in the ``spectral_region`` and
         yields a *single* value for the noise to use in the result spectrum.
 
     Returns
     -------
-    spectrum_uncertainty: `~specutils.spectra.Spectrum1D
+    spectrum_uncertainty : `~specutils.Spectrum1D`
         The ``spectrum``, but with a constant uncertainty set by the result of
         the noise region calculation
-
     """
 
     # Extract the sub spectrum based on the region

--- a/specutils/manipulation/estimate_uncertainty.py
+++ b/specutils/manipulation/estimate_uncertainty.py
@@ -28,8 +28,8 @@ def noise_region_uncertainty(spectrum, spectral_region, noise_func=np.std):
         A function which takes the (1D) flux in the ``spectral_region`` and
         yields a *single* value for the noise to use in the result spectrum.
 
-    Return
-    ------
+    Returns
+    -------
     spectrum_uncertainty: `~specutils.spectra.Spectrum1D
         The ``spectrum``, but with a constant uncertainty set by the result of
         the noise region calculation


### PR DESCRIPTION
This PR fixes the errant "`specutils()`" on the main documentation page (it appears this was used for cross referencing?).  I fixed this, keeping the cross referencing intact.

![specutils_docs](https://user-images.githubusercontent.com/4992897/46422509-892ba100-c702-11e8-8f6d-c6866cad8779.png)

While testing the above, I discovered a few more documentation errors that I fixed.  The docs now build without (doc) warnings.