### PR TITLE
FITS WCS deepcopy fix

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -55,15 +55,15 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         if flux is not None and not isinstance(flux, u.Quantity):
             raise ValueError("Flux must be a `Quantity` object.")
 
-        # Insure that the unit information codified in the quantity object is
-        # the One True Unit.
-        kwargs.setdefault('unit', flux.unit if isinstance(flux, u.Quantity)
-                                            else kwargs.get('unit'))
-
         # In cases of slicing, new objects will be initialized with `data`
         # instead of `flux`. Ensure we grab the `data` argument.
         if flux is None and 'data' in kwargs:
             flux = kwargs.pop('data')
+
+        # Ensure that the unit information codified in the quantity object is
+        # the One True Unit.
+        kwargs.setdefault('unit', flux.unit if isinstance(flux, u.Quantity)
+                                            else kwargs.get('unit'))
 
         # Attempt to parse the spectral axis. If none is given, try instead to
         # parse a given wcs. This is put into a GWCS object to

--- a/specutils/wcs/adapters/fitswcs_adapter.py
+++ b/specutils/wcs/adapters/fitswcs_adapter.py
@@ -41,6 +41,14 @@ class FITSWCSAdapter(WCSAdapter):
         """Pass slicing information to the internal `FITSWCS` object."""
         return self.wcs[item]
 
+    def __deepcopy__(self, *args, **kwargs):
+        """
+        Ensure deepcopy is passed through to the underlying fits wcs object.
+        Doing so allows for proper memoization handling in the astropy fits
+        machinery.
+        """
+        return self.__class__(self.wcs.__deepcopy__(*args, **kwargs))
+
     def world_to_pixel(self, world_array):
         """
         Method for performing the world to pixel transformations.


### PR DESCRIPTION
This fixes a deep copying issue in which the adapter class was interfering with the underlying fits wcs copy handling.