### PR TITLE
Implement zero_fill for resamplers and related fixes

### DIFF
--- a/docs/manipulation.rst
+++ b/docs/manipulation.rst
@@ -217,7 +217,7 @@ single spectrum. This can be achieved as follows:
 
     >>> new_spectral_axis = np.concatenate([spec1.spectral_axis.value, spec2.spectral_axis.to_value(spec1.spectral_axis.unit)]) * spec1.spectral_axis.unit
 
-    >>> resampler = LinearInterpolatedResampler(edge_action='zero_fill')
+    >>> resampler = LinearInterpolatedResampler(extrapolation_treatment='zero_fill')
     >>> new_spec1 = resampler(spec1, new_spectral_axis)
     >>> new_spec2 = resampler(spec2, new_spectral_axis)
 

--- a/docs/manipulation.rst
+++ b/docs/manipulation.rst
@@ -207,9 +207,6 @@ The resampling functionality detailed above is also the default way
 :ref:`specutils <specutils>` supports splicing multiple spectra together into a
 single spectrum. This can be achieved as follows:
 
-
-
-
 .. plot::
     :include-source:
     :align: center
@@ -220,11 +217,9 @@ single spectrum. This can be achieved as follows:
 
     >>> new_spectral_axis = np.concatenate([spec1.spectral_axis.value, spec2.spectral_axis.to_value(spec1.spectral_axis.unit)]) * spec1.spectral_axis.unit
 
-    >>> resampler = LinearInterpolatedResampler()
+    >>> resampler = LinearInterpolatedResampler(edge_action='zero_fill')
     >>> new_spec1 = resampler(spec1, new_spectral_axis)
-    >>> new_spec1.flux[np.isnan(new_spec1.flux)] = 0
     >>> new_spec2 = resampler(spec2, new_spectral_axis)
-    >>> new_spec2.flux[np.isnan(new_spec2.flux)] = 0
 
     >>> final_spec = new_spec1 + new_spec2
 

--- a/specutils/manipulation/resample.py
+++ b/specutils/manipulation/resample.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from warnings import warn
+
 import numpy as np
 from scipy.interpolate import CubicSpline
 from astropy.units import Quantity

--- a/specutils/tests/test_resample.py
+++ b/specutils/tests/test_resample.py
@@ -8,6 +8,11 @@ from ..spectra.spectrum1d import Spectrum1D
 from ..tests.spectral_examples import simulated_spectra
 from ..manipulation.resample import FluxConservingResampler, LinearInterpolatedResampler, SplineInterpolatedResampler
 
+
+@pytest.fixture(params=[FluxConservingResampler, LinearInterpolatedResampler, SplineInterpolatedResampler])
+def all_resamplers(request):
+    return request.param
+
 # todo: Should add tests for different weighting options once those
 # are more solidified.
 
@@ -162,3 +167,18 @@ def test_expanded_grid_interp_spline():
     assert_quantity_allclose(results.flux,
                             np.array([np.nan, 3.98808594, 6.94042969, 6.45869141,
                                       5.89921875, 7.29736328, np.nan, np.nan, np.nan])*u.mJy)
+
+
+@pytest.mark.parametrize("edgetype,lastvalue",
+                         [("nan_fill", np.nan), ("zero_fill", 0)])
+def test_resample_edges(edgetype, lastvalue, all_resamplers):
+    input_spectrum = Spectrum1D(spectral_axis=[1, 3, 7, 6, 20] * u.micron,
+                                flux=[2, 4, 12, 16, 20] * u.mJy)
+    resamp_grid = [1, 3, 7, 6, 20, 100] * u.micron
+
+    resampler = all_resamplers(edgetype)
+    resampled = resampler(input_spectrum, resamp_grid)
+    if lastvalue is np.nan:
+        assert np.isnan(resampled.flux[-1])
+    else:
+        assert resampled.flux[-1] == lastvalue

--- a/specutils/tests/test_resample.py
+++ b/specutils/tests/test_resample.py
@@ -172,8 +172,8 @@ def test_expanded_grid_interp_spline():
 @pytest.mark.parametrize("edgetype,lastvalue",
                          [("nan_fill", np.nan), ("zero_fill", 0)])
 def test_resample_edges(edgetype, lastvalue, all_resamplers):
-    input_spectrum = Spectrum1D(spectral_axis=[1, 3, 7, 6, 20] * u.micron,
-                                flux=[2, 4, 12, 16, 20] * u.mJy)
+    input_spectrum = Spectrum1D(spectral_axis=[2, 4, 12, 16, 20] * u.micron,
+                                flux=[1, 3, 7, 6, 20] * u.mJy)
     resamp_grid = [1, 3, 7, 6, 20, 100] * u.micron
 
     resampler = all_resamplers(edgetype)


### PR DESCRIPTION
Inspired by needing to do nan-replacement in #536, I went ahead and implemented an additional option for the "resampling beyond the edge of the spectrum" case in all three resamplers which fills "off the edge" parts of the spectrum with 0s.  There are of course more possibilities for how this filling might happen, but since we have a clear and specific use case for the "zero" option, it seemed logical.

Along the way I encountered several other implementation issues with the resampling code and fixed those, so this contains several related fixes (related in the sense that they are not easily-separable, otherwise I would have done them as separate PRs).

What this does *not* do is anything with masking.  Arguably we may want to add an option to *mask* the bad parts of the spectrum, but I think that could be done as a straightforward follow-on PR if desired.