### PR TITLE
Copied over fixed parameters to new models

### DIFF
--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -212,6 +212,44 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
     return fit_model
 
 
+def _convert_and_dequantify(poss_quantity, dispersion_unit, dispersion, flux_unit):
+    """
+    This method will convert the ``poss_quantity`` value to the proper
+    dispersion or flux units and then strip the units.
+
+    If the ``poss_quantity`` is None, or a number, we just return that...
+
+    Note: This method can be removed along with most of the others here
+          when astropy.fitting will fit models that contain units.
+
+    """
+
+    if poss_quantity is None or isinstance(poss_quantity, (float, int)):
+        return poss_quantity
+
+    if hasattr(poss_quantity, 'quantity') and poss_quantity.quantity is not None:
+        q = poss_quantity.quantity
+
+        #
+        # Convert the quantity to the spectrum's units, and then we will use
+        # the *value* of it in the new unitless-model.
+        #
+
+        if q.unit.is_equivalent(dispersion_unit, equivalencies=u.equivalencies.spectral()):
+            quantity = q.to(dispersion_unit, equivalencies=u.equivalencies.spectral())
+
+        elif q.unit.is_equivalent(flux_unit, equivalencies=u.equivalencies.spectral_density(dispersion)):
+            quantity = q.to(flux_unit, equivalencies=u.equivalencies.spectral_density(dispersion))
+
+        # The value must be a quantity in order to use setattr (below)
+        # as the setter requires a Quantity on the rhs if the parameter
+        # is already a value.
+        v = quantity.value
+    else:
+        v = poss_quantity.value
+
+    return v
+
 def _strip_units_from_model(model_in, spectrum):
     """
     This method strips the units from the model, so the result can
@@ -286,28 +324,7 @@ def _strip_units_from_model(model_in, spectrum):
         for pn in new_sub_model.param_names:
 
             # This could be a Quantity or Parameter
-            a = getattr(sub_model, pn)
-
-            if hasattr(a, 'quantity') and a.quantity is not None:
-                q = getattr(sub_model, pn).quantity
-
-                #
-                # Convert the quantity to the spectrum's units, and then we will use
-                # the *value* of it in the new unitless-model.
-                #
-
-                if q.unit.is_equivalent(dispersion_unit, equivalencies=u.equivalencies.spectral()):
-                    quantity = q.to(dispersion_unit, equivalencies=u.equivalencies.spectral())
-
-                elif q.unit.is_equivalent(flux_unit, equivalencies=u.equivalencies.spectral_density(dispersion)):
-                    quantity = q.to(flux_unit, equivalencies=u.equivalencies.spectral_density(dispersion))
-
-                # The value must be a quantity in order to use setattr (below)
-                # as the setter requires a Quantity on the rhs if the parameter
-                # is already a value.
-                v = quantity.value
-            else:
-                v = getattr(sub_model, pn).value
+            v = _convert_and_dequantify(getattr(sub_model, pn), dispersion_unit, dispersion, flux_unit)
 
             #
             # Add this information for the parameter name into the
@@ -317,10 +334,22 @@ def _strip_units_from_model(model_in, spectrum):
             setattr(new_sub_model, pn, v)
 
             #
-            # Set the fixed parameter
+            # Set the fixed and tied parameters
             #
 
             new_sub_model.fixed[pn] = sub_model.fixed[pn]
+            new_sub_model.tied[pn] = sub_model.tied[pn]
+
+            #
+            # Convert teh bounds parameter
+            #
+            print(sub_model.bounds[pn])
+            new_bounds = []
+            for a in sub_model.bounds[pn]:
+                v = _convert_and_dequantify(a, dispersion_unit, dispersion, flux_unit)
+                new_bounds.append(v)
+
+            new_sub_model.bounds[pn] = tuple(new_bounds)
 
         # The new model now has unitless information in it but has
         # been converted to spectral unit scale.
@@ -470,6 +499,8 @@ def _add_units_to_model(model_in, model_orig, spectrum):
             #
 
             new_sub_model.fixed[pn] = m_orig.fixed[pn]
+            new_sub_model.bounds[pn] = m_orig.bounds[pn]
+            new_sub_model.tied[pn] = m_orig.tied[pn]
 
         #
         # Add the new unit-filled model onto the stack.

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -343,7 +343,6 @@ def _strip_units_from_model(model_in, spectrum):
             #
             # Convert teh bounds parameter
             #
-            print(sub_model.bounds[pn])
             new_bounds = []
             for a in sub_model.bounds[pn]:
                 v = _convert_and_dequantify(a, dispersion_unit, dispersion, flux_unit)

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -341,6 +341,12 @@ def _strip_units_from_model(model_in, spectrum):
             new_sub_model.tied[pn] = sub_model.tied[pn]
 
             #
+            # Copy over all the constraints (e.g., tied, fixed...)
+            #
+            for k, v in sub_model._constraints.items():
+                new_sub_model._constraints[k] = v
+
+            #
             # Convert teh bounds parameter
             #
             new_bounds = []
@@ -349,6 +355,7 @@ def _strip_units_from_model(model_in, spectrum):
                 new_bounds.append(v)
 
             new_sub_model.bounds[pn] = tuple(new_bounds)
+
 
         # The new model now has unitless information in it but has
         # been converted to spectral unit scale.
@@ -494,12 +501,10 @@ def _add_units_to_model(model_in, model_orig, spectrum):
             setattr(new_sub_model, pn, v)
 
             #
-            # Set the fixed parameter
+            # Copy over all the constraints (e.g., tied, fixed, bounds...)
             #
-
-            new_sub_model.fixed[pn] = m_orig.fixed[pn]
-            new_sub_model.bounds[pn] = m_orig.bounds[pn]
-            new_sub_model.tied[pn] = m_orig.tied[pn]
+            for k, v in m_orig._constraints.items():
+                new_sub_model._constraints[k] = v
 
         #
         # Add the new unit-filled model onto the stack.

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -224,7 +224,7 @@ def _convert_and_dequantify(poss_quantity, dispersion_unit, dispersion, flux_uni
 
     """
 
-    if poss_quantity is None or isinstance(poss_quantity, (float, int)):
+    if poss_quantity is None or isinstance(poss_quantity, (float, int, u.Quantity)):
         return poss_quantity
 
     if hasattr(poss_quantity, 'quantity') and poss_quantity.quantity is not None:

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -316,6 +316,12 @@ def _strip_units_from_model(model_in, spectrum):
 
             setattr(new_sub_model, pn, v)
 
+            #
+            # Set the fixed parameter
+            #
+
+            new_sub_model.fixed[pn] = sub_model.fixed[pn]
+
         # The new model now has unitless information in it but has
         # been converted to spectral unit scale.
         model_out_stack.append(new_sub_model)
@@ -458,6 +464,12 @@ def _add_units_to_model(model_in, model_orig, spectrum):
             #
 
             setattr(new_sub_model, pn, v)
+
+            #
+            # Set the fixed parameter
+            #
+
+            new_sub_model.fixed[pn] = m_orig.fixed[pn]
 
         #
         # Add the new unit-filled model onto the stack.

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -334,13 +334,6 @@ def _strip_units_from_model(model_in, spectrum):
             setattr(new_sub_model, pn, v)
 
             #
-            # Set the fixed and tied parameters
-            #
-
-            new_sub_model.fixed[pn] = sub_model.fixed[pn]
-            new_sub_model.tied[pn] = sub_model.tied[pn]
-
-            #
             # Copy over all the constraints (e.g., tied, fixed...)
             #
             for k, v in sub_model._constraints.items():

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -275,3 +275,19 @@ def test_double_peak_fit_with_exclusion():
                                        1.40343441e-074, 1.38268273e-097, 1.04632487e-123, 6.08168818e-153])
 
     assert np.allclose(y1_double_fit.value[::10], y1_double_fit_expected, atol=1e-5)
+
+
+def test_fixed_parameters():
+    """
+    Test to confirm fixed parameters do not change.
+    """
+
+    x = np.linspace(0., 10., 200)
+    y = 3 * np.exp(-0.5 * (x - 6.3)**2 / 0.8**2)
+    y += np.random.normal(0., 0.2, x.shape)
+    spectrum = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um)
+
+    g_init = models.Gaussian1D(amplitude=3.*u.Jy, mean=6.1*u.um, stddev=1.*u.um, fixed={'mean': True})
+    g_fit = fit_lines(spectrum, g_init)
+
+    assert g_fit.mean == 6.1*u.um

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -277,6 +277,12 @@ def test_double_peak_fit_with_exclusion():
     assert np.allclose(y1_double_fit.value[::10], y1_double_fit_expected, atol=1e-5)
 
 
+def tie_center(model):
+    """ Dummy method for testing passing of tied parameter """
+    mean = 50 * model.stddev
+    return mean
+
+
 def test_fixed_parameters():
     """
     Test to confirm fixed parameters do not change.
@@ -287,7 +293,19 @@ def test_fixed_parameters():
     y += np.random.normal(0., 0.2, x.shape)
     spectrum = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um)
 
-    g_init = models.Gaussian1D(amplitude=3.*u.Jy, mean=6.1*u.um, stddev=1.*u.um, fixed={'mean': True})
+    # Test passing fixed and bounds parameters
+    g_init = models.Gaussian1D(amplitude=3.*u.Jy, mean=6.1*u.um, stddev=1.*u.um,
+                               fixed={'mean': True},
+                               bounds={'amplitude': (2, 5)*u.Jy})
+
     g_fit = fit_lines(spectrum, g_init)
 
     assert g_fit.mean == 6.1*u.um
+    assert g_fit.bounds == g_init.bounds
+
+    # Test passing of tied parameter
+    g_init = models.Gaussian1D(amplitude=3.*u.Jy, mean=6.1*u.um, stddev=1.*u.um,
+                               tied={'mean': tie_center})
+    g_fit = fit_lines(spectrum, g_init)
+
+    assert g_fit.tied == g_init.tied


### PR DESCRIPTION
The fixed parameter attribute of the model was not copied over when stripping and adding units. This is now fixed and a test was added based on the code in the issue below.

Fixes https://github.com/astropy/specutils/issues/357