### PR TITLE
Explain how to make a continuum normalized spectrum

### DIFF
--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -666,6 +666,10 @@ convenience functions to perform exactly this task.  An example is shown below.
     plt.title('Continuum Fitting')
     plt.grid('on')
 
+    # construct normalized spectrum by dividing the old spectrum
+    # by the continuum
+    spec_normalized = spectrum / y_continuum_fitted
+
 
 Reference/API
 -------------

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -637,6 +637,7 @@ convenience functions to perform exactly this task.  An example is shown below.
 .. plot::
     :include-source:
     :align: center
+    :context: close-figs
 
     import numpy as np
     import matplotlib.pyplot as plt
@@ -666,11 +667,21 @@ convenience functions to perform exactly this task.  An example is shown below.
     plt.title('Continuum Fitting')
     plt.grid('on')
 
-    # construct normalized spectrum by dividing the old spectrum
-    # by the continuum
+The normalized spectrum is simply the old spectrum devided by the
+fitted continuum, which returns a new object:
+
+.. plot::
+    :include-source:
+    :align: center
+    :context: close-figs
+
     spec_normalized = spectrum / y_continuum_fitted
 
+    plt.plot(spec_normalized.spectral_axis, spec_normalized.flux)
+    plt.title('Continuum normalized spectrum')
+    plt.grid('on')
 
+    
 Reference/API
 -------------
 


### PR DESCRIPTION
In the fitting section, the docs talk quite a bit about how continuum
normalized spectra are useful and how the tools help to make them.
However, it is not shown how to actually normalize the spectrum.
I opened #415 because I could not find the answer after experimenting.
This doc change adds a simple example.