### PR TITLE
Add new module shift with gravitational redshift function

### DIFF
--- a/specutils/manipulation/shift.py
+++ b/specutils/manipulation/shift.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from astropy import constants
+from astropy import units as u
+
+
+def gravitational_redshift(solar=True, obj_mass=None, obj_radius=None,
+                           obj_distance=None):
+    """
+    Calculates the gravitational redshift z of a distant object
+    for an observer at Earth. Also includes the Earth's gravitational blueshift.
+
+    Parameters
+    ----------
+    solar : bool, optional
+        If True, will use the Sun as distant object so that mass, radius,
+        and distance are taken from constants and not needed as arguments.
+    obj_mass : `Quantity` object (number with mass units)
+        Mass of the distant object.
+    obj_radius: `Quantity` object (number with length units)
+        Radius of the distant object.
+    obj_distance: `Quantity` object (number with length units)
+        Distance from Earth to the distant object. Can be inf if unknown.
+
+    Returns
+    -------
+    grav_red : `Quantity` (dimensionless)
+        Gravitational redshift z. Convert to wavelength shift by multiplying
+        by reference wavelength, or to velocity by multiplying by the
+        speed of light.
+    """
+    if solar:
+        obj_mass = constants.M_sun
+        obj_radius = constants.R_sun
+        obj_distance = constants.au
+    else:
+        qtype = u.Quantity
+        assert all([isinstance(obj_mass, qtype),
+                    isinstance(obj_radius, qtype),
+                    isinstance(obj_distance, qtype)]), ("If object is not 'sun',"
+                      " mass, radius and distance must be given as Quantity.")
+        obj_mass = obj_mass.si
+        obj_radius = obj_radius.si
+        obj_distance = obj_distance.si
+    # Schwarzschild radii of object and Earth
+    r0 = constants.G * obj_mass / (constants.c ** 2)
+    r0_earth = constants.G * constants.M_earth / (constants.c ** 2)
+    shift_obj = (1 - r0 / obj_distance) / (1 - r0 / obj_radius)
+    shift_earth = (1 - r0_earth / obj_distance) / (1 - r0_earth / constants.R_earth)
+    return shift_obj - shift_earth

--- a/specutils/tests/test_shift.py
+++ b/specutils/tests/test_shift.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import numpy as np
+from astropy import constants as const
+
+from ..manipulation.shift import gravitational_redshift
+
+def test_gravitational_redshift():
+    assert np.isclose(gravitational_redshift(solar=True).value, 2.1119411024450585e-06)
+    zsolar = gravitational_redshift(solar=False, obj_mass=const.M_sun,
+                                    obj_radius=const.R_sun, obj_distance=const.au)
+    assert gravitational_redshift(solar=True) == zsolar
+    with pytest.raises(AssertionError):
+        gravitational_redshift(solar=False, obj_mass=1)


### PR DESCRIPTION
Here is a suggestion to add a new module `shift.py` inside `specutils.manipulation`. This can serve as a place to put functions to perform changes in the spectral axis. 

As a first function I added `gravitational_redshift`, to calculate the redshift due to gravity of a distant object. This is relevant for precision spectroscopy when comparing synthetic and observed spectra. The function assumes an observer on the surface of Earth, as I suspect it is of limited usefulness to make it general. But this should be straightforward to change, if needed. Currently the function only returns a scalar, but one can in the future write an interface for `Spectrum1D` or similar. 