### PR TITLE
Fix Gaussian Parameter estimation

### DIFF
--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -157,8 +157,8 @@ Then estimate the line  parameters it it for a Gaussian line profile::
       Parameters:
               amplitude            mean             stddev
                   Jy                um                um
-          ------------------ ---------------- ------------------
-          1.1845669151078486 4.57517271067525 0.3199324375933905
+          ------------------ ---------------- -------------------
+          1.1845669151078486 4.57517271067525 0.19373372929165977
 
 
 If an `~astropy.modeling.Model` is used that does not have the predefined
@@ -681,7 +681,7 @@ fitted continuum, which returns a new object:
     plt.title('Continuum normalized spectrum')
     plt.grid('on')
 
-    
+
 Reference/API
 -------------
 

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -8,7 +8,7 @@ import astropy.units as u
 from astropy.stats import sigma_clipped_stats
 
 from ..manipulation.utils import excise_regions
-from ..analysis import fwhm, centroid, warn_continuum_below_threshold
+from ..analysis import fwhm, gaussian_sigma_width, centroid, warn_continuum_below_threshold
 from ..utils import QuantityModel
 from ..manipulation import extract_region, noise_region_uncertainty
 from ..spectra.spectral_region import SpectralRegion
@@ -30,7 +30,7 @@ _parameter_estimators = {
     'Gaussian1D': {
         'amplitude': lambda s: max(s.flux),
         'mean': lambda s: centroid(s, region=None),
-        'stddev': lambda s: fwhm(s)
+        'stddev': lambda s: gaussian_sigma_width(s)
     },
     'Lorentz1D': {
         'amplitude': lambda s: max(s.flux),

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -110,7 +110,7 @@ def test_single_peak_estimate():
 
     assert np.isclose(g_init.amplitude.value, 3., rtol=.2)
     assert np.isclose(g_init.mean.value, 6.3, rtol=.1)
-    assert np.isclose(g_init.stddev.value, 0.8, rtol=.1)
+    assert np.isclose(g_init.stddev.value, 0.8, rtol=.3)
 
     assert g_init.amplitude.unit == u.Jy
     assert g_init.mean.unit == u.um

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -101,13 +101,16 @@ def test_single_peak_estimate():
 
     #
     # Estimate parameter Gaussian1D
+    # we give the true values for the Gaussian because it actually *should*
+    # be pretty close to the true values, because it's a Gaussian...
     #
 
     g_init = estimate_line_parameters(s_single, models.Gaussian1D())
 
-    assert np.isclose(g_init.amplitude.value, 3.354169257846847)
-    assert np.isclose(g_init.mean.value, 6.218588636687762)
-    assert np.isclose(g_init.stddev.value, 1.6339001193853715)
+
+    assert np.isclose(g_init.amplitude.value, 3., rtol=.2)
+    assert np.isclose(g_init.mean.value, 6.3, rtol=.1)
+    assert np.isclose(g_init.stddev.value, 0.8, rtol=.1)
 
     assert g_init.amplitude.unit == u.Jy
     assert g_init.mean.unit == u.um
@@ -115,6 +118,9 @@ def test_single_peak_estimate():
 
     #
     # Estimate parameter Lorentz1D
+    # unlike the Gaussian1D here we do hand-picked comparison values, because
+    # the "single peak" is a Gaussian and therefore the Lorentzian fit shouldn't
+    # be quite right anyway
     #
 
     g_init = estimate_line_parameters(s_single, models.Lorentz1D())


### PR DESCRIPTION
While doing some tests with specutils I noticed that the Gaussian parameter estimator has a bug where the `FWHM` estimator function is interpreted as a sigma (i.e., it's off by a factor of ~2.3). While the fix could have just been to rescale the FWHM to a sigma, I think for the Gaussian it makes more sense to use the `gaussian_sigma_width` estimator, which is specifically meant for Gaussians, so seems reasonably applicable.  

This PR implements that.