### PR TITLE
fix creation of empty spectrum, well, geting spectral_axis of empty spectrum

### DIFF
--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -58,7 +58,13 @@ class OneDSpectrumMixin(object):
         """
         Returns a Quantity array with the values of the spectral axis.
         """
-        return self.wcs.pixel_to_world(np.arange(self.flux.shape[-1]))
+
+        if len(self.flux) > 0:
+            spectral_axis = self.wcs.pixel_to_world(np.arange(self.flux.shape[-1]))
+        else:
+            spectral_axis = []*self.wcs.spectral_axis_unit
+
+        return spectral_axis
 
     @property
     def spectral_axis_unit(self):

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -63,10 +63,12 @@ class OneDSpectrumMixin(object):
             spectral_axis = self.wcs.pixel_to_world(np.arange(self.flux.shape[-1]))
         else:
             # After some discussion it was suggested to create the empty spectral
-            # axis this way to better use the WCS infrastructure. Changes in the mid
-            # term might necessitate a revisit of this.
-            dummy_spectrum=self.__class__(spectral_axis=[1,2]*self.wcs.spectral_axis_unit,
-                                          flux=[1,2]*self.flux.unit)
+            # axis this way to better use the WCS infrastructure. This is to prepare
+            # for a future where pixel_to_world might yield something more than
+            # just a raw Quantity, which is planned for the mid-term in astropy and
+            # possible gwcs.  Such changes might necessitate a revisit of this code.
+            dummy_spectrum = self.__class__(spectral_axis=[1,2]*self.wcs.spectral_axis_unit,
+                                            flux=[1,2]*self.flux.unit)
             spectral_axis = dummy_spectrum.wcs.pixel_to_world([0])[1:]
 
         return spectral_axis

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -62,7 +62,12 @@ class OneDSpectrumMixin(object):
         if len(self.flux) > 0:
             spectral_axis = self.wcs.pixel_to_world(np.arange(self.flux.shape[-1]))
         else:
-            spectral_axis = []*self.wcs.spectral_axis_unit
+            # After some discussion it was suggested to create the empty spectral
+            # axis this way to better use the WCS infrastructure. Changes in the mid
+            # term might necessitate a revisit of this.
+            dummy_spectrum=self.__class__(spectral_axis=[1,2]*self.wcs.spectral_axis_unit,
+                                          flux=[1,2]*self.flux.unit)
+            spectral_axis = dummy_spectrum.wcs.pixel_to_world([0])[1:]
 
         return spectral_axis
 

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -13,6 +13,16 @@ from ..manipulation import noise_region_uncertainty
 
 from ..spectra import Spectrum1D, SpectralRegion
 
+def test_empty_spectrum():
+    spec = Spectrum1D(spectral_axis=[]*u.um,
+                      flux=[]*u.Jy)
+
+    assert isinstance(spec.spectral_axis, u.Quantity)
+    assert spec.spectral_axis.size == 0
+
+    assert isinstance(spec.flux, u.Quantity)
+    assert spec.flux.size == 0
+
 
 def test_create_from_arrays():
     spec = Spectrum1D(spectral_axis=np.arange(50) * u.AA,


### PR DESCRIPTION
There was a need to create an empty spectrum, which works, but then when `empty_spectrum.spectral_axis` was called it threw errors and exceptions (though `empty_spectrum.flux` worked).  So, this PR fixes that issue.

Now, 
```
In [1]: from specutils import Spectrum1D

In [2]: from astropy import units as u

In [3]: tt = Spectrum1D(flux=[]*u.Jy, spectral_axis=[]*u.um)
WARNING:root:GWCS does not store rest frequency information. Please define the rest value explicitly in the `Spectrum1D` object.
WARNING:root:GWCS does not store rest wavelength information. Please define the rest value explicitly in the `Spectrum1D` object.

In [4]: tt.spectral_axis
Out[4]: <Quantity [] um>

In [5]: tt.flux
Out[5]: <Quantity [] Jy>
```

Fixes https://github.com/astropy/specutils/issues/371