### PR TITLE
Make line/continuum fitting work in the mask case (and other mask-related tests)

### DIFF
--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -287,7 +287,7 @@ def fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
     weights : array-like or 'unc', optional
         If 'unc', the unceratinties from the spectrum object are used to
         to calculate the weights. If array-like, represents the weights to
-        use in the fitting.  Not that if a mask is present on the spectrum, it
+        use in the fitting.  Note that if a mask is present on the spectrum, it
         will be applied to the ``weights`` as it would be to the spectrum
         itself.
     window : `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -427,7 +427,7 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
     if window is not None and isinstance(window, (float, int)):
         center = model.mean
         window_indices = np.nonzero((spectrum.spectral_axis >= center-window) &
-                             (spectrum.spectral_axis < center+window))
+                                    (spectrum.spectral_axis < center+window))
 
     # In this case the window is the start and end points of where we
     # should fit
@@ -440,14 +440,16 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
     elif window is not None and isinstance(window, SpectralRegion):
         idx1, idx2 = window.bounds
         if idx1 == idx2:
-            raise Exception("Bad selected region.")
+            raise IndexError("Tried to fit a region containing no pixels.")
 
         # HACK WARNING! This uses the extract machinery to create a set of
         # indices by making an "index spectrum"
+        # note that any unit will do but Jy is at least flux-y
         # TODO: really the spectral region machinery should have the power
         # to create a mask, and we'd just use that...
+        idxarr = np.arange(spectrum.flux.size).reshape(spectrum.flux.shape)
         index_spectrum = Spectrum1D(spectral_axis=spectrum.spectral_axis,
-                                    flux=np.arange(spectrum.flux.size).reshape(spectrum.flux.shape)*u.Jy)
+                                    flux=u.Quantity(idxarr, u.Jy, dtype=int))
 
         extracted_regions = extract_region(index_spectrum, window)
         if isinstance(extracted_regions, list):

--- a/specutils/tests/spectral_examples.py
+++ b/specutils/tests/spectral_examples.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 import numpy as np
 import astropy.units as u
 from astropy.modeling import models
@@ -32,6 +34,9 @@ class SpectraExamples:
 
         4. s1_AA_nJy_e3 - same as 1, but with a fourth instance of noise
                           dispersion: Angstroms, flux: nJy
+
+        5. s1_um_mJy_e1_masked - same as 1, but with a random set of pixels
+                                 masked.
     """
 
     def __init__(self):
@@ -71,7 +76,7 @@ class SpectraExamples:
                                         flux=self._flux_e2 * u.mJy)
 
         #
-        # Create on spectrum with the same flux but in angstrom units
+        # Create one spectrum with the same flux but in angstrom units
         #
 
         self.wavelengths_AA = self.wavelengths_um * 10000
@@ -79,12 +84,19 @@ class SpectraExamples:
                                         flux=self._flux_e1 * u.mJy)
 
         #
-        # Create on spectrum with the same flux but in angstrom units and nJy
+        # Create one spectrum with the same flux but in angstrom units and nJy
         #
 
         self._flux_e4 = (self.base_flux + 400 * np.random.random(self.base_flux.shape)) * 1000000
         self._s1_AA_nJy_e4 = Spectrum1D(spectral_axis=self.wavelengths_AA * u.AA,
                                         flux=self._flux_e4 * u.nJy)
+
+
+        #
+        # Create one spectrum like 1 but with a mask
+        #
+        self._s1_um_mJy_e1_masked = copy(self._s1_um_mJy_e1)  # SHALLOW copy
+        self._s1_um_mJy_e1_masked.mask = (np.random.randn(*self.base_flux.shape) + 1) > 0
 
 
     @property
@@ -118,6 +130,11 @@ class SpectraExamples:
     @property
     def s1_AA_nJy_e4_flux(self):
         return self._flux_e4
+
+    @property
+    def s1_um_mJy_e1_masked(self):
+        return self._s1_um_mJy_e1_masked
+
 
 
 @pytest.fixture

--- a/specutils/tests/spectral_examples.py
+++ b/specutils/tests/spectral_examples.py
@@ -95,7 +95,7 @@ class SpectraExamples:
         #
         # Create one spectrum like 1 but with a mask
         #
-        self._s1_um_mJy_e1_masked = copy(self._s1_um_mJy_e1)  # SHALLOW copy
+        self._s1_um_mJy_e1_masked = copy(self._s1_um_mJy_e1)  # SHALLOW copy - the data are shared with the above non-masked case
         self._s1_um_mJy_e1_masked.mask = (np.random.randn(*self.base_flux.shape) + 1) > 0
 
 

--- a/specutils/tests/test_arithmetic.py
+++ b/specutils/tests/test_arithmetic.py
@@ -93,3 +93,15 @@ def test_add_diff_spectral_axis(simulated_spectra):
 
     # Calculate using the spectrum1d/nddata code
     spec3 = simulated_spectra.s1_um_mJy_e1 + simulated_spectra.s1_AA_mJy_e3
+
+
+def test_masks(simulated_spectra):
+    masked_spec = simulated_spectra.s1_um_mJy_e1_masked
+
+    masked_sum = masked_spec + masked_spec
+    assert np.all(masked_sum.mask == simulated_spectra.s1_um_mJy_e1_masked.mask)
+
+    masked_sum.mask[:50] = True
+    masked_diff = masked_sum - masked_spec
+    assert u.allclose(masked_diff.flux, masked_spec.flux)
+    assert np.all(masked_diff.mask == masked_sum.mask | masked_spec.mask)

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -601,8 +601,8 @@ def test_masking():
     """
     Test fitting spectra with masks
     """
-    x, y = double_peak()
-    s = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um)
+    wl, flux = double_peak()
+    s = Spectrum1D(flux=flux*u.Jy, spectral_axis=wl*u.um)
 
     # first we fit a single gaussian to the double_peak model, using the
     # known-good second peak (but a bit higher in amplitude). It should lock
@@ -613,7 +613,7 @@ def test_masking():
 
     # now create a spectrum where the region around the second peak is masked.
     # The fit should now go to the *first* peak
-    s_msk = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um, mask=(5.1 < x)&(x < 6.1))
+    s_msk = Spectrum1D(flux=flux*u.Jy, spectral_axis=wl*u.um, mask=(5.1 < wl)&(wl < 6.1))
     g_fit2 = fit_lines(s_msk, g_init)
     assert u.allclose(g_fit2.mean, 4.6, atol=.1)
 
@@ -627,18 +627,18 @@ def test_window_extras():
     Test that fitting works with masks and weights when a window is present
     """
     # similar to the masking test, but add a broad window around the whole thing
-    x, y = double_peak()
+    wl, flux = double_peak()
     g_init = models.Gaussian1D(2.5, 5.5, 0.2)
     window_region = SpectralRegion(4*u.um, 8*u.um)
-    mask = (5.1 < x) & (x < 6.1)
+    mask = (5.1 < wl) & (wl < 6.1)
 
-    s_msk = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um, mask=mask)
+    s_msk = Spectrum1D(flux=flux*u.Jy, spectral_axis=wl*u.um, mask=mask)
 
     g_fit1 = fit_lines(s_msk, g_init, window=window_region)
     assert u.allclose(g_fit1.mean, 4.6, atol=.1)
 
     # check that if we weight instead of masking, we get the same result
-    s = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um)
+    s = Spectrum1D(flux=flux*u.Jy, spectral_axis=wl*u.um)
     weights = (~mask).astype(float)
     g_fit2 = fit_lines(s, g_init, weights=weights, window=window_region)
     assert u.allclose(g_fit2.mean, 4.6, atol=.1)

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -616,3 +616,7 @@ def test_masking():
     s_msk = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um, mask=(5.1 < x)&(x < 6.1))
     g_fit2 = fit_lines(s_msk, g_init)
     assert u.allclose(g_fit2.mean, 4.6, atol=.1)
+
+    # double check that it works with weights as well
+    g_fit3 = fit_lines(s_msk, g_init, weights=np.ones_like(s_msk.flux.value))
+    assert g_fit2.mean == g_fit3.mean

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -174,3 +174,17 @@ def test_linear_excise_invert_from_spectrum():
                              np.diff(excised_spec[51:61].flux))
     assert quantity_allclose(np.diff(excised_spec[80:90].flux),
                              np.diff(excised_spec[81:91].flux))
+
+
+def test_extract_masked():
+    wl = [1, 2, 3, 4]*u.nm
+    flux = np.arange(4)*u.Jy
+    mask = [False, False, True, True]
+
+    masked_spec = Spectrum1D(spectral_axis=wl, flux=flux, mask=mask)
+    region = SpectralRegion(1.5 * u.nm, 3.5 * u.nm)
+
+    extracted = extract_region(masked_spec, region)
+
+    assert np.all(extracted.mask == [False, True])
+    assert np.all(extracted.flux.value == [1, 2])


### PR DESCRIPTION
This is the PR I promised in #516. It fixes the line-fitting machinery to ignore any masked parts of the spectrum when doing a fit.

Note this also includes a couple of tests I added in process of the above to ensure the masks behave correctly for arithmetic and spectral regions.

cc @brechmos-stsci @camipacifici @nmearl 

(This may particularly benefit from a review by @brechmos-stsci who did a fair amount of the fitting stuff)