### PR TITLE
Extend list of hacks for reading non-standard complied 1d WCS fits files

### DIFF
--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -49,7 +49,7 @@ def test_spectrumlist_GMOSfits(remote_data_path, caplog):
 
     logmsg = caplog.record_tuples[0]
     assert logmsg[1] == logging.WARN
-    assert "Assuming the axis 0 labelled 'linear' is spectral" in logmsg[2]
+    assert "Assuming the axis 0 labeled 'linear' is spectral" in logmsg[2]
 
 
 
@@ -70,7 +70,7 @@ def test_ctypye_not_compliant(remote_data_path, caplog):
                                    format='wcs1d-fits')
     logmsg = caplog.record_tuples[0]
     assert logmsg[1] == logging.WARN
-    assert "Assuming the axis 0 labelled 'wavelength' is spectral" in logmsg[2]
+    assert "Assuming the axis 0 labeled 'wavelength' is spectral" in logmsg[2]
 
 
 def test_generic_ecsv_reader(tmpdir):

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import tempfile
@@ -36,7 +37,7 @@ def test_spectrum1d_GMOSfits(remote_data_path):
 
 
 @remote_access([{'id': '1481190', 'filename': 'L5g_0355+11_Cruz09.fits'}])
-def test_spectrumlist_GMOSfits(remote_data_path):
+def test_spectrumlist_GMOSfits(remote_data_path, caplog):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', (VerifyWarning, UnitsWarning))
         spectrum_list = SpectrumList.read(remote_data_path, format='wcs1d-fits')
@@ -45,6 +46,11 @@ def test_spectrumlist_GMOSfits(remote_data_path):
 
     spec = spectrum_list[0]
     assert len(spec.data) == 3020
+
+    logmsg = caplog.record_tuples[0]
+    assert logmsg[1] == logging.WARN
+    assert "Assuming the axis 0 labelled 'linear' is spectral" in logmsg[2]
+
 
 
 @remote_access([{'id': '1481190', 'filename': 'L5g_0355+11_Cruz09.fits'}])
@@ -56,6 +62,15 @@ def test_specific_spec_axis_unit(remote_data_path):
                                        format='wcs1d-fits')
 
     assert optical_spec.spectral_axis.unit == "Angstrom"
+
+@remote_access([{'id': '2656720', 'filename': '_v1410ori_20181204_261_Forrest%20Sims.fit'}])
+def test_ctypye_not_compliant(remote_data_path, caplog):
+    optical_spec = Spectrum1D.read(remote_data_path,
+                                   spectral_axis_unit="Angstrom",
+                                   format='wcs1d-fits')
+    logmsg = caplog.record_tuples[0]
+    assert logmsg[1] == logging.WARN
+    assert "Assuming the axis 0 labelled 'wavelength' is spectral" in logmsg[2]
 
 
 def test_generic_ecsv_reader(tmpdir):

--- a/specutils/wcs/adapters/fitswcs_adapter.py
+++ b/specutils/wcs/adapters/fitswcs_adapter.py
@@ -4,7 +4,6 @@ from astropy.wcs import (WCS, WCSSUB_CELESTIAL, WCSSUB_CUBEFACE,
                          WCSSUB_LATITUDE, WCSSUB_LONGITUDE, WCSSUB_SPECTRAL,
                          WCSSUB_STOKES, InvalidSubimageSpecificationError)
 
-from astropy.utils.exceptions import AstropyUserWarning
 # Use this once in specutils
 from ...utils.wcs_utils import (convert_spectral_axis,
                                 determine_ctype_from_vconv)
@@ -86,7 +85,7 @@ class FITSWCSAdapter(WCSAdapter):
             for n in self.substitute_spec_axis_names:
                 if n in ctypelist:
                     self._spec_axis = ctypelist.index(n)
-                    logging.warning("WCS has a non-standards spectral axis, 'ctype's might be incorrect. Assuming the axis {} labelled '{}' is spectral and proceeding.".format(self._spec_axis, n))
+                    logging.warning("WCS has a non-standard spectral axis, 'ctype's might be incorrect. Assuming the axis {} labeled '{}' is spectral and proceeding.".format(self._spec_axis, n))
                     break
             else:
                 raise InvalidSubimageSpecificationError(


### PR DESCRIPTION
In the current code, there is a hack to allow "LINEAR" as a spectral
axis. That's clearly not compliant with the FITS WCS standard as defined in
https://www.aanda.org/articles/aa/full/2006/05/aa3818-05/aa3818-05.html
and might just be motivated by the GMOS spectrum currently used as
example for this loader (@kelle ?).
This code change makes this list of keywords that will be treated as
spectral extensible and adds "Wavelength" (which is much closer to
"WAVE" as required in the standard than "LINEAR").

Tests and docs are still missing, but those are easy to add once we agree on this approach.