### PR TITLE
Keep model names after fitting

### DIFF
--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -358,6 +358,8 @@ def fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
         fit_model = _fit_lines(spectrum, model_guess, fitter,
                                exclude_regions, weights, model_window,
                                ignore_units, **kwargs)
+        if model_guess.name is not None:
+            fit_model.name = model_guess.name
 
         fitted_models.append(fit_model)
 

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -635,9 +635,9 @@ def _strip_units_from_model(model_in, spectrum, convert=True):
         #
 
         if isinstance(sub_model, models.PolynomialModel):
-            new_sub_model = sub_model.__class__(sub_model.degree)
+            new_sub_model = sub_model.__class__(sub_model.degree, name=sub_model.name)
         else:
-            new_sub_model = sub_model.__class__()
+            new_sub_model = sub_model.__class__(name=sub_model.name)
 
         # Now for each parameter in the model determine if a dispersion or
         # flux type of unit, then convert to spectrum units and then
@@ -753,9 +753,9 @@ def _add_units_to_model(model_in, model_orig, spectrum):
         #
 
         if isinstance(m_in, models.PolynomialModel):
-            new_sub_model = m_in.__class__(m_in.degree)
+            new_sub_model = m_in.__class__(m_in.degree, name=m_in.name)
         else:
-            new_sub_model = m_in.__class__()
+            new_sub_model = m_in.__class__(name=m_in.name)
 
         #
         # Convert the model values from the spectrum units back to the

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -461,12 +461,14 @@ def test_fixed_parameters():
     # Test passing fixed and bounds parameters
     g_init = models.Gaussian1D(amplitude=3.*u.Jy, mean=6.1*u.um, stddev=1.*u.um,
                                fixed={'mean': True},
-                               bounds={'amplitude': (2, 5)*u.Jy})
+                               bounds={'amplitude': (2, 5)*u.Jy},
+                               name="Gaussian Test Model")
 
     g_fit = fit_lines(spectrum, g_init)
 
     assert g_fit.mean == 6.1*u.um
     assert g_fit.bounds == g_init.bounds
+    assert g_fit.name == "Gaussian Test Model"
 
     # Test passing of tied parameter
     g_init = models.Gaussian1D(amplitude=3.*u.Jy, mean=6.1*u.um, stddev=1.*u.um,
@@ -474,6 +476,7 @@ def test_fixed_parameters():
     g_fit = fit_lines(spectrum, g_init)
 
     assert g_fit.tied == g_init.tied
+    assert g_fit.name == g_init.name
 
 
 def test_ignore_units():

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -479,6 +479,25 @@ def test_fixed_parameters():
     assert g_fit.name == g_init.name
 
 
+def test_name_preservation_after_fitting():
+    """
+    Test to confirm model and submodels names are preserved after fitting.
+    """
+
+    x = np.linspace(0., 10., 200)
+    y = 3 * np.exp(-0.5 * (x - 6.3)**2 / 0.8**2)
+    y += np.random.normal(0., 0.2, x.shape)
+    spectrum = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um)
+
+    subcomponents = models.Gaussian1D(name="Model I") * models.Gaussian1D(name="Second Model")
+    c_model = subcomponents + models.Gaussian1D(name="Model 3")
+    c_model.name = "Compound Model with 3 components"
+    model_fit = fit_lines(spectrum, c_model)
+
+    assert model_fit.name == "Compound Model with 3 components"
+    assert model_fit.submodel_names == ("Model I", "Second Model", "Model 3")
+
+
 def test_ignore_units():
     """
     Ignore the units


### PR DESCRIPTION
This PR makes `fit_lines` to preserve the names of the original model(s) after fitting.

Fixes #503 