### PR TITLE
Make sure all automatically created SpectrumList readers also have identifiers

### DIFF
--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -77,6 +77,7 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
             load_spectrum_list.priority = priority
 
             io_registry.register_reader(label, SpectrumList, load_spectrum_list)
+            io_registry.register_identifier(label, SpectrumList, identifier)
             logging.debug("Created SpectrumList reader for \"{}\".".format(label))
 
         @wraps(func)

--- a/specutils/tests/test_io.py
+++ b/specutils/tests/test_io.py
@@ -5,6 +5,7 @@ This module tests SpecUtils io routines
 """
 
 from ..io.parsing_utils import generic_spectrum_from_table # or something like that
+from astropy.io import registry
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.tests.helper import catch_warnings
@@ -12,6 +13,9 @@ import astropy.units as u
 import numpy as np
 import pytest
 import warnings
+
+from specutils import SpectrumList
+
 
 def test_generic_spectrum_from_table(recwarn):
     """
@@ -61,3 +65,9 @@ def test_generic_spectrum_from_table(recwarn):
     with pytest.raises(IOError) as exc:
         spectrum = generic_spectrum_from_table(table)
         assert 'Could not identify column containing the wavelength, frequency or energy' in exc
+
+
+def test_speclist_autoidentify():
+
+    formats = registry.get_formats(SpectrumList)
+    assert (formats['Auto-identify'] == 'Yes').all()


### PR DESCRIPTION
This is a bug and is causing problems in `specviz` (see https://github.com/spacetelescope/specviz/issues/618). The result was that `SpectrumList` readers that are automatically created by `specutils` were sometimes being used to load invalid files since they didn't have an associated identifier.