### PR TITLE
WIP: first pass as expanding spectrum1d doc page to include spectrum_mixin

### DIFF
--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -126,7 +126,7 @@ common spectral axis.
 
     >>> spec = Spectrum1D(spectral_axis=np.arange(5000, 5010)*u.AA, flux=np.random.sample((5, 10))*u.Jy)
     >>> spec_slice = spec[0] #doctest:+SKIP
-    >>> spec_slice.wavelength #doctest:+SKIP
+    >>> spec_slice.spectral_axis #doctest:+SKIP
     <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] Angstrom>
     >>> spec_slice.flux #doctest:+SKIP
     <Quantity [0.72722821, 0.32147784, 0.70256482, 0.04445197, 0.03390352,

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -143,6 +143,7 @@ Reference/API
 
 .. automodapi:: specutils
     :no-main-docstr:
+    :inherited-members:
     :no-heading:
     :headings: -~
 

--- a/docs/spectrum_collection.rst
+++ b/docs/spectrum_collection.rst
@@ -36,9 +36,9 @@ solution.
     (5,)
     >>> spec_coll.flux.unit
     Unit("Jy")
-    >>> spec_coll.wavelength.shape
+    >>> spec_coll.spectral_axis.shape
     (5, 10)
-    >>> spec_coll.wavelength.unit
+    >>> spec_coll.spectral_axis.unit
     Unit("Angstrom")
 
 Collections from 1D spectra
@@ -67,7 +67,7 @@ a list of :class:`~specutils.Spectrum1D`:
     Unit("Jy")
     >>> spec_coll.wavelength.shape
     (2, 50)
-    >>> spec_coll.wavelength.unit
+    >>> spec_coll.spectral_axis.unit
     Unit("Angstrom")
 
 :class:`~specutils.SpectrumCollection` objects can be treated just like

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -51,6 +51,9 @@ class OneDSpectrumMixin:
 
     @property
     def spectral_wcs(self):
+        """
+        Returns the spectral axes of the WCS
+        """
         return self.wcs.axes.spectral
 
     @lazyproperty
@@ -132,6 +135,9 @@ class OneDSpectrumMixin:
 
     @property
     def velocity_convention(self):
+        """
+        Returns the velocity convention
+        """
         return self._velocity_convention
 
     def with_velocity_convention(self, velocity_convention):


### PR DESCRIPTION
Original reason for making this PR is #475

Here's what the spectrum1D API doc looks like after adding :inherited-members:

Are there some parameters in `spectrum_mixin` that we should make private? This resulted in quite a lot of attributes listed, some of which seem like they might not be user focused?