### PR TITLE
Add better air to vacuum wavelength conversion

### DIFF
--- a/specutils/tests/test_utils.py
+++ b/specutils/tests/test_utils.py
@@ -1,10 +1,40 @@
+import pytest
+import numpy as np
 from astropy import units as u
 from astropy import modeling
 from specutils.utils import QuantityModel
+from ..utils.wcs_utils import refraction_index, vac_to_air, air_to_vac
 
+wavelengths = [300, 500, 1000] * u.nm
+data_index_refraction = {
+   'Griesen2006': np.array([3.07393068, 2.9434858 , 2.8925797 ]),
+   'Edlen1953': np.array([2.91557413, 2.78963801, 2.74148172]),
+   'Edlen1966': np.array([2.91554272, 2.7895973 , 2.74156098]),
+   'PeckReeder1972': np.array([2.91554211, 2.78960005, 2.74152561]),
+   'Morton2000': np.array([2.91568573, 2.78973402, 2.74169531]),
+   'Ciddor1996': np.array([2.91568633, 2.78973811, 2.74166131])
+}
 
 def test_quantity_model():
     c = modeling.models.Chebyshev1D(3)
     uc = QuantityModel(c, u.AA, u.km)
 
     assert uc(10*u.nm).to(u.m) == 0*u.m
+
+
+@pytest.mark.parametrize("method", data_index_refraction.keys())
+def test_refraction_index(method):
+    tmp = (refraction_index(wavelengths, method) - 1) * 1e4
+    assert np.isclose(tmp, data_index_refraction[method], atol=1e-7).all()
+
+
+@pytest.mark.parametrize("method", data_index_refraction.keys())
+def test_air_to_vac(method):
+    tmp = refraction_index(wavelengths, method)
+    assert np.isclose(wavelengths.value * tmp,
+                      air_to_vac(wavelengths, method=method, scheme='inversion').value,
+                      rtol=1e-6).all()
+    assert np.isclose(wavelengths.value,
+                      air_to_vac(vac_to_air(wavelengths, method=method),
+                                 method=method, scheme='iteration').value,
+                      atol=1e-12).all()

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -363,26 +363,177 @@ def cdelt_derivative(crval, cdelt, intype, outtype, linear=False, rest=None):
         raise ValueError("Invalid in/out frames")
 
 
-def air_to_vac(wavelength):
+def refraction_index(wavelength, method='Griesen2006', co2=None):
     """
-    Implements the air to vacuum wavelength conversion described in eqn 65 of
-    Griesen 2006
-    """
-    wlum = wavelength.to(u.um).value
-    return (1+1e-6*(287.6155+1.62887/wlum**2+0.01360/wlum**4)) * wavelength
+    Calculates the index of refraction of dry air at standard temperature
+    and pressure, at different wavelengths, using different methods.
 
-def vac_to_air(wavelength):
-    """
-    Griesen 2006 reports that the error in naively inverting Eqn 65 is less
-    than 10^-9 and therefore acceptable.  This is therefore eqn 67
-    """
-    wlum = wavelength.to(u.um).value
-    nl = (1+1e-6*(287.6155+1.62887/wlum**2+0.01360/wlum**4))
-    return wavelength/nl
+    Parameters
+    ----------
+    wavelength : `Quantity` object (number or sequence)
+        Vacuum wavelengths with an astropy.unit.
+    method : str, optional
+        Method used to convert wavelengths. Options are:
+        'Griesen2006' (default) - from Greisen et al. (2006, A&A 446, 747),
+            eqn. 65, standard used by International Unionof Geodesy and Geophysics
+        'Edlen1953' - from Edlen (1953, J. Opt. Soc. Am, 43, 339). Standard
+            adopted by IAU (resolution No. C15, Commission 44, XXI GA, 1991),
+            which refers to Oosterhoff (1957) that uses Edlen (1953). Also used
+            by Morton (1991, ApJS, 77, 119), which is frequently cited as IAU source.
+        'Edlen1966' - from Edlen (1966, Metrologia 2, 71), rederived constants
+            from optical and near UV data.
+        'PeckReeder1972' - from Peck & Reeder (1972, J. Opt. Soc. 62), derived
+            from additional infrared measurements (up to 1700 nm).
+        'Morton2000' - from Morton (2000, ApJS, 130, 403), eqn 8. Used by VALD,
+            the Vienna Atomic Line Database. Very similar to Edlen (1966).
+        'Ciddor1996' - from Ciddor (1996, Appl. Opt. 35, 1566). Based on
+            Peck & Reeder (1972), but updated to account for the changes in
+            the international temperature scale and adjust the results for
+            CO2 concentration. Arguably most accurate conversion available.
+    co2 : number, optional
+        CO2 concentration in ppm. Only used for method='Ciddor1996'. If not
+        given, a default concentration of 450 ppm is used.
 
-def air_to_vac_deriv(wavelength):
+    Returns
+    -------
+    refr : number or sequence
+        Index of refraction at each given air wavelength.
     """
-    Eqn 66 of Greisen 2006
+    VALID_METHODS = ['Griesen2006', 'Edlen1953', 'Edlen1966', 'Morton2000',
+                     'PeckReeder1972', 'Ciddor1996']
+    assert isinstance(method, str), 'method must be a string'
+    method = method.lower()
+    sigma2 = (1 / wavelength.to(u.um).value)**2
+    if method == 'griesen2006':
+        refr = 1e-6 * (287.6155 + 1.62887 * sigma2 + 0.01360 * sigma2**2)
+    elif method == 'edlen1953':
+        refr = 6.4328e-5 + 2.94981e-2 / (146 - sigma2) + 2.5540e-4 / (41 - sigma2)
+    elif method == 'edlen1966':
+        refr = 8.34213e-5 + 2.406030e-2 / (130 - sigma2) + 1.5997e-4 / (38.9 - sigma2)
+    elif method == 'morton2000':
+        refr = 8.34254e-5 + 2.406147e-2 / (130 - sigma2) + 1.5998e-4 / (38.9 - sigma2)
+    elif method == 'peckreeder1972':
+        refr = 5.791817e-2 / (238.0185 - sigma2) + 1.67909e-3 / (57.362 - sigma2)
+    elif method == 'ciddor1996':
+        refr = 5.792105e-2 / (238.0185 - sigma2) + 1.67917e-3 / (57.362 - sigma2)
+        if co2:
+            refr *= 1 + 0.534e-6 * (co2 - 450)
+    else:
+        raise ValueError("Method must be one of " + ", ".join(VALID_METHODS))
+    return refr + 1
+
+
+def vac_to_air(wavelength, method='Griesen2006', co2=None):
     """
+    Converts vacuum to air wavelengths using different methods.
+
+    Parameters
+    ----------
+    wavelength : `Quantity` object (number or sequence)
+        Vacuum wavelengths with an astropy.unit.
+    method : str, optional
+        One of the methods in refraction_index().
+    co2 : number, optional
+        Atmospheric CO2 concentration in ppm. Only used for method='Ciddor1996'.
+        If not given, a default concentration of 450 ppm is used.
+
+    Returns
+    -------
+    air_wavelength : `Quantity` object (number or sequence)
+        Air wavelengths with the same unit as wavelength.
+    """
+    refr = refraction_index(wavelength, method=method, co2=co2)
+    return wavelength / refr
+
+
+def air_to_vac(wavelength, scheme='inversion', method='Griesen2006', co2=None,
+               precision=1e-12, maxiter=30):
+    """
+    Converts air to vacuum wavelengths using different methods.
+
+    Parameters
+    ----------
+    wavelength : `Quantity` object (number or sequence)
+        Air wavelengths with an astropy.unit.
+    scheme : str, optional
+        How the to convert from vacuum to air wavelengths. Options are:
+        'inversion' (default) - result is simply the inversion (1 / n) of the
+            refraction index of air. Griesen et al. (2006) report that the error
+            in naively inverting is less than 10^-9.
+        'Piskunov' - uses an analytical solution used derived by Nikolai Piskunov
+            and used by the Vienna Atomic Line Database (VALD).
+        'iteration' - uses an iterative scheme to invert the index of refraction.
+    method : str, optional
+        Only used if scheme is 'inversion' or 'iteration'. One of the methods
+        in refraction_index().
+    co2 : number, optional
+        Atmospheric CO2 concentration in ppm. Only used of scheme='inversion' and
+        method='Ciddor1996'. If not given, a default concentration of 450 ppm is used.
+    precision : float
+        Maximum fractional in refraction conversion beyond which iteration will
+        be stopped. Only used if scheme='iteration'.
+    maxiter : integer
+        Maximum number of iterations to run. Only used if scheme='iteration'.
+
+    Returns
+    -------
+    vac_wavelength : `Quantity` object (number or sequence)
+        Vacuum wavelengths with the same unit as wavelength.
+    """
+    VALID_SCHEMES = ['inversion', 'iteration', 'piskunov']
+    assert isinstance(scheme, str), 'scheme must be a string'
+    scheme = scheme.lower()
+    if scheme == 'inversion':
+        refr = refraction_index(wavelength, method=method, co2=co2)
+        #return wavelength * refr
+    elif scheme == 'piskunov':
+        wlum = wavelength.to(u.angstrom).value
+        sigma2 = (1e4 / wlum)**2
+        refr = (8.336624212083e-5 + 2.408926869968e-2 / (130.1065924522 - sigma2) +
+                1.599740894897e-4 / (38.92568793293 - sigma2)) + 1
+        #return wavelength * refr
+    elif scheme == 'iteration':
+        # Refraction index is a function of vacuum wavelengths.
+        # Iterate to get index of refraction that gives air wavelength that
+        # is consistent with the reverse transformation.
+        counter = 0
+        result = wavelength.copy()
+        refr = refraction_index(wavelength, method=method, co2=co2)
+        while True:
+            counter += 1
+            diff = wavelength * refr - result
+            if abs(diff.max().value) < precision:
+                break
+                #return wavelength * conv
+            if counter > maxiter:
+                raise RuntimeError("Reached maximum number of iterations "
+                                   "without reaching desired precision level.")
+            result += diff
+            refr = refraction_index(result, method=method, co2=co2)
+    else:
+        raise ValueError("Method must be one of " + ", ".join(VALID_SCHEMES))
+    return wavelength * refr
+
+
+def air_to_vac_deriv(wavelength, method='Griesen2006'):
+    """
+    Calculates the derivative d(wave_vacuum) / d(wave_air) using different
+    methods.
+
+    Parameters
+    ----------
+    wavelength : `Quantity` object (number or sequence)
+        Air wavelengths with an astropy.unit.
+    method : str, optional
+        Method used to convert wavelength derivative. Options are:
+        'Griesen2006' (default) - from Greisen et al. (2006, A&A 446, 747),
+            eqn. 66.
+
+    Returns
+    -------
+    wave_deriv : `Quantity` object (number or sequence)
+        Derivative d(wave_vacuum) / d(wave_air).
+    """
+    assert method.lower() == 'griesen2006', "Only supported method is 'Griesen2006'"
     wlum = wavelength.to(u.um).value
-    return (1+1e-6*(287.6155 - 1.62887/wlum**2 - 0.04080/wlum**4))
+    return (1 + 1e-6 * (287.6155 - 1.62887 / wlum**2 - 0.04080 / wlum**4))

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -456,21 +456,21 @@ def air_to_vac(wavelength, scheme='inversion', method='Griesen2006', co2=None,
     wavelength : `Quantity` object (number or sequence)
         Air wavelengths with an astropy.unit.
     scheme : str, optional
-        How the to convert from vacuum to air wavelengths. Options are:
+        How to convert from vacuum to air wavelengths. Options are:
         'inversion' (default) - result is simply the inversion (1 / n) of the
             refraction index of air. Griesen et al. (2006) report that the error
             in naively inverting is less than 10^-9.
-        'Piskunov' - uses an analytical solution used derived by Nikolai Piskunov
+        'Piskunov' - uses an analytical solution derived by Nikolai Piskunov
             and used by the Vienna Atomic Line Database (VALD).
         'iteration' - uses an iterative scheme to invert the index of refraction.
     method : str, optional
         Only used if scheme is 'inversion' or 'iteration'. One of the methods
         in refraction_index().
     co2 : number, optional
-        Atmospheric CO2 concentration in ppm. Only used of scheme='inversion' and
+        Atmospheric CO2 concentration in ppm. Only used if scheme='inversion' and
         method='Ciddor1996'. If not given, a default concentration of 450 ppm is used.
     precision : float
-        Maximum fractional in refraction conversion beyond which iteration will
+        Maximum fractional value in refraction conversion beyond at which iteration will
         be stopped. Only used if scheme='iteration'.
     maxiter : integer
         Maximum number of iterations to run. Only used if scheme='iteration'.
@@ -485,13 +485,11 @@ def air_to_vac(wavelength, scheme='inversion', method='Griesen2006', co2=None,
     scheme = scheme.lower()
     if scheme == 'inversion':
         refr = refraction_index(wavelength, method=method, co2=co2)
-        #return wavelength * refr
     elif scheme == 'piskunov':
         wlum = wavelength.to(u.angstrom).value
         sigma2 = (1e4 / wlum)**2
         refr = (8.336624212083e-5 + 2.408926869968e-2 / (130.1065924522 - sigma2) +
                 1.599740894897e-4 / (38.92568793293 - sigma2)) + 1
-        #return wavelength * refr
     elif scheme == 'iteration':
         # Refraction index is a function of vacuum wavelengths.
         # Iterate to get index of refraction that gives air wavelength that


### PR DESCRIPTION
Following the discussion at https://github.com/astropy/astropy/issues/8427, added new methods to convert from vacuum to air wavelengths. The new approach adds a `method` argument on `vac_to_air`, and uses a new function to calculate the index of refraction of air for given wavelengths. This makes it easier to add the data and formulation directly from the sources, avoiding any ambiguity. 

I also added different ways to calculate the inverse transformation (`air_to_vac`). Because the index of refraction depends on vacuum wavelengths, simply inverting the relation will introduce a small error, which can be significant for some applications. The new approach allows for three options: `inversion` - `1 / n`, same as before), `iteration` - iteratively solve for an index of refraction such that it is consistent with the inverse transform, within a certain user-defined  precision, and `piskunov` - following an approximate analytical expression derived by Nikolai Piskunov and [used in VALD](http://www.astro.uu.se/valdwiki/Air-to-vacuum%20conversion).

It can be debated if the wavelength conversion routines should be kept in the relatively obscure `utils.wcs_utils` or be put somewhere where a user could actually find them.

Another point is whether Greisen et al. (2006) should be set as the default method. I've kept it this way to ensure backwards compatibility, but I have strong reservations against using it for astronomical applications. See the notebook https://github.com/weaverba137/pydl/blob/master/docs/notebooks/Vacuum%20Wavelength%20Conversions.ipynb by @weaverba137  for some additional discussion on the methods. Greisen et al. (2006) differs significantly from all the methods used in astronomy over nearly a century. From my own experience, it also works very poorly in the UV (comparing vacuum and measured air wavelengths), and the authors themselves write that the expression only applies at 'normal optical wavelengths'. A few more points regarding the discussion in the notebook:

* Neither the Ciddor (1996) or Greisen et al. (2006) formulae have singularities below 200 nm. This is probably the wcslib implementation, and because historically the convention in spectroscopy is to not convert to air wavelengths below 200 nm (because the Earth's absorption is so high that they are unlikely to be observed from the ground). 
* The IAU standard (resolution No. C15, Commission 44, XXI GA, 1991) is to use the formula from Oosterhoff (1957), which in turn is just Edlen (1953). Sometimes people mention the IAU standard as following Morton (1991), but this is again just Edlen (1953).
* Ciddor (1996) should really be regarded as the better method. It works well in UV, optical, and infrared.
* More discussion in an [APOGEE Technical Note by Carlos Allende Prieto](http://www.as.utexas.edu/~hebe/apogee/docs/air_vacuum.pdf).