### PR TITLE
Region extract error vs empty spectrum

### DIFF
--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -27,23 +27,47 @@ def _to_edge_pixel(subregion, spectrum):
 
     """
 
+    #
+    # Left/lower side of sub region
+    #
     if subregion[0].unit.is_equivalent(u.pix):
         left_index = floor(subregion[0].value)
     else:
-        left_reg_in_spec_unit = subregion[0].to(spectrum.spectral_axis.unit, u.spectral())
-        try:
-            left_index = int(np.ceil(spectrum.wcs.world_to_pixel([left_reg_in_spec_unit])))
-        except Exception as e:
-            left_index = None
 
+        # Convert lower value to spectrum spectral_axis units
+        left_reg_in_spec_unit = subregion[0].to(spectrum.spectral_axis.unit, u.spectral())
+
+        if left_reg_in_spec_unit < spectrum.spectral_axis[0]:
+            left_index = 0
+        elif left_reg_in_spec_unit > spectrum.spectral_axis[-1]:
+            left_index = len(spectrum.spectral_axis)-1
+        else:
+            try:
+                left_index = int(np.ceil(spectrum.wcs.world_to_pixel([left_reg_in_spec_unit])))
+            except Exception as e:
+                raise ValueError("Lower value, {}, could not convert using spectrum's WCS {}".format(
+                    left_reg_in_spec_unit, spectrum.wcs))
+
+    #
+    # Right/upper side of sub region
+    #
     if subregion[1].unit.is_equivalent(u.pix):
         right_index = ceil(subregion[1].value)
     else:
+
+        # Convert upper value to spectrum spectral_axis units
         right_reg_in_spec_unit = subregion[1].to(spectrum.spectral_axis.unit, u.spectral())
-        try:
-            right_index = int(np.floor(spectrum.wcs.world_to_pixel([right_reg_in_spec_unit]))) + 1
-        except Exception as e:
-            right_index = None
+
+        if right_reg_in_spec_unit > spectrum.spectral_axis[-1]:
+            right_index = len(spectrum.spectral_axis)-1
+        elif right_reg_in_spec_unit < spectrum.spectral_axis[0]:
+            right_index = 0 
+        else:
+            try:
+                right_index = int(np.floor(spectrum.wcs.world_to_pixel([right_reg_in_spec_unit]))) + 1
+            except Exception as e:
+                raise ValueError("Upper value, {}, could not convert using spectrum's WCS {}".format(
+                    right_reg_in_spec_unit, spectrum.wcs))
 
     return left_index, right_index
 

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -3,6 +3,7 @@ from math import floor, ceil  # faster than int(np.floor/ceil(float))
 import numpy as np
 
 from astropy import units as u
+from .. import Spectrum1D
 
 __all__ = ['extract_region']
 
@@ -88,7 +89,9 @@ def extract_region(spectrum, region):
 
         # If both indices are out of bounds then return None
         if left_index is None and right_index is None:
-            extracted_spectrum.append(None)
+            empty_spectrum = Spectrum1D(spectral_axis=[]*spectrum.spectral_axis.unit, 
+                                        flux=[]*spectrum.flux.unit)
+            extracted_spectrum.append(empty_spectrum)
         else:
 
             # If only one index is out of bounds then set it to

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -105,6 +105,9 @@ def extract_region(spectrum, region):
         And we calculate ``sub_spectrum = extract_region(spectrum, region)``, then the ``sub_spectrum``
         spectral axis will be ``[0.2, 0.3, 0.4, 0.5] * u.um``.
 
+    If the ``region`` does not overlap with the ``spectrum`` then an empty Spectrum1D object
+    will be returned.
+
     """
 
     extracted_spectrum = []

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -229,9 +229,12 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             other, compare_wcs=lambda o1, o2: self._compare_wcs(self, other))
 
     def _format_array_summary(self, label, array):
-        mean = np.mean(array)
-        s = "{:17} [ {:.5}, ..., {:.5} ],  mean={:.5}"
-        return s.format(label+':', array[0], array[-1], mean)
+        if len(array) > 0:
+            mean = np.mean(array)
+            s = "{:17} [ {:.5}, ..., {:.5} ],  mean={:.5}"
+            return s.format(label+':', array[0], array[-1], mean)
+        else:
+            return "{:17} [ ],  mean= n/a".format(label+':')
 
     def __str__(self):
         result = "Spectrum1D "

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -72,22 +72,34 @@ def test_region_empty(simulated_spectra):
     spectrum = Spectrum1D(spectral_axis=np.linspace(1, 25, 25)*u.um, flux=np.random.random(25)*u.Jy)
     region = SpectralRegion(28*u.um, 30*u.um)
     sub_spectrum = extract_region(spectrum, region)
-    assert sub_spectrum.spectral_axis == empty_spectrum.spectral_axis
-    assert sub_spectrum.flux == empty_spectrum.flux
+
+    assert np.allclose(sub_spectrum.spectral_axis.value, empty_spectrum.spectral_axis.value)
+    assert sub_spectrum.spectral_axis.unit == empty_spectrum.spectral_axis.unit
+
+    assert np.allclose(sub_spectrum.flux.value, empty_spectrum.flux.value)
+    assert sub_spectrum.flux.unit == empty_spectrum.flux.unit
 
     # Region below lower range of spectrum
     spectrum = Spectrum1D(spectral_axis=np.linspace(1, 25, 25)*u.um, flux=np.random.random(25)*u.Jy)
     region = SpectralRegion(0.1*u.um, 0.3*u.um)
     sub_spectrum = extract_region(spectrum, region)
-    assert sub_spectrum.spectral_axis == empty_spectrum.spectral_axis
-    assert sub_spectrum.flux == empty_spectrum.flux
+
+    assert np.allclose(sub_spectrum.spectral_axis.value, empty_spectrum.spectral_axis.value)
+    assert sub_spectrum.spectral_axis.unit == empty_spectrum.spectral_axis.unit
+
+    assert np.allclose(sub_spectrum.flux.value, empty_spectrum.flux.value)
+    assert sub_spectrum.flux.unit == empty_spectrum.flux.unit
 
     # Region below lower range of spectrum and upper range in the spectrum.
-    spectrum = Spectrum1D(spectral_axis=np.linspace(1, 25, 25)*u.um, flux=np.random.random(25)*u.Jy)
+    spectrum = Spectrum1D(spectral_axis=np.linspace(1, 25, 25)*u.um, flux=2*np.linspace(1, 25, 25)*u.Jy)
     region = SpectralRegion(0.1*u.um, 3.3*u.um)
     sub_spectrum = extract_region(spectrum, region)
-    assert sub_spectrum.spectral_axis == empty_spectrum.spectral_axis
-    assert sub_spectrum.flux == empty_spectrum.flux
+
+    assert np.allclose(sub_spectrum.spectral_axis.value, [1, 2, 3])
+    assert sub_spectrum.spectral_axis.unit == empty_spectrum.spectral_axis.unit
+
+    assert np.allclose(sub_spectrum.flux.value, [2, 4, 6])
+    assert sub_spectrum.flux.unit == empty_spectrum.flux.unit
 
     # Region has lower and upper bound the same
     with pytest.raises(Exception) as e_info:

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -66,23 +66,28 @@ def test_region_simple_check_ends(simulated_spectra):
 def test_region_empty(simulated_spectra):
     np.random.seed(42)
 
+    empty_spectrum = Spectrum1D(spectral_axis=[]*u.um, flux=[]*u.Jy)
+
     # Region past upper range of spectrum
     spectrum = Spectrum1D(spectral_axis=np.linspace(1, 25, 25)*u.um, flux=np.random.random(25)*u.Jy)
     region = SpectralRegion(28*u.um, 30*u.um)
     sub_spectrum = extract_region(spectrum, region)
-    assert sub_spectrum is None
+    assert sub_spectrum.spectral_axis == empty_spectrum.spectral_axis
+    assert sub_spectrum.flux == empty_spectrum.flux
 
     # Region below lower range of spectrum
     spectrum = Spectrum1D(spectral_axis=np.linspace(1, 25, 25)*u.um, flux=np.random.random(25)*u.Jy)
     region = SpectralRegion(0.1*u.um, 0.3*u.um)
     sub_spectrum = extract_region(spectrum, region)
-    assert sub_spectrum is None
+    assert sub_spectrum.spectral_axis == empty_spectrum.spectral_axis
+    assert sub_spectrum.flux == empty_spectrum.flux
 
     # Region below lower range of spectrum and upper range in the spectrum.
     spectrum = Spectrum1D(spectral_axis=np.linspace(1, 25, 25)*u.um, flux=np.random.random(25)*u.Jy)
     region = SpectralRegion(0.1*u.um, 3.3*u.um)
     sub_spectrum = extract_region(spectrum, region)
-    assert sub_spectrum is not None
+    assert sub_spectrum.spectral_axis == empty_spectrum.spectral_axis
+    assert sub_spectrum.flux == empty_spectrum.flux
 
     # Region has lower and upper bound the same
     with pytest.raises(Exception) as e_info:

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -168,7 +168,7 @@ def test_wcs_transformations():
     assert isinstance(pix_axis, np.ndarray)
     assert isinstance(disp_axis, u.Quantity)
 
-    assert np.allclose(spec.wcs.world_to_pixel([7000*u.AA]), [461.2])
+    assert np.allclose(spec.wcs.world_to_pixel([7000*u.AA, 700*u.nm]), [461.2, 461.2])
 
 def test_create_explicit_fitswcs():
     my_wcs = fitswcs.WCS(header={'CDELT1': 1, 'CRVAL1': 6562.8, 'CUNIT1': 'Angstrom',

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -10,6 +10,7 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.modeling import models
 from astropy.tests.helper import quantity_allclose
 from ..manipulation import noise_region_uncertainty
+from ..wcs.adapters import fitswcs_adapter
 
 from ..spectra import Spectrum1D, SpectralRegion
 
@@ -166,6 +167,8 @@ def test_wcs_transformations():
 
     assert isinstance(pix_axis, np.ndarray)
     assert isinstance(disp_axis, u.Quantity)
+
+    assert np.allclose(spec.wcs.world_to_pixel([7000*u.AA]), [461.2])
 
 def test_create_explicit_fitswcs():
     my_wcs = fitswcs.WCS(header={'CDELT1': 1, 'CRVAL1': 6562.8, 'CUNIT1': 'Angstrom',

--- a/specutils/wcs/adapters/fitswcs_adapter.py
+++ b/specutils/wcs/adapters/fitswcs_adapter.py
@@ -45,7 +45,9 @@ class FITSWCSAdapter(WCSAdapter):
         """
         Method for performing the world to pixel transformations.
         """
-        return self.axes.spectral.all_world2pix(world_array, 0)[0]
+        with u.set_enabled_equivalencies(u.spectral()):
+            world_array=u.Quantity(world_array, unit=self.spectral_axis_unit)
+        return self.axes.spectral.all_world2pix(world_array.value, 0)[0]
 
     def pixel_to_world(self, pixel_array):
         """

--- a/specutils/wcs/adapters/fitswcs_adapter.py
+++ b/specutils/wcs/adapters/fitswcs_adapter.py
@@ -46,7 +46,7 @@ class FITSWCSAdapter(WCSAdapter):
         Method for performing the world to pixel transformations.
         """
         with u.set_enabled_equivalencies(u.spectral()):
-            world_array=u.Quantity(world_array, unit=self.spectral_axis_unit)
+            world_array = u.Quantity(world_array, unit=self.spectral_axis_unit)
         return self.axes.spectral.all_world2pix(world_array.value, 0)[0]
 
     def pixel_to_world(self, pixel_array):


### PR DESCRIPTION
This changes the functionality so that a SpectralRegion that is out of bounds of the Spectrum1D will return an empty Spectrum1D object (as opposed to None).  Any other exceptions are raised and passed through so the callers will need to catch the exceptions and deal with them appropriately.

Fixes #367 
Fixes https://github.com/spacetelescope/specviz/issues/471