### PR TITLE
Fix excisor bounds

### DIFF
--- a/specutils/manipulation/utils.py
+++ b/specutils/manipulation/utils.py
@@ -51,7 +51,7 @@ def linear_exciser(spectrum, region):
 
     flux = spectrum.flux.value
     modified_flux = flux
-    modified_flux[s:e] = np.linspace(flux[s], flux[e], len(inclusive_indices)+1)
+    modified_flux[s:e] = np.linspace(flux[s], flux[e], modified_flux[s:e].size)
 
     # Return a new object with the regions excised.
     return Spectrum1D(flux=modified_flux*spectrum.flux.unit,

--- a/specutils/manipulation/utils.py
+++ b/specutils/manipulation/utils.py
@@ -47,7 +47,8 @@ def linear_exciser(spectrum, region):
     # linear range
     #
 
-    s, e = max(inclusive_indices[0]-1, 0), inclusive_indices[-1]+1
+    s, e = max(inclusive_indices[0]-1, 0), min(inclusive_indices[-1]+1,
+                                               wavelengths.size-1)
 
     flux = spectrum.flux.value
     modified_flux = flux

--- a/specutils/manipulation/utils.py
+++ b/specutils/manipulation/utils.py
@@ -47,7 +47,7 @@ def linear_exciser(spectrum, region):
     # linear range
     #
 
-    s, e = inclusive_indices[0]-1, inclusive_indices[-1]+1
+    s, e = max(inclusive_indices[0]-1, 0), inclusive_indices[-1]+1
 
     flux = spectrum.flux.value
     modified_flux = flux

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -170,5 +170,5 @@ def test_linear_excise_invert_from_spectrum():
 
     excised_spec = linear_exciser(spec, exc_regs)
 
-    assert quantity_allclose(np.diff(excised_spec[50:61].flux), 0.00854853)
-    assert quantity_allclose(np.diff(excised_spec[80:91].flux), 0.00854853)
+    assert quantity_allclose(np.diff(excised_spec[50:61].flux), 0.00854853 * u.Jy)
+    assert quantity_allclose(np.diff(excised_spec[80:91].flux), 0.00854853 * u.Jy)

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -170,5 +170,7 @@ def test_linear_excise_invert_from_spectrum():
 
     excised_spec = linear_exciser(spec, exc_regs)
 
-    assert quantity_allclose(np.diff(excised_spec[50:61].flux), 0.00854853 * u.Jy)
-    assert quantity_allclose(np.diff(excised_spec[80:91].flux), 0.00854853 * u.Jy)
+    assert quantity_allclose(np.diff(excised_spec[50:60].flux),
+                             np.diff(excised_spec[51:61].flux))
+    assert quantity_allclose(np.diff(excised_spec[80:90].flux),
+                             np.diff(excised_spec[81:91].flux))

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -7,6 +7,7 @@ from astropy.tests.helper import quantity_allclose
 
 from ..spectra import Spectrum1D, SpectralRegion
 from ..manipulation import extract_region
+from ..manipulation.utils import linear_exciser
 from .spectral_examples import simulated_spectra
 
 
@@ -157,6 +158,17 @@ def test_extract_region_mismatched_units():
 
     extracted = extract_region(spectrum, region)
 
-    print(extracted.flux)
-
     assert quantity_allclose(extracted.flux, [10, 11]*u.Jy)
+
+
+def test_linear_excise_invert_from_spectrum():
+    spec = Spectrum1D(flux=np.random.sample(100) * u.Jy,
+                      spectral_axis=np.arange(100) * u.AA)
+    inc_regs = SpectralRegion(80 * u.AA, 90 * u.AA) + \
+               SpectralRegion(50 * u.AA, 60 * u.AA)
+    exc_regs = inc_regs.invert_from_spectrum(spec)
+
+    excised_spec = linear_exciser(spec, exc_regs)
+
+    assert quantity_allclose(np.diff(excised_spec[50:61].flux), 0.00854853)
+    assert quantity_allclose(np.diff(excised_spec[80:91].flux), 0.00854853)


### PR DESCRIPTION
Minor fix to bounds in excised region.

Example of bug:

```python
In [23]: from specutils import SpectralRegion

In [24]: from specutils.fitting import fit_generic_continuum

In [25]: spec = Spectrum1D(flux=np.random.sample(100) * u.Jy, spectral_axis=np.arange(100) * u.AA)

In [26]: inc_regs = SpectralRegion(80 * u.AA, 90 * u.AA) + SpectralRegion(50 * u.AA, 60 * u.AA)

In [27]: exc_regs = inc_regs.invert_from_spectrum(spec)

In [28]: cont_mod = fit_generic_continuum(spec, exclude_regions=exc_regs)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-28-a7adc8495e39> in <module>()
----> 1 cont_mod = fit_generic_continuum(spec, exclude_regions=exc_regs)

~/projects/specutils/specutils/fitting/continuum.py in fit_generic_continuum(spectrum, median_window, model, fitter, exclude_regions, weights)
     55     #
     56
---> 57     return fit_continuum(spectrum_smoothed, model, fitter, exclude_regions, weights)
     58
     59

~/projects/specutils/specutils/fitting/continuum.py in fit_continuum(spectrum, model, fitter, exclude_regions, window, weights)
     95     #
     96
---> 97     continuum_spectrum = fit_lines(spectrum, model, fitter, exclude_regions, weights)
     98
     99     return continuum_spectrum

~/projects/specutils/specutils/fitting/fitmodels.py in fit_lines(spectrum, model, fitter, exclude_regions, weights, window, **kwargs)
     64
     65     if exclude_regions is not None:
---> 66         spectrum = excise_regions(spectrum, exclude_regions)
     67
     68     #

~/projects/specutils/specutils/manipulation/utils.py in excise_regions(spectrum, regions, exciser)
    102
    103     for region in regions:
--> 104         spectrum = excise_region(spectrum, region, exciser)
    105
    106     return spectrum

~/projects/specutils/specutils/manipulation/utils.py in excise_region(spectrum, region, exciser)
    150     #
    151
--> 152     return exciser(spectrum, region)

~/projects/specutils/specutils/manipulation/utils.py in linear_exciser(spectrum, region)
     52     flux = spectrum.flux.value
     53     modified_flux = flux
---> 54     modified_flux[s:e] = np.linspace(flux[s], flux[e], len(inclusive_indices)+1)
     55
     56     # Return a new object with the regions excised.

ValueError: could not broadcast input array from shape (51) into shape (0)

In [29]:
```