### PR TITLE
Fix "no attribute dispersion" bug from issue #528

### DIFF
--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -158,10 +158,10 @@ This again will be done in a separate python file and placed in the user's
     @custom_writer("fits-writer")
     def generic_fits(spectrum, file_name, **kwargs):
         flux = spectrum.flux.value
-        disp = spectrum.dispersion.value
+        disp = spectrum.spectral_axis.value
         meta = spectrum.meta
 
-        tab = Table([disp, flux], names=("dispersion", "flux"), meta=meta)
+        tab = Table([disp, flux], names=("spectral_axis", "flux"), meta=meta)
 
         tab.write(file_name, format="fits")
 

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -74,9 +74,9 @@ def tabular_fits_loader(file_name, column_mapping=None, **kwargs):
 @custom_writer("tabular-fits")
 def tabular_fits_writer(spectrum, file_name, **kwargs):
     flux = spectrum.flux.value
-    disp = spectrum.dispersion.value
+    disp = spectrum.spectral_axis.value
     meta = spectrum.meta
 
-    tab = Table([disp, flux], names=("dispersion", "flux"), meta=meta)
+    tab = Table([disp, flux], names=("spectral_axis", "flux"), meta=meta)
 
     tab.write(file_name, format="fits")

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -4,13 +4,12 @@ import os
 from astropy import units as u
 from astropy.io import fits
 from astropy.wcs import WCS
-from astropy.table import Table
 from astropy.modeling import models, fitting
 
 import shlex
 
 from ...spectra import Spectrum1D
-from ..registers import data_loader, custom_writer
+from ..registers import data_loader
 
 __all__ = ['wcs1d_fits_loader', 'wcs1d_fits_writer', 'non_linear_wcs1d_fits']
 
@@ -80,17 +79,6 @@ def wcs1d_fits_loader(file_name, spectral_axis_unit=None, flux_unit=None,
         meta = {'header': header}
 
     return Spectrum1D(flux=data, wcs=wcs, meta=meta)
-
-
-@custom_writer("wcs-fits")
-def wcs1d_fits_writer(spectrum, file_name, **kwargs):
-    flux = spectrum.flux.value
-    disp = spectrum.dispersion.value
-    meta = spectrum.meta
-
-    tab = Table([disp, flux], names=("dispersion", "flux"), meta=meta)
-
-    tab.write(file_name, format="fits")
 
 
 def identify_iraf_wcs(origin, *args):


### PR DESCRIPTION
This is a fix for the `AttributeError: 'Spectrum1D' object has no attribute 'dispersion'` bug described in #528 . 

I also removed one of the fits writers, as it was redundant, and misleading given its name.

Note that it appears there are no tests for either of these writers. I'm not sure where such tests should go, or how they should be formatted.