### PR TITLE
Restore missing import of pytest in loader test

### DIFF
--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -3,6 +3,8 @@ import tempfile
 import urllib
 import warnings
 
+import pytest
+
 import astropy.units as u
 import numpy as np
 from astropy.io.fits.verify import VerifyWarning


### PR DESCRIPTION
This fixes a bug that was introduced when merging #401.