### PR TITLE
Fix a few typos / missing references in the docs

### DIFF
--- a/docs/spectral_regions.rst
+++ b/docs/spectral_regions.rst
@@ -87,6 +87,7 @@ maximum of the upper bounds:
     <Quantity 0.8 um>
 
 One can also delete a sub-region:
+
 .. code-block:: python
 
     >>> from astropy import units as u

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -22,7 +22,7 @@ def line_flux(spectrum, regions=None):
     spectrum : Spectrum1D
         The spectrum object over which the summed flux will be calculated.
 
-    regions : `~specutils.spectra.spectral_region.SpectralRegion` or list of `~specutils.spectra.spectral_region.SpectralRegion`
+    regions : `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
         Region within the spectrum to calculate the gaussian sigma width. If
         regions is `None`, computation is performed over entire spectrum.
 
@@ -52,7 +52,7 @@ def equivalent_width(spectrum, continuum=1, regions=None):
     spectrum : Spectrum1D
         The spectrum object overwhich the equivalent width will be calculated.
 
-    regions: `~specutils.spectra.spectral_region.SpectralRegion` or list of `~specutils.spectra.spectral_region.SpectralRegion`
+    regions: `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
         Region within the spectrum to calculate the gaussian sigma width. If
         regions is `None`, computation is performed over entire spectrum.
 

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -22,7 +22,7 @@ def line_flux(spectrum, regions=None):
     spectrum : Spectrum1D
         The spectrum object over which the summed flux will be calculated.
 
-    regions: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    regions : `~specutils.spectra.spectral_region.SpectralRegion` or list of `~specutils.spectra.spectral_region.SpectralRegion`
         Region within the spectrum to calculate the gaussian sigma width. If
         regions is `None`, computation is performed over entire spectrum.
 
@@ -52,7 +52,7 @@ def equivalent_width(spectrum, continuum=1, regions=None):
     spectrum : Spectrum1D
         The spectrum object overwhich the equivalent width will be calculated.
 
-    regions: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    regions: `~specutils.spectra.spectralregion.SpectralRegion` or list of `~specutils.spectra.spectralregion.SpectralRegion`
         Region within the spectrum to calculate the gaussian sigma width. If
         regions is `None`, computation is performed over entire spectrum.
 

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -52,7 +52,7 @@ def equivalent_width(spectrum, continuum=1, regions=None):
     spectrum : Spectrum1D
         The spectrum object overwhich the equivalent width will be calculated.
 
-    regions: `~specutils.spectra.spectralregion.SpectralRegion` or list of `~specutils.spectra.spectralregion.SpectralRegion`
+    regions: `~specutils.spectra.spectral_region.SpectralRegion` or list of `~specutils.spectra.spectral_region.SpectralRegion`
         Region within the spectrum to calculate the gaussian sigma width. If
         regions is `None`, computation is performed over entire spectrum.
 

--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -17,10 +17,10 @@ class SpectralRegion:
     Parameters
     ----------
 
-    lower: Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
+    lower : Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
        The lower bound of the region.
 
-    upper: Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
+    upper : Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
        The upper bound of the region.
 
     Notes
@@ -38,10 +38,10 @@ class SpectralRegion:
         Parameters
         ----------
 
-        center: Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
+        center : Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
            The center of the spectral region.
 
-        Width: Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
+        width : Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
            The width of the spectral region.
         """
 
@@ -227,15 +227,15 @@ class SpectralRegion:
         Parameters
         ----------
 
-        lower: Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
+        lower : Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
            The lower bound of the region.
 
-        upper: Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
+        upper : Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
            The upper bound of the region.
 
         Returns
         -------
-        spectral_region: `~specutils.SpectralRegion`
+        spectral_region : `~specutils.SpectralRegion`
            Spectral region of the non-selected regions
 
         Notes


### PR DESCRIPTION
I build the Sphinx docs locally and checked that the links are rendered correctly.