### PR TITLE
Raise exception when spectral and flux axes have different lengths

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -60,6 +60,12 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         if flux is None and 'data' in kwargs:
             flux = kwargs.pop('data')
 
+        # Check to make sure the wavelength length is the same in both
+        if flux is not None and spectral_axis is not None:
+            if not spectral_axis.shape[0] == flux.shape[-1]:
+                raise ValueError('Spectral axis ({}) and flux axis ({}) lengths must be the same'.format(
+                    spectral_axis.shape[0], flux.shape[-1]))
+
         # Ensure that the unit information codified in the quantity object is
         # the One True Unit.
         kwargs.setdefault('unit', flux.unit if isinstance(flux, u.Quantity)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -91,7 +91,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         # Check to make sure the wavelength length is the same in both
         if flux is not None and spectral_axis is not None:
             if not spectral_axis.shape[0] == flux.shape[-1]:
-                raise ValueError('Spectral axis ({}) and flux axis ({}) lengths must be the same'.format(
+                raise ValueError('Spectral axis ({}) and the last flux axis ({}) lengths must be the same'.format(
                     spectral_axis.shape[0], flux.shape[-1]))
 
         self._velocity_convention = velocity_convention

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -120,7 +120,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
 
         if hasattr(self, 'uncertainty') and self.uncertainty is not None:
             if not flux.shape == self.uncertainty.array.shape:
-                raise ValueError('Flux axis ({}) and uncertainty ({}) shapes must be the same (or uncertainty must be a singleton)'.format(
+                raise ValueError('Flux axis ({}) and uncertainty ({}) shapes must be the same.'.format(
                     flux.shape, self.uncertainty.array.shape))
 
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -60,12 +60,6 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         if flux is None and 'data' in kwargs:
             flux = kwargs.pop('data')
 
-        # Check to make sure the wavelength length is the same in both
-        if flux is not None and spectral_axis is not None:
-            if not spectral_axis.shape[0] == flux.shape[-1]:
-                raise ValueError('Spectral axis ({}) and flux axis ({}) lengths must be the same'.format(
-                    spectral_axis.shape[0], flux.shape[-1]))
-
         # Ensure that the unit information codified in the quantity object is
         # the One True Unit.
         kwargs.setdefault('unit', flux.unit if isinstance(flux, u.Quantity)
@@ -94,6 +88,12 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             raise LookupError("No WCS object or spectral axis information has "
                               "been given. Please provide one.")
 
+        # Check to make sure the wavelength length is the same in both
+        if flux is not None and spectral_axis is not None:
+            if not spectral_axis.shape[0] == flux.shape[-1]:
+                raise ValueError('Spectral axis ({}) and flux axis ({}) lengths must be the same'.format(
+                    spectral_axis.shape[0], flux.shape[-1]))
+
         self._velocity_convention = velocity_convention
 
         if rest_value is None:
@@ -117,6 +117,12 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         super(Spectrum1D, self).__init__(
             data=flux.value if isinstance(flux, u.Quantity) else flux,
             wcs=wcs, **kwargs)
+
+        if hasattr(self, 'uncertainty') and self.uncertainty is not None:
+            if not flux.shape == self.uncertainty.array.shape:
+                raise ValueError('Flux axis ({}) and uncertainty ({}) shapes must be the same (or uncertainty must be a singleton)'.format(
+                    flux.shape, self.uncertainty.array.shape))
+
 
     @property
     def frequency(self):

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -215,6 +215,16 @@ def test_create_with_uncertainty():
 
     assert spec.flux.unit == spec.uncertainty.unit
 
+    # If flux and uncertainty are different sizes then raise exception
+    wavelengths = np.arange(0, 10)
+    flux=100*np.abs(np.random.randn(3, 4, 10))*u.Jy
+    uncertainty = StdDevUncertainty(np.abs(np.random.randn(3, 2, 10))*u.Jy)
+
+    with pytest.raises(ValueError) as e_info:
+        s1d = Spectrum1D(spectral_axis=wavelengths*u.um,
+                         flux=flux,
+                         uncertainty=uncertainty)
+
 
 @remote_access([{'id': '1481190', 'filename': 'L5g_0355+11_Cruz09.fits'}])
 def test_read_linear_solution(remote_data_path):

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -45,6 +45,11 @@ def test_create_from_multidimensional_arrays():
     assert (spec.frequency == freqs).all()
     assert (spec.flux == flux).all()
 
+    # Mis-matched lengths should raise and exception
+    freqs = np.arange(50) * u.GHz
+    flux = np.random.random((5, len(freqs)-1)) * u.Jy
+    with pytest.raises(ValueError) as e_info:
+        spec = Spectrum1D(spectral_axis=freqs, flux=flux)
 
 def test_create_from_quantities():
     spec = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm,
@@ -53,6 +58,11 @@ def test_create_from_quantities():
     assert isinstance(spec.spectral_axis, u.Quantity)
     assert spec.spectral_axis.unit == u.nm
     assert spec.spectral_axis.size == 49
+
+    # Mis-matched lengths should raise and exception
+    with pytest.raises(ValueError) as e_info:
+        spec = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm,
+                      flux=np.random.randn(48) * u.Jy)
 
 
 def test_create_implicit_wcs():

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -45,7 +45,7 @@ def test_create_from_multidimensional_arrays():
     assert (spec.frequency == freqs).all()
     assert (spec.flux == flux).all()
 
-    # Mis-matched lengths should raise and exception
+    # Mis-matched lengths should raise an exception
     freqs = np.arange(50) * u.GHz
     flux = np.random.random((5, len(freqs)-1)) * u.Jy
     with pytest.raises(ValueError) as e_info:
@@ -59,7 +59,7 @@ def test_create_from_quantities():
     assert spec.spectral_axis.unit == u.nm
     assert spec.spectral_axis.size == 49
 
-    # Mis-matched lengths should raise and exception
+    # Mis-matched lengths should raise an exception
     with pytest.raises(ValueError) as e_info:
         spec = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm,
                       flux=np.random.randn(48) * u.Jy)

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -257,7 +257,7 @@ def test_repr():
     spec_with_unc = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
                                flux=np.random.random(10) * u.Jy,
                                uncertainty=StdDevUncertainty(
-                                   np.random.sample(50), unit='Jy'))
+                                   np.random.sample(10), unit='Jy'))
     result = repr(spec_with_unc)
     assert result.startswith('<Spectrum1D(flux=<Quantity [')
     assert 'spectral_axis=<Quantity [' in result


### PR DESCRIPTION
This will check the spectral_axis and flux axis lengths to make sure they are the same and will raise an exception if that is not the case. 

Fixes https://github.com/astropy/specutils/issues/326