### PR TITLE
Prevent errors from identifier functions for loaders

### DIFF
--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -37,6 +37,19 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
         Set the priority of the loader. Currently influences the sorting of the
         returned loaders for a dtype.
     """
+    def identifier_wrapper(ident):
+        def wrapper(*args, **kwargs):
+            '''In case the identifier function raises an exception, log that and continue'''
+            try:
+                return ident(*args, **kwargs)
+            except Exception as e:
+                logging.debug("Tried to read this as {} file, but could not.".format(label))
+                logging.debug(e, exc_info=True)
+                return False
+        return wrapper
+
+    identifier = identifier_wrapper(identifier)
+
     def decorator(func):
         io_registry.register_reader(label, dtype, func)
 


### PR DESCRIPTION
A well-written identifier function will return `True` or `False`.
However, the existing identifier functions often make assumptions
about the file which may be wrong, e.g. they check the fits header
keyword "TELESCOP" and fail with a `KeyError` when that keyword does
not exist or the file is not valid fits.
The correct return would be `False`, as in "this is not a file
I can read", which then allows the registry to try the next format.

This fixes the problem for the existing default reader and adds a
test.