### PR TITLE
fixed bug for highest flux at start or end of spectrum

### DIFF
--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -148,8 +148,17 @@ def _compute_single_fwhm(flux, spectral_axis):
     left = flux[:argmax] <= halfval
     right = flux[argmax+1:] <= halfval
 
-    l_idx = np.where(left == True)[0][-1]
-    r_idx = np.where(right == True)[0][0] + argmax
+    # Highest signal at the first point
+    if len(left) == 0:
+        l_idx = 0
+    else:
+        l_idx = np.where(left == True)[0][-1]
+
+    # Highest signal at the last point
+    if len(right) == 0:
+        r_idx = len(flux)-1
+    else:
+        r_idx = np.where(right == True)[0][0] + argmax
 
     return spectral_axis[r_idx] - spectral_axis[l_idx]
 

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -461,18 +461,18 @@ def test_fwhm():
 
 
     # Highest point at the first point
-    frequencies = np.linspace(1, 10, 100) * u.um
-    flux = (1.0 / frequencies.value)*u.Jy # highest point first.
+    wavelengths = np.linspace(1, 10, 100) * u.um
+    flux = (1.0 / wavelengths.value)*u.Jy # highest point first.
 
-    spectrum = Spectrum1D(spectral_axis=frequencies, flux=flux)
+    spectrum = Spectrum1D(spectral_axis=wavelengths, flux=flux)
     result = fwhm(spectrum)
     assert result == 0.9090909090909092*u.um
 
     # Highest point at the last point
-    frequencies = np.linspace(1, 10, 100) * u.um
-    flux = frequencies.value*u.Jy # highest point last.
+    wavelengths = np.linspace(1, 10, 100) * u.um
+    flux = wavelengths.value*u.Jy # highest point last.
 
-    spectrum = Spectrum1D(spectral_axis=frequencies, flux=flux)
+    spectrum = Spectrum1D(spectral_axis=wavelengths, flux=flux)
     result = fwhm(spectrum)
     assert result == 5*u.um
 

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -460,6 +460,23 @@ def test_fwhm():
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)
 
 
+    # Highest point at the first point
+    frequencies = np.linspace(1, 10, 100) * u.um
+    flux = (1.0 / frequencies.value)*u.Jy # highest point first.
+
+    spectrum = Spectrum1D(spectral_axis=frequencies, flux=flux)
+    result = fwhm(spectrum)
+    assert result == 0.9090909090909092*u.um
+
+    # Highest point at the last point
+    frequencies = np.linspace(1, 10, 100) * u.um
+    flux = frequencies.value*u.Jy # highest point last.
+
+    spectrum = Spectrum1D(spectral_axis=frequencies, flux=flux)
+    result = fwhm(spectrum)
+    assert result == 5*u.um
+
+
 def test_fwhm_multi_spectrum():
 
     np.random.seed(42)


### PR DESCRIPTION
There was an issue with a spectrum where the highest flux was at the beginning of the spectrum. This meant the `left` was empty which caused some issues. This should now be fixed in this code.

Fixes https://github.com/astropy/specutils/issues/374