### PR TITLE
Allow tests that perform remote data access to be disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES='gwcs scipy matplotlib'
         - EVENT_TYPE='pull_request push'
-        - CONDA_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='pytest-remotedata'
         - CONDA_CHANNELS='astropy-ci-extras'
 
         # If there are matplotlib or other GUI tests, uncomment the following

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,10 @@ minversion = 3.1
 testpaths = "specutils" "docs"
 norecursedirs = build docs/_build
 doctest_plus = enabled
+remote_data_strict = True
+# The remote data tests will run by default. Passing --remote-data=none on the
+# command line will override this setting.
+addopts = --remote-data=any
 
 [ah_bootstrap]
 auto_use = True

--- a/specutils/tests/conftest.py
+++ b/specutils/tests/conftest.py
@@ -11,6 +11,11 @@ def remote_data_path(request):
     Remotely access the Zenodo deposition archive to retrieve the versioned
     test data.
     """
+    # Make use of configuration option from pytest-remotedata in order to
+    # control access to remote data.
+    if request.config.getoption('remote_data', 'any') != 'any':
+        pytest.skip()
+
     file_id, file_name = request.param.values()
 
     url = "https://zenodo.org/record/{}/files/{}?download=1".format(

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -103,6 +103,7 @@ def test_hst_stis(remote_data_path):
     assert spec.flux.size > 0
 
 
+@pytest.mark.remote_data
 def test_sdss_spec():
     with urllib.request.urlopen('https://dr14.sdss.org/optical/spectrum/view/data/format%3Dfits/spec%3Dlite?mjd=55359&fiberid=596&plateid=4055') as response:
         with tempfile.NamedTemporaryFile() as tmp_file:
@@ -114,6 +115,7 @@ def test_sdss_spec():
             assert spec.flux.size > 0
 
 
+@pytest.mark.remote_data
 def test_sdss_spspec():
     with urllib.request.urlopen('http://das.sdss.org/spectro/1d_26/0273/1d/spSpec-51957-0273-016.fit') as response:
         with tempfile.NamedTemporaryFile() as tmp_file:


### PR DESCRIPTION
This makes use of the [pytest-remotedata](https://github.com/astropy/pytest-remotedata) plugin in order to control tests that require access to remote data. By default all tests will run, including those that access remote data. To disable this, pass `--remote-data=none` to the `pytest` command.

This means that `pytest-remotedata` is now a test dependency.

This resolves #399. cc @olebole