### PR TITLE
Intial changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,27 @@
+
+0.5.1 (unreleased)
+------------------
+
+API Changes
+^^^^^^^^^^^
+
+New Features
+^^^^^^^^^^^^
+
+Bug Fixes
+^^^^^^^^^
+
+- Fixed a bug in using spectral regions that have been inverted. [#403]
+
+- (the remote data one)
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+0.5 (2018-11-21)
+----------------
+
+This was the first release of specutils executing the
+[APE14](https://github.com/astropy/astropy-APEs/blob/master/APE14.rst)
+plan (i.e. the "new" specutils) and therfore intended for broad use.


### PR DESCRIPTION
An initial cut at the changelog.  This means we need to start adding changelog entries for each PR.

We may want to experiment with [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/quickstart.html), but to get something in for 0.5.1 this format should do the trick.