### PR TITLE
fix api changes with new modeling

### DIFF
--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -5,7 +5,6 @@ import logging
 import numpy as np
 from scipy.signal import convolve
 
-import astropy
 import astropy.units as u
 from astropy.stats import sigma_clipped_stats
 
@@ -81,19 +80,13 @@ def estimate_line_parameters(spectrum, model):
         Model with parameters estimated.
     """
 
-    #if not 'parameter_estimator' in model._constraints:
-        #model = _set_parameter_estimators(model)
     model = _set_parameter_estimators(model)
     # Estimate the parameters based on the estimators already
     # attached to the model
-    #if 'parameter_estimator' in model._constraints:
-        #for param, estimator in model._constraints['parameter_estimator'].items():
-            #setattr(model, param, estimator(spectrum))
     for name in model.param_names:
         par = getattr(model, name)
         try:
             estimator = getattr(par, "estimator")
-            #par.value = estimator(spectrum)
             setattr(model, name, estimator(spectrum))
         except AttributeError:
             raise Exception('No method to estimate parameter {}'.format(name))

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -4,6 +4,8 @@ import logging
 
 import numpy as np
 from scipy.signal import convolve
+
+import astropy
 import astropy.units as u
 from astropy.stats import sigma_clipped_stats
 
@@ -51,8 +53,10 @@ def _set_parameter_estimators(model):
     Helper method used in method below.
     """
     if model.__class__.__name__ in _parameter_estimators:
-        model._constraints['parameter_estimator'] = _parameter_estimators[
-            model.__class__.__name__]
+        model_pars = _parameter_estimators[model.__class__.__name__]
+        for name in model.param_names:
+            par = getattr(model, name)
+            setattr(par, "estimator", model_pars[name])
 
     return model
 
@@ -77,18 +81,22 @@ def estimate_line_parameters(spectrum, model):
         Model with parameters estimated.
     """
 
-    if not 'parameter_estimator' in model._constraints:
-        model = _set_parameter_estimators(model)
-
+    #if not 'parameter_estimator' in model._constraints:
+        #model = _set_parameter_estimators(model)
+    model = _set_parameter_estimators(model)
     # Estimate the parameters based on the estimators already
     # attached to the model
-    if 'parameter_estimator' in model._constraints:
-        for param, estimator in model._constraints['parameter_estimator'].items():
-            setattr(model, param, estimator(spectrum))
-
-    # No estimators.
-    else:
-        raise Exception('No method to estimate parameters')
+    #if 'parameter_estimator' in model._constraints:
+        #for param, estimator in model._constraints['parameter_estimator'].items():
+            #setattr(model, param, estimator(spectrum))
+    for name in model.param_names:
+        par = getattr(model, name)
+        try:
+            estimator = getattr(par, "estimator")
+            #par.value = estimator(spectrum)
+            setattr(model, name, estimator(spectrum))
+        except AttributeError:
+            raise Exception('No method to estimate parameter {}'.format(name))
 
     return model
 
@@ -604,8 +612,7 @@ def _strip_units_from_model(model_in, spectrum, convert=True):
     #
     # Determine if a compound model
     #
-
-    compound_model = model_in.n_submodels() > 1
+    compound_model = model_in.n_submodels > 1
 
     if not compound_model:
         # For this we are going to just make it a list so that we
@@ -615,8 +622,7 @@ def _strip_units_from_model(model_in, spectrum, convert=True):
         # If it is a compound model then we are going to create the RPN
         # representation of it which is a list that contains either astropy
         # models or string representations of operators (e.g., '+' or '*').
-        model_in = [c.value for c in model_in._tree.traverse_postorder()]
-
+        model_in = model_in.traverse_postorder(include_operator=True)
     #
     # Run through each model in the list or compound model
     #
@@ -713,15 +719,15 @@ def _add_units_to_model(model_in, model_orig, spectrum):
     # list so we can use the for loop below.
     #
 
-    compound_model = model_in.n_submodels() > 1
+    compound_model = model_in.n_submodels > 1
     if not compound_model:
         model_in_list = [model_in]
         model_orig_list = [model_orig]
     else:
         compound_model_in = model_in
 
-        model_in_list = [c.value for c in model_in._tree.traverse_postorder()]
-        model_orig_list = [c.value for c in model_orig._tree.traverse_postorder()]
+        model_in_list = model_in.traverse_postorder(include_operator=True)
+        model_orig_list = model_orig.traverse_postorder(include_operator=True)
 
     model_out_stack = []
     model_index = 0

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -4,6 +4,9 @@ import astropy.units as u
 from astropy.modeling import models
 from astropy.nddata import StdDevUncertainty
 
+from astropy.tests.helper import assert_quantity_allclose
+
+
 from ..spectra import Spectrum1D, SpectralRegion
 from ..fitting import (fit_lines, find_lines_derivative,
                        find_lines_threshold, estimate_line_parameters)
@@ -151,9 +154,12 @@ def test_single_peak_estimate():
     estimators = {
         'amplitude': lambda s: max(s.flux),
         'x_0': lambda s: centroid(s, region=None),
-        'stddev': lambda s: fwhm(s)
+        'sigma': lambda s: fwhm(s)
     }
-    mh._constraints['parameter_estimator'] = estimators
+    #mh._constraints['parameter_estimator'] = estimators
+    mh.amplitude.estimator = lambda s: max(s.flux)
+    mh.x_0.estimator = lambda s: centroid(s, region=None)
+    mh.sigma.estimator = lambda s: fwhm(s)
 
     g_init = estimate_line_parameters(s_single, mh)
 
@@ -163,7 +169,7 @@ def test_single_peak_estimate():
 
     assert g_init.amplitude.unit == u.Jy
     assert g_init.x_0.unit == u.um
-    assert g_init.stddev.unit == u.um
+    assert g_init.sigma.unit == u.um
 
 
 def test_single_peak_fit():
@@ -466,13 +472,13 @@ def test_fixed_parameters():
 
     g_fit = fit_lines(spectrum, g_init)
 
-    assert g_fit.mean == 6.1*u.um
+    assert_quantity_allclose(g_fit.mean, 6.1*u.um)
     assert g_fit.bounds == g_init.bounds
     assert g_fit.name == "Gaussian Test Model"
 
     # Test passing of tied parameter
-    g_init = models.Gaussian1D(amplitude=3.*u.Jy, mean=6.1*u.um, stddev=1.*u.um,
-                               tied={'mean': tie_center})
+    g_init = models.Gaussian1D(amplitude=3.*u.Jy, mean=6.1*u.um, stddev=1.*u.um)
+    g_init.mean.tied = tie_center
     g_fit = fit_lines(spectrum, g_init)
 
     assert g_fit.tied == g_init.tied

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -148,9 +148,9 @@ def test_single_peak_estimate():
 
 
     #
-    # Estimate parameter MexicanHat1D
+    # Estimate parameter RickerWavelet1D
     #
-    mh = models.MexicanHat1D()
+    mh = models.RickerWavelet1D
     estimators = {
         'amplitude': lambda s: max(s.flux),
         'x_0': lambda s: centroid(s, region=None),
@@ -165,7 +165,7 @@ def test_single_peak_estimate():
 
     assert np.isclose(g_init.amplitude.value, 3.354169257846847)
     assert np.isclose(g_init.x_0.value, 6.218588636687762)
-    assert np.isclose(g_init.stddev.value, 1.6339001193853715)
+    assert np.isclose(g_init.sigma.value, 1.6339001193853715)
 
     assert g_init.amplitude.unit == u.Jy
     assert g_init.x_0.unit == u.um


### PR DESCRIPTION
**DO NOT MERGE:** Requires astropy/astropy#8769 

The changes in this PR are necessary to work with the refactored modeling. They are also mostly fixing code implemented as work around issues with modeling. They are due to

- Model parameters now store their values and constraints (as opposed to storing these in the Model).
  The estimators are implemented now as parameter attributes.
- `Model.n_submodels` is now a property, not a method.

The changes here are not made to be backwards compatible. If backwards compatibility is important it can be added with a check for the astropy version.

One test still fails because the constraints are not copied over when a model without units is created. This can be fixed in specutils and should eventually be fixed in modeling as well but I wanted to explore whether this is actually still necessary. The reason it was done (AFAIK) is to fit models with units. Since such changes were already made in modeling it'd be good to know if there are any lingering issues related to fitting of models with units. 
