### PR TITLE
Fix bug in creation of default identifiers for data loaders

### DIFF
--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -59,7 +59,7 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
                              "explicit identifier. Creating identifier using "
                              "list of compatible extensions".format(
                                  label, dtype.__name__))
-                id_func = lambda *args, **kwargs: any([args[0].endswith(x)
+                id_func = lambda *args, **kwargs: any([args[1].endswith(x)
                                                           for x in extensions])
             # Otherwise, create a dummy identifier
             else:

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -66,7 +66,7 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
                 logging.warning("'{}' data loader provided for {} without "
                              "explicit identifier or list of compatible "
                              "extensions".format(label, dtype.__name__))
-                id_func = lambda *args, **kwargs: False
+                id_func = lambda *args, **kwargs: True
         else:
             id_func = identifier_wrapper(identifier)
 

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -55,10 +55,17 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
             # If the identifier is not defined, but the extensions are, create
             # a simple identifier based off file extension.
             if extensions is not None:
+                logging.info("'{}' data loader provided for {} without "
+                             "explicit identifier. Creating identifier using "
+                             "list of compatible extensions".format(
+                                 label, dtype.__name__))
                 id_func = lambda *args, **kwargs: any([args[0].endswith(x)
                                                           for x in extensions])
             # Otherwise, create a dummy identifier
             else:
+                logging.warning("'{}' data loader provided for {} without "
+                             "explicit identifier or list of compatible "
+                             "extensions".format(label, dtype.__name__))
                 id_func = lambda *args, **kwargs: False
         else:
             id_func = identifier_wrapper(identifier)

--- a/specutils/tests/test_io.py
+++ b/specutils/tests/test_io.py
@@ -14,7 +14,8 @@ import numpy as np
 import pytest
 import warnings
 
-from specutils import SpectrumList
+from specutils import Spectrum1D, SpectrumList
+from specutils.io import data_loader
 
 
 def test_generic_spectrum_from_table(recwarn):
@@ -71,3 +72,29 @@ def test_speclist_autoidentify():
 
     formats = registry.get_formats(SpectrumList)
     assert (formats['Auto-identify'] == 'Yes').all()
+
+
+def test_default_identifier(tmpdir):
+
+    fname = str(tmpdir.join('empty.txt'))
+    with open(fname, 'w') as ff:
+        ff.write('\n')
+
+    format_name = 'default_identifier_test'
+
+    @data_loader(format_name)
+    def reader(*args, **kwargs):
+        """Doesn't actually get used."""
+        return
+
+    # Test Spectrum1D identifier
+    fmts = registry.identify_format('read', Spectrum1D, fname, None, [], {})
+    assert format_name in fmts
+
+    # Test SpectrumList identifier
+    fmts = registry.identify_format('read', SpectrumList, fname, None, [], {})
+    assert format_name in fmts
+
+    for datatype in [Spectrum1D, SpectrumList]:
+        registry.unregister_reader(format_name, datatype)
+        registry.unregister_identifier(format_name, datatype)

--- a/specutils/tests/test_io.py
+++ b/specutils/tests/test_io.py
@@ -87,14 +87,39 @@ def test_default_identifier(tmpdir):
         """Doesn't actually get used."""
         return
 
-    # Test Spectrum1D identifier
-    fmts = registry.identify_format('read', Spectrum1D, fname, None, [], {})
-    assert format_name in fmts
+    for datatype in [Spectrum1D, SpectrumList]:
+        fmts = registry.identify_format('read', datatype, fname, None, [], {})
+        assert format_name in fmts
 
-    # Test SpectrumList identifier
-    fmts = registry.identify_format('read', SpectrumList, fname, None, [], {})
-    assert format_name in fmts
+        # Clean up after ourselves
+        registry.unregister_reader(format_name, datatype)
+        registry.unregister_identifier(format_name, datatype)
+
+
+def test_default_identifier_extension(tmpdir):
+
+    good_fname = str(tmpdir.join('empty.fits'))
+    bad_fname = str(tmpdir.join('empty.txt'))
+
+    # Create test data files.
+    for name in [good_fname, bad_fname]:
+        with open(name, 'w') as ff:
+            ff.write('\n')
+
+    format_name = 'default_identifier_extension_test'
+
+    @data_loader(format_name, extensions=['fits'])
+    def reader(*args, **kwargs):
+        """Doesn't actually get used."""
+        return
 
     for datatype in [Spectrum1D, SpectrumList]:
+        fmts = registry.identify_format('read', datatype, good_fname, None, [], {})
+        assert format_name in fmts
+
+        fmts = registry.identify_format('read', datatype, bad_fname, None, [], {})
+        assert format_name not in fmts
+
+        # Clean up after ourselves
         registry.unregister_reader(format_name, datatype)
         registry.unregister_identifier(format_name, datatype)

--- a/specutils/tests/test_io.py
+++ b/specutils/tests/test_io.py
@@ -123,3 +123,36 @@ def test_default_identifier_extension(tmpdir):
         # Clean up after ourselves
         registry.unregister_reader(format_name, datatype)
         registry.unregister_identifier(format_name, datatype)
+
+
+def test_custom_identifier(tmpdir):
+
+    good_fname = str(tmpdir.join('good.txt'))
+    bad_fname = str(tmpdir.join('bad.txt'))
+
+    # Create test data files.
+    for name in [good_fname, bad_fname]:
+        with open(name, 'w') as ff:
+            ff.write('\n')
+
+    format_name = 'custom_identifier_test'
+
+    def identifier(origin, *args, **kwargs):
+        fname = args[0]
+        return 'good' in fname
+
+    @data_loader(format_name, identifier=identifier)
+    def reader(*args, **kwargs):
+        """Doesn't actually get used."""
+        return
+
+    for datatype in [Spectrum1D, SpectrumList]:
+        fmts = registry.identify_format('read', datatype, good_fname, None, [], {})
+        assert format_name in fmts
+
+        fmts = registry.identify_format('read', datatype, bad_fname, None, [], {})
+        assert format_name not in fmts
+
+        # Clean up after ourselves
+        registry.unregister_reader(format_name, datatype)
+        registry.unregister_identifier(format_name, datatype)


### PR DESCRIPTION
Prior to this PR, if no identifier or list of compatible extensions was provided to the `data_loader` decorator, then an invalid identifier would be created. This fixes that bug and also adds more informative output for these cases.

It's worth noting that `specviz` now expects all loaders to have identifiers. So if a user creates a custom loader that has neither an explicit identifier nor a list of compatible extensions, it will not be possible to load the associated files using `specviz`.

We may want to consider adding an optional argument to `data_loader` that automatically creates a dummy identifier that positively identifies all files.

Thanks @nluetzge for providing the original bug report.