### PR TITLE
Add travis stages and other cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: c
 os:
     - linux
 
-stage: Initial tests
+stage: Comprehensive tests
 
 
 addons:
@@ -51,7 +51,7 @@ matrix:
         - stage: Initial tests
           env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
-        - stage: Initial tests:
+        - stage: Initial tests
           os: linux
           env: PYTHON_VERSION=3.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,13 +87,13 @@ matrix:
 
         # Try development version of Astropy
         - os: linux
-          env: ASTROPY_VERSION=dev
+          env: ASTROPY_VERSION=dev EVENT_TYPE='pull_request push cron'
                PIP_DEPENDENCIES="$GWCS_DEV $ASDF_DEV scipy matplotlib"
 
     allow_failures:
         # Try development version of Astropy
         - os: linux
-          env: ASTROPY_VERSION=dev
+          env: ASTROPY_VERSION=dev EVENT_TYPE='pull_request push cron'
                PIP_DEPENDENCIES="$GWCS_DEV $ASDF_DEV scipy matplotlib"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,13 @@ language: c
 os:
     - linux
 
-# Setting sudo to false opts in to Travis-CI container-based builds.
-sudo: false
+stage: Initial tests
 
-# The apt packages below are needed for sphinx builds. A full list of packages
-# that can be included can be found here:
-#
-# https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
 
 addons:
     apt:
         packages:
             - graphviz
-            - texlive-latex-extra
-            - dvipng
 
 env:
     global:
@@ -35,17 +28,18 @@ env:
         - PIP_DEPENDENCIES='gwcs scipy matplotlib'
         - EVENT_TYPE='pull_request push'
         - CONDA_DEPENDENCIES='pytest-remotedata'
-        - CONDA_CHANNELS='astropy-ci-extras'
         - GWCS_DEV="git+https://github.com/spacetelescope/gwcs.git#egg=gwcs"
         - ASDF_DEV="git+https://github.com/spacetelescope/asdf.git#egg=asdf"
 
-        # If there are matplotlib or other GUI tests, uncomment the following
-        # line to use the X virtual framebuffer.
-        # - SETUP_XVFB=True
 
-    matrix:
-        # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+stages:
+   # Do the style check and a single test job, don't proceed if it fails
+   - name: Initial tests
+   # Test docs, astropy dev, and without optional dependencies
+   - name: Comprehensive tests
+   # These will only run when cron is opted in
+   - name: Cron tests
+     if: type = cron
 
 matrix:
 
@@ -53,6 +47,14 @@ matrix:
     fast_finish: true
 
     include:
+        # Make sure that egg_info works without dependencies
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+
+        - stage: Initial tests:
+          os: linux
+          env: PYTHON_VERSION=3.7
+
         # Try MacOS X
         - os: osx
           env: SETUP_CMD='test --remote-data=any'
@@ -76,16 +78,10 @@ matrix:
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.15
         - os: linux
           env: NUMPY_VERSION=1.14
-        - os: linux
-          env: PYTHON_VERSION=3.7
-
-        # Try numpy pre-release
-        - os: linux
-          env: NUMPY_VERSION=prerelease
-               EVENT_TYPE='pull_request push cron'
 
         # Do a PEP8 test with pycodestyle
-        - os: linux
+        - stage: Initial tests
+          os: linux
           env: MAIN_CMD='pycodestyle specutils --count'
                SETUP_CMD=''
 


### PR DESCRIPTION
This is to close #514 

I haven't really updated the version combinations in the matrix to be the most comprehensive, but added a weekly cron that will run on the astropy dev job as that's a valuable way to provide feedback of failures upstream while they are still in the dev cycle.