### PR TITLE
Use assert_almost_equal in test_template_comparison.py

### DIFF
--- a/specutils/tests/test_template_comparison.py
+++ b/specutils/tests/test_template_comparison.py
@@ -64,7 +64,7 @@ def test_template_match_with_resample():
                              flux=spec1.flux * template_comparison._normalize_for_template_matching(spec, spec1))
 
     assert quantity_allclose(tm_result[0].flux, spec_result.flux, atol=0.01*u.Jy)
-    assert tm_result[1] == 40093.28353756253
+    np.testing.assert_almost_equal(tm_result[1], 40093.28353756253)
 
 
 def test_template_match_list():
@@ -93,7 +93,7 @@ def test_template_match_list():
     # Get result from template_match
     tm_result = template_comparison.template_match(spec, template_list)
 
-    assert tm_result[1] == 40093.28353756253
+    np.testing.assert_almost_equal(tm_result[1], 40093.28353756253)
 
 
 def test_template_match_spectrum_collection():
@@ -121,7 +121,7 @@ def test_template_match_spectrum_collection():
     # Get result from template_match
     tm_result = template_comparison.template_match(spec, spec_coll)
 
-    assert tm_result[1] == 40093.28353756253
+    np.testing.assert_almost_equal(tm_result[1], 40093.28353756253)
 
 
 def test_template_match_multidim_spectrum():
@@ -144,4 +144,4 @@ def test_template_match_multidim_spectrum():
     # Get result from template_match
     tm_result = template_comparison.template_match(spec, multidim_spec)
 
-    assert tm_result[1] == 250.26870401777543
+    np.testing.assert_almost_equal(tm_result[1], 250.26870401777543)


### PR DESCRIPTION
On 32-bit x86, `test_template_match_multidim_spectrum` [fails during build](https://buildd.debian.org/status/fetch.php?pkg=specutils&arch=i386&ver=0.6-1&stamp=1569073687&raw=0) due to slightly different floating points:
```
    def test_template_match_multidim_spectrum():
        """[…]"""
        np.random.seed(42)
    
        # Create test spectra
        spec_axis1 = np.linspace(0, 50, 50) * u.AA
        spec_axis2 = np.linspace(0, 50, 50) * u.AA
    
        spec = Spectrum1D(spectral_axis=spec_axis1,
                          flux=np.random.sample(50) * u.Jy,
                          uncertainty=StdDevUncertainty(np.random.sample(50)))
        multidim_spec = Spectrum1D(spectral_axis=spec_axis2,
                                   flux=np.random.sample((2, 50)) * u.Jy,
                                   uncertainty=StdDevUncertainty(np.random.sample((2, 50))))
    
        # Get result from template_match
        tm_result = template_comparison.template_match(spec, multidim_spec)
    
>       assert tm_result[1] == 250.26870401777543
E       assert 250.26870401777546 == 250.26870401777543
```
The equal here should be an "almost equal". This patch fixes this in `test_template_comparison.py`. Although there are direct comparisons in many other test files, I pragmatically left them untouched since they didn't cause a failure, and I am not always sure whether a direct equal was meant there.