### PR TITLE
Fix asdf extension url mapping bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,16 +86,19 @@ matrix:
 
         # Do a PEP8 test with pycodestyle
         - os: linux
-          env: MAIN_CMD='pycodestyle specutils --count' SETUP_CMD=''
+          env: MAIN_CMD='pycodestyle specutils --count'
+               SETUP_CMD=''
 
         # Try development version of Astropy
         - os: linux
-          env: ASTROPY_VERSION=dev "PIP_DEPENDENCIES=$GWCS_DEV $ASDF_DEV"
+          env: ASTROPY_VERSION=dev
+               PIP_DEPENDENCIES="$GWCS_DEV $ASDF_DEV scipy matplotlib"
 
     allow_failures:
         # Try development version of Astropy
         - os: linux
-          env: ASTROPY_VERSION=dev "PIP_DEPENDENCIES=$GWCS_DEV $ASDF_DEV"
+          env: ASTROPY_VERSION=dev
+               PIP_DEPENDENCIES="$GWCS_DEV $ASDF_DEV scipy matplotlib"
 
 
 install:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+from importlib.util import find_spec
+import pkg_resources
+
+entry_points = []
+for entry_point in pkg_resources.iter_entry_points('pytest11'):
+    entry_points.append(entry_point.name)
+
+if "asdf_schema_tester" not in entry_points and find_spec('asdf') is not None:
+	pytest_plugins = ['asdf.tests.schema_tester']
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,5 +54,3 @@ github_project = astropy/specutils
 install_requires = astropy>=3.1, gwcs, scipy
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
 version = 0.6.dev
-
-[entry_points]

--- a/specutils/conftest.py
+++ b/specutils/conftest.py
@@ -27,7 +27,6 @@ except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
 
 # Use ASDF schema tester plugin if ASDF is installed
 if find_spec('asdf') is not None:
-    pytest_plugins = ['asdf.tests.schema_tester']
     PYTEST_HEADER_MODULES['Asdf'] = 'asdf'
 
 # Uncomment the following lines to display the version number of the

--- a/specutils/io/asdf/extension.py
+++ b/specutils/io/asdf/extension.py
@@ -2,6 +2,7 @@
 Defines extension that is used by ASDF for recognizing specutils types
 """
 import os
+import urllib
 
 from asdf.util import filepath_to_url
 from asdf.extension import AsdfExtension
@@ -15,9 +16,9 @@ from .types import _specutils_types
 SCHEMA_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), 'schemas'))
 SPECUTILS_URL_MAPPING = [
-    (ASTROPY_SCHEMA_URI_BASE,
+    (urllib.parse.urljoin(ASTROPY_SCHEMA_URI_BASE, 'specutils/'),
      filepath_to_url(
-         os.path.join(SCHEMA_PATH, 'astropy.org')) +
+         os.path.join(SCHEMA_PATH, 'astropy.org', 'specutils')) +
          '/{url_suffix}.yaml')]
 
 

--- a/specutils/io/asdf/tags/tests/test_spectra.py
+++ b/specutils/io/asdf/tags/tests/test_spectra.py
@@ -5,8 +5,10 @@ pytest.importorskip('asdf')
 import numpy as np
 
 import astropy.units as u
+from astropy.coordinates import FK5
 
 from asdf.tests.helpers import assert_roundtrip_tree
+import asdf
 
 from specutils import Spectrum1D, SpectrumList
 
@@ -46,3 +48,11 @@ def test_asdf_spectrumlist(tmpdir):
 
     tree = dict(spectra=spectra)
     assert_roundtrip_tree(tree, tmpdir)
+
+
+@pytest.mark.filterwarnings("error::UserWarning")
+def test_asdf_url_mapper():
+    """Make sure specutils asdf extension url_mapping doesn't interfere with astropy schemas"""
+    frame = FK5()
+    af = asdf.AsdfFile()
+    af.tree = {'frame': frame}

--- a/specutils/tests/test_io.py
+++ b/specutils/tests/test_io.py
@@ -4,7 +4,7 @@
 This module tests SpecUtils io routines
 """
 
-from ..io.parsing_utils import generic_spectrum_from_table # or something like that
+from specutils.io.parsing_utils import generic_spectrum_from_table # or something like that
 from astropy.io import registry
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning


### PR DESCRIPTION
Fixes #465.

Also:
- Moves the `asdf` pytest schema tester into the top-level `conftest.py`.  `pytest>=4` requires that plugins be specified only at the top level.  This will re-enable the testing of ASDF schemas.
- Will use the schema tester via `entry_points` if available (currently in dev in `asdf`).