### PR TITLE
Add data loader for JWST spectra

### DIFF
--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -124,7 +124,7 @@ can be utilized by referencing its name in the ``read`` method of the
 .. _multiple_spectra:
 
 Loading Multiple Spectra
-========================
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 It is possible to create a loader that reads multiple spectra from the same
 file. For the general case where none of the spectra are assumed to be the same
@@ -134,9 +134,9 @@ custom JWST data loader as an example:
 .. literalinclude:: ../specutils/io/default_loaders/jwst_reader.py
     :language: python
 
-Note that by default, any loader that uses `dtype=Spectrum1D` will also
+Note that by default, any loader that uses ``dtype=Spectrum1D`` will also
 automatically add a reader for `~specutils.SpectrumList`. This enables client
-code to call `~specutils.SpectrumList.read` in all cases if it can't make
+code to call ``specutils.SpectrumList.read`` in all cases if it can't make
 assumptions about whether a loader returns one or many `~specutils.Spectrum1D`
 objects.
 

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -136,9 +136,10 @@ custom JWST data loader as an example:
 
 Note that by default, any loader that uses ``dtype=Spectrum1D`` will also
 automatically add a reader for `~specutils.SpectrumList`. This enables user
-code to call ``specutils.SpectrumList.read`` in all cases if it can't make
+code to call `specutils.SpectrumList.read` in all cases if it can't make
 assumptions about whether a loader returns one or many `~specutils.Spectrum1D`
-objects.
+objects. This method is available since `~specutils.SpectrumList` makes use of
+the Astropy IO registry.
 
 
 Creating a Custom Writer

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -121,6 +121,25 @@ can be utilized by referencing its name in the ``read`` method of the
 
     spec = Spectrum1D.read("path/to/data", format="my-format")
 
+.. _multiple_spectra:
+
+Loading Multiple Spectra
+========================
+
+It is possible to create a loader that reads multiple spectra from the same
+file. For the general case where none of the spectra are assumed to be the same
+length, the loader should return a `~specutils.SpectrumList`. Consider the
+custom JWST data loader as an example:
+
+.. literalinclude:: ../specutils/io/default_loaders/jwst_reader.py
+    :language: python
+
+Note that by default, any loader that uses `dtype=Spectrum1D` will also
+automatically add a reader for `~specutils.SpectrumList`. This enables client
+code to call `~specutils.SpectrumList.read` in all cases if it can't make
+assumptions about whether a loader returns one or many `~specutils.Spectrum1D`
+objects.
+
 
 Creating a Custom Writer
 ------------------------

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -136,10 +136,11 @@ custom JWST data loader as an example:
 
 Note that by default, any loader that uses ``dtype=Spectrum1D`` will also
 automatically add a reader for `~specutils.SpectrumList`. This enables user
-code to call `specutils.SpectrumList.read` in all cases if it can't make
-assumptions about whether a loader returns one or many `~specutils.Spectrum1D`
-objects. This method is available since `~specutils.SpectrumList` makes use of
-the Astropy IO registry.
+code to call `specutils.SpectrumList.read <astropy.nddata.NDIOMixin.read>` in
+all cases if it can't make assumptions about whether a loader returns one or
+many `~specutils.Spectrum1D` objects. This method is available since
+`~specutils.SpectrumList` makes use of the Astropy IO registry (see
+`astropy.io.registry.read`).
 
 
 Creating a Custom Writer

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -135,7 +135,7 @@ custom JWST data loader as an example:
     :language: python
 
 Note that by default, any loader that uses ``dtype=Spectrum1D`` will also
-automatically add a reader for `~specutils.SpectrumList`. This enables client
+automatically add a reader for `~specutils.SpectrumList`. This enables user
 code to call ``specutils.SpectrumList.read`` in all cases if it can't make
 assumptions about whether a loader returns one or many `~specutils.Spectrum1D`
 objects.

--- a/docs/types_of_spectra.rst
+++ b/docs/types_of_spectra.rst
@@ -44,7 +44,9 @@ with their corresponding ``specutils`` representations:
    not rectangular), this case does not have a specific representation in
    ``specutils``.  Instead, this case should be dealt with by making lists (or
    numpy object-arrays) of `~specutils.Spectrum1D` objects, and iterating over
-   them. Specutils does provide a `SpectrumList` class which is
+   them. 
+   
+   Specutils does provide a `SpectrumList` class which is
    primarily intended for enabling data loaders that need to read multiple
    heterogenous spectra (see :ref:`multiple_spectra`). Users should rarely need
    to use `SpectrumList` directly since a `list` of `Spectrum1D` objects is

--- a/docs/types_of_spectra.rst
+++ b/docs/types_of_spectra.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: specutils
+
 Overview of How Specutils Represents Spectra
 --------------------------------------------
 
@@ -42,7 +44,11 @@ with their corresponding ``specutils`` representations:
    not rectangular), this case does not have a specific representation in
    ``specutils``.  Instead, this case should be dealt with by making lists (or
    numpy object-arrays) of `~specutils.Spectrum1D` objects, and iterating over
-   them.
+   them. Specutils does provide a `SpectrumList` class which is
+   primarily intended for enabling data loaders that need to read multiple
+   heterogenous spectra (see :ref:`multiple_spectra`). Users should rarely need
+   to use `SpectrumList` directly since a `list` of `Spectrum1D` objects is
+   sufficient for most other purposes.
 
 In all of these cases, the objects have additional attributes (e.g.
 uncertainties), along with other metadata.  But the list above is exhaustive

--- a/docs/types_of_spectra.rst
+++ b/docs/types_of_spectra.rst
@@ -44,13 +44,14 @@ with their corresponding ``specutils`` representations:
    not rectangular), this case does not have a specific representation in
    ``specutils``.  Instead, this case should be dealt with by making lists (or
    numpy object-arrays) of `~specutils.Spectrum1D` objects, and iterating over
-   them. 
-   
-   Specutils does provide a `SpectrumList` class which is
-   primarily intended for enabling data loaders that need to read multiple
-   heterogenous spectra (see :ref:`multiple_spectra`). Users should rarely need
-   to use `SpectrumList` directly since a `list` of `Spectrum1D` objects is
-   sufficient for most other purposes.
+   them.
+
+   Specutils does provide a `SpectrumList` class which is a simple subclass of
+   `list` that is integrated with the Astropy IO registry. It enables data
+   loaders to read and return multiple heterogenous spectra (see
+   :ref:`multiple_spectra`). Users should not need to use `SpectrumList`
+   directly since a `list` of `Spectrum1D` objects is sufficient for all other
+   purposes.
 
 In all of these cases, the objects have additional attributes (e.g.
 uncertainties), along with other metadata.  But the list above is exhaustive

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -6,6 +6,13 @@ from ..registers import data_loader
 
 
 def identify_jwst_fits(origin, *args, **kwargs):
+    """
+    Check whether the given file is a JWST spectral data product.
+
+    This check is fairly simple. It expects FITS files that contain an ASDF
+    header (which is not used here, but indicates a JWST data product). It then
+    looks for at least one EXTRACT1D header, which contains spectral data.
+    """
 
     try:
         with fits.open(args[0]) as hdulist:
@@ -21,8 +28,22 @@ def identify_jwst_fits(origin, *args, **kwargs):
         return False
 
 
-@data_loader("JWST", identifier=identify_jwst_fits, dtype=SpectrumList)
+@data_loader("JWST", identifier=identify_jwst_fits, dtype=SpectrumList,
+             extensions=['fits'])
 def jwst_loader(filename, spectral_axis_unit=None, **kwargs):
+    """
+    Loader for JWST data files.
+
+    Parameters
+    ----------
+    file_name: str
+        The path to the FITS file
+
+    Returns
+    -------
+    data: SpectrumList
+        A list of the spectra that are contained in this file.
+    """
 
     spectra = []
 

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -1,0 +1,38 @@
+import astropy.units as u
+from astropy.io import fits
+
+from ...spectra import Spectrum1D
+from ..registers import data_loader
+
+
+def identify_jwst_fits(origin, *args, **kwargs):
+
+    try:
+        with fits.open(args[0]) as hdulist:
+            # This is a near-guarantee that we have a JWST data product
+            if not 'ASDF' in hdulist:
+                return False
+            # This indicates the data product contains  spectral data
+            if not 'EXTRACT1D' in hdulist:
+                return False
+        return True
+    # This probably means we didn't have a FITS file
+    except Exception:
+        return False
+
+
+@data_loader("JWST", identifier=identify_jwst_fits, dtype=Spectrum1D)
+def jwst_loader(filename, spectral_axis_unit=None, **kwargs):
+
+    with fits.open(filename) as hdulist:
+        # TODO: eventually we will pass a SpectrumCollection back, but for now
+        # we just return the first spectrum in the file.
+        hdu = hdulist['EXTRACT1D']
+        wavelength = hdu.data['WAVELENGTH'] * u.Unit(hdu.header['TUNIT1'])
+        flux = hdu.data['FLUX'] * u.Unit(hdu.header['TUNIT2'])
+        error = hdu.data['ERROR'] * u.Unit(hdu.header['TUNIT3'])
+
+        meta = dict(slitname=hdu.header.get('SLTNAME', ''))
+
+    # TODO: pass uncertainty using the error from the HDU
+    return Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)

--- a/specutils/io/default_loaders/tests/test_jwst_loader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_loader.py
@@ -1,0 +1,45 @@
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table
+
+from specutils import Spectrum1D, SpectrumList
+
+
+def create_spectrum_hdu(data_len):
+    # Create a minimal header for the purposes of testing
+
+    data = np.random.random((data_len, 3))
+    table = Table(data=data, names=['WAVELENGTH', 'FLUX', 'ERROR'])
+
+    hdu = fits.BinTableHDU(table, name='EXTRACT1D')
+    hdu.header['TUNIT1'] = 'um'
+    hdu.header['TUNIT2'] = 'mJy'
+    hdu.header['TUNIT3'] = 'mJy'
+
+    return hdu
+
+
+def test_jwst_loader(tmpdir):
+
+    tmpfile = str(tmpdir.join('jwst.fits'))
+
+    hdulist = fits.HDUList()
+    # Make sure the file has a primary HDU
+    hdulist.append(fits.PrimaryHDU())
+    # Add several BinTableHDUs that contain spectral data
+    hdulist.append(create_spectrum_hdu(100))
+    hdulist.append(create_spectrum_hdu(120))
+    hdulist.append(create_spectrum_hdu(110))
+    # JWST data product will always contain an ASDF header which is a BinTable
+    hdulist.append(fits.BinTableHDU(name='ASDF'))
+    hdulist.writeto(tmpfile)
+
+    data = SpectrumList.read(tmpfile, format='JWST')
+    assert len(data) == 3
+
+    for item in data:
+        assert isinstance(item, Spectrum1D)
+
+    assert data[0].shape == (100,)
+    assert data[1].shape == (120,)
+    assert data[2].shape == (110,)

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -7,7 +7,7 @@ from functools import wraps
 
 from astropy.io import registry as io_registry
 
-from ..spectra.spectrum1d import Spectrum1D
+from ..spectra import Spectrum1D, SpectrumList
 
 
 __all__ = ['data_loader', 'custom_writer', 'get_loaders_by_extension']
@@ -64,6 +64,16 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
         io_registry._readers.update(sorted_loaders)
 
         logging.debug("Successfully loaded reader \"{}\".".format(label))
+
+        # Automatically register a SpectrumList reader for any data_loader that
+        # reads Spectrum1D objects. TODO: it's possible that this
+        # functionality should be opt-in rather than automatic.
+        if dtype == Spectrum1D:
+            def load_specrum_list(*args, **kwargs):
+                return SpectrumList([ func(*args, **kwargs) ])
+
+            io_registry.register_reader(label, SpectrumList, load_specrum_list)
+            logging.debug("Created SpectrumList reader for \"{}\".".format(label))
 
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -68,7 +68,7 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
         # Automatically register a SpectrumList reader for any data_loader that
         # reads Spectrum1D objects. TODO: it's possible that this
         # functionality should be opt-in rather than automatic.
-        if dtype == Spectrum1D:
+        if dtype is Spectrum1D:
             def load_specrum_list(*args, **kwargs):
                 return SpectrumList([ func(*args, **kwargs) ])
 

--- a/specutils/spectra/__init__.py
+++ b/specutils/spectra/__init__.py
@@ -4,17 +4,7 @@ The core specutils data objects package. This contains the
 """
 from __future__ import absolute_import
 
-from astropy.nddata import NDIOMixin
-
 from .spectrum1d import *  # noqa
 from .spectral_region import *  # noqa
 from .spectrum_collection import *  #noqa
-
-
-class SpectrumList(list, NDIOMixin):
-    """
-    A list that is used to hold a list of Spectrum1D objects
-
-    The primary purpose of this class is to allow loaders to return a list of
-    heterogenous spectra that do have a spectral axis of the same length.
-    """
+from .spectrum_list import * #noqa

--- a/specutils/spectra/__init__.py
+++ b/specutils/spectra/__init__.py
@@ -4,6 +4,17 @@ The core specutils data objects package. This contains the
 """
 from __future__ import absolute_import
 
+from astropy.nddata import NDIOMixin
+
 from .spectrum1d import *  # noqa
 from .spectral_region import *  # noqa
 from .spectrum_collection import *  #noqa
+
+
+class SpectrumList(list, NDIOMixin):
+    """
+    A list that is used to hold a list of Spectrum1D objects
+
+    The primary purpose of this class is to allow loaders to return a list of
+    heterogenous spectra that do have a spectral axis of the same length.
+    """

--- a/specutils/spectra/spectrum_list.py
+++ b/specutils/spectra/spectrum_list.py
@@ -1,0 +1,13 @@
+from astropy.nddata import NDIOMixin
+
+
+__all__ = ['SpectrumList']
+
+
+class SpectrumList(list, NDIOMixin):
+    """
+    A list that is used to hold a list of Spectrum1D objects
+
+    The primary purpose of this class is to allow loaders to return a list of
+    heterogenous spectra that do have a spectral axis of the same length.
+    """

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -9,6 +9,7 @@ import tempfile
 from .. import Spectrum1D
 from .conftest import remote_data_path
 from ..io import get_loaders_by_extension
+from .. import Spectrum1D, SpectrumList
 
 
 remote_access = lambda argvals: pytest.mark.parametrize(
@@ -27,6 +28,16 @@ def test_spectrum1d_GMOSfits(remote_data_path):
     optical_spec_2 = Spectrum1D.read(remote_data_path, format='wcs1d-fits')
 
     assert len(optical_spec_2.data) == 3020
+
+
+def test_spectrumlist_GMOSfits():
+    optical_fits_file = get_pkg_data_filename('data/L5g_0355+11_Cruz09.fits')
+    spectrum_list = SpectrumList.read(optical_fits_file, format='wcs1d-fits')
+
+    assert len(spectrum_list) == 1
+
+    spec = spectrum_list[0]
+    assert len(spec.data) == 3020
 
 
 @remote_access([{'id': '1481190', 'filename': 'L5g_0355+11_Cruz09.fits'}])

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -5,6 +5,14 @@ import pytest
 import urllib
 import shutil
 import tempfile
+import warnings
+
+import pytest
+
+from astropy.units import UnitsWarning
+from astropy.wcs import FITSFixedWarning
+from astropy.io.fits.verify import VerifyWarning
+from astropy.utils.data import get_pkg_data_filename
 
 from .. import Spectrum1D
 from .conftest import remote_data_path
@@ -25,14 +33,19 @@ def test_get_loaders_by_extension():
 
 @remote_access([{'id': '1481190', 'filename': 'L5g_0355+11_Cruz09.fits'}])
 def test_spectrum1d_GMOSfits(remote_data_path):
-    optical_spec_2 = Spectrum1D.read(remote_data_path, format='wcs1d-fits')
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', (VerifyWarning, UnitsWarning))
+        optical_spec_2 = Spectrum1D.read(remote_data_path, format='wcs1d-fits')
 
     assert len(optical_spec_2.data) == 3020
 
 
 def test_spectrumlist_GMOSfits():
     optical_fits_file = get_pkg_data_filename('data/L5g_0355+11_Cruz09.fits')
-    spectrum_list = SpectrumList.read(optical_fits_file, format='wcs1d-fits')
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', (VerifyWarning, UnitsWarning))
+        spectrum_list = SpectrumList.read(optical_fits_file, format='wcs1d-fits')
 
     assert len(spectrum_list) == 1
 
@@ -42,9 +55,11 @@ def test_spectrumlist_GMOSfits():
 
 @remote_access([{'id': '1481190', 'filename': 'L5g_0355+11_Cruz09.fits'}])
 def test_specific_spec_axis_unit(remote_data_path):
-    optical_spec = Spectrum1D.read(remote_data_path,
-                                   spectral_axis_unit="Angstrom",
-                                   format='wcs1d-fits')
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', (VerifyWarning, UnitsWarning))
+        optical_spec = Spectrum1D.read(remote_data_path,
+                                       spectral_axis_unit="Angstrom",
+                                       format='wcs1d-fits')
 
     assert optical_spec.spectral_axis.unit == "Angstrom"
 
@@ -104,7 +119,9 @@ def test_sdss_spspec():
         with tempfile.NamedTemporaryFile() as tmp_file:
             shutil.copyfileobj(response, tmp_file)
 
-            spec = Spectrum1D.read(tmp_file.name, format="SDSS-I/II spSpec")
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', FITSFixedWarning)
+                spec = Spectrum1D.read(tmp_file.name, format="SDSS-I/II spSpec")
 
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0


### PR DESCRIPTION
This PR adds a new loader for JWST spectral data products.

It also adds a new lightweight container class called `SpectrumList`.

The essential problem is this: we need the JWST data loader to be able to return multiple spectra since any given JWST data product will contain an arbitrary number of spectra.

However, `SpectrumCollection` is not sufficient since it expects all spectra to have axes of the same length. This is not true for JWST data products since different slits may have slightly different dispersions.

I don't think that `SpectrumList` needs to be any more than a dumb container for `Spectrum1D` objects. It also plugs in to Astropy's IO machinery, which makes using the loader even more convenient.