### PR TITLE
Simple utility continuum baseline checker

### DIFF
--- a/specutils/__init__.py
+++ b/specutils/__init__.py
@@ -41,10 +41,10 @@ class Conf(_config.ConfigNamespace):
     Configuration parameters for specutils.
     """
 
-    always_check_continuum = _config.ConfigItem(
+    do_continuum_function_check = _config.ConfigItem(
         True,
         'Whether to check the spectrum baseline value is close'
-        'to zero. If it is not within ``eps`` then a warning is raised.'
+        'to zero. If it is not within ``threshold`` then a warning is raised.'
     )
 
 conf = Conf()

--- a/specutils/__init__.py
+++ b/specutils/__init__.py
@@ -7,6 +7,7 @@ Specutils: an astropy package for spectroscopy.
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
 from ._astropy_init import *
+from astropy import config as _config
 # ----------------------------------------------------------------------------
 
 # Enforce Python version check during package import.
@@ -34,3 +35,17 @@ if not _ASTROPY_SETUP_:
     _load_user_io()
 
 __citation__ = 'https://doi.org/10.5281/zenodo.1421356'
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for specutils.
+    """
+
+    always_check_continuum = _config.ConfigItem(
+        True,
+        'Whether to check the spectrum baseline value is close'
+        'to zero. If it is not within ``eps`` then a warning is raised.'
+    )
+
+conf = Conf()
+

--- a/specutils/__init__.py
+++ b/specutils/__init__.py
@@ -48,4 +48,3 @@ class Conf(_config.ConfigNamespace):
     )
 
 conf = Conf()
-

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -127,17 +127,17 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None):
 
 def is_continuum_below_threshold(spectrum, threshold=0.01):
     """
-    Determine if the baseline of this spectrum is less than the threshold. 
+    Determine if the baseline of this spectrum is less than the threshold.
     I.e., an estimate of whether or not the continuum has been subtracted.
 
     If the threshold is an `~astropy.units.Quantity` then compare the median
-    of the flux to the threshold.  
+    of the flux to the threshold.
 
-    If the threshold is a float then the spectrum's uncertainty will be 
+    If the threshold is a float then the spectrum's uncertainty will be
     used or an estimate of the uncertainty. If the uncertainty is present then the
     threshold is compared to the median of the flux divided by the
     uncertainty.  If the uncertainty is not present then the threshold
-    is compared to the median of the flux divided by the 
+    is compared to the median of the flux divided by the
     `~astropy.stats.median_absolute_deviation`.
 
     Parameters
@@ -147,7 +147,7 @@ def is_continuum_below_threshold(spectrum, threshold=0.01):
 
     threshold: float or `~astropy.units.Quantity`
         The tolerance on the quantification to confirm the continuum is
-        near zero. 
+        near zero.
 
     Returns
     -------

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -158,7 +158,6 @@ def is_continuum_near_zero(spectrum, eps=0.01):
     # to compare the median of the flux regardless of the
     # existence of the uncertainty.
     if hasattr(eps, 'unit'):
-        print('here with med {}'.format(spectrum.flux))
         return np.median(flux) < eps
 
     # If eps does not have a unit, ie it is not a quantity, then
@@ -178,7 +177,6 @@ def warn_spectrum_continuum_subtracted(eps=0.01, check=conf.always_check_continu
     def actual_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
-            print('args is {} and kwargs is {}'.format(args, kwargs))
             if check:
                 spectrum = args[0]
                 if not is_continuum_near_zero(spectrum, eps):

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -139,7 +139,7 @@ def is_continuum_below_threshold(spectrum, threshold=0.01):
     threshold is compared to the median of the flux divided by the
     uncertainty.  If the uncertainty is not present then the threshold
     is compared to the median of the flux divided by the
-    `~astropy.stats.median_absolute_deviation`.
+    `~astropy.stats.mad_std`.
 
     Parameters
     ----------

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -178,6 +178,7 @@ def warn_spectrum_continuum_subtracted(eps=0.01, check=conf.always_check_continu
     def actual_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
+            print('args is {} and kwargs is {}'.format(args, kwargs))
             if check:
                 spectrum = args[0]
                 if not is_continuum_near_zero(spectrum, eps):

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -178,10 +178,14 @@ def is_continuum_below_threshold(spectrum, threshold=0.01):
     else:
         return np.median(flux) / median_absolute_deviation(flux) < threshold
 
-def warn_continuum_below_threshold(threshold=0.01, check=conf.always_check_continuum):
+def warn_continuum_below_threshold(threshold=0.01, check=conf.do_continuum_function_check):
     """
     Decorator for methods that should warn if the baseline
     of the spectrum does not appear to be below a threshold.
+
+    The ``check`` parameter is based on the `astropy configuration system
+    http://docs.astropy.org/en/stable/config/#adding-new-configuration-items`_.
+    Examples are on that page to show how to turn off this type of warning checking.
     """
     def actual_decorator(function):
         @wraps(function)

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -130,7 +130,8 @@ def is_continuum_below_threshold(spectrum, threshold=0.01):
     Determine if the baseline of this spectrum is less than a threshold.
     I.e., an estimate of whether or not the continuum has been subtracted.
 
-    If the threshold is an `~astropy.units.Quantity` then compare the median
+    If ``threshold`` is an `~astropy.units.Quantity` with flux units, this 
+    directly compares the median of the spectrum to the threshold.
     of the flux to the threshold.
 
     If the threshold is a float then the spectrum's uncertainty will be

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -161,3 +161,14 @@ def is_continuum_near_zero(spectrum, eps=0.01):
     else:
         raise Exception('Spectrum flux has units, eps does not, either include uncertainty or use units on eps')
         #return np.median(spectrum.flux) / median_absolute_deviation(spectrum.flux) < eps
+
+def warn_spectrum_continuum_subtracted(eps):
+    def real_decorator(function):
+        def wrapper(*args, **kwargs):
+            spectrum = args[0]
+            if not is_continuum_near_zero(spectrum, eps):
+                raise Exception('Spectrum does not appear to be continuum subtracted.')
+            result = function(*args, **kwargs)
+            return result
+        return wrapper
+    return real_decorator

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -183,7 +183,7 @@ def warn_continuum_below_threshold(threshold=0.01, check=conf.do_continuum_funct
     Decorator for methods that should warn if the baseline
     of the spectrum does not appear to be below a threshold.
 
-    The ``check`` parameter is based on the 
+    The ``check`` parameter is based on the
     `astropy configuration system <http://docs.astropy.org/en/stable/config/#adding-new-configuration-items>`_.
     Examples are on that page to show how to turn off this type of warning checking.
     """

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -183,8 +183,8 @@ def warn_continuum_below_threshold(threshold=0.01, check=conf.do_continuum_funct
     Decorator for methods that should warn if the baseline
     of the spectrum does not appear to be below a threshold.
 
-    The ``check`` parameter is based on the `astropy configuration system
-    http://docs.astropy.org/en/stable/config/#adding-new-configuration-items`_.
+    The ``check`` parameter is based on the 
+    `astropy configuration system <http://docs.astropy.org/en/stable/config/#adding-new-configuration-items>`_.
     Examples are on that page to show how to turn off this type of warning checking.
     """
     def actual_decorator(function):

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -195,7 +195,7 @@ def warn_continuum_below_threshold(threshold=0.01):
                 if not is_continuum_below_threshold(spectrum, threshold):
                     message = "Spectrum is not below the threshold {}.\n\n".format(threshold)
                     message += ("""If you want to suppress this warning either type """
-                                """'specutils.conf.do_continuum_functin_check = False' or """
+                                """'specutils.conf.do_continuum_function_check = False' or """
                                 """see http://docs.astropy.org/en/stable/config/#adding-new-configuration-items """
                                 """for other ways to configure the warning.""")
 

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -134,7 +134,7 @@ def is_continuum_below_threshold(spectrum, threshold=0.01):
     directly compares the median of the spectrum to the threshold.
     of the flux to the threshold.
 
-    If the threshold is a float then the spectrum's uncertainty will be
+    If the threshold is a float or dimensionless quantity then the spectrum's uncertainty will be
     used or an estimate of the uncertainty. If the uncertainty is present then the
     threshold is compared to the median of the flux divided by the
     uncertainty.  If the uncertainty is not present then the threshold

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -130,7 +130,7 @@ def is_continuum_below_threshold(spectrum, threshold=0.01):
     Determine if the baseline of this spectrum is less than a threshold.
     I.e., an estimate of whether or not the continuum has been subtracted.
 
-    If ``threshold`` is an `~astropy.units.Quantity` with flux units, this 
+    If ``threshold`` is an `~astropy.units.Quantity` with flux units, this
     directly compares the median of the spectrum to the threshold.
     of the flux to the threshold.
 

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -178,7 +178,7 @@ def is_continuum_below_threshold(spectrum, threshold=0.01):
     else:
         return np.median(flux) / median_absolute_deviation(flux) < threshold
 
-def warn_continuum_below_threshold(threshold=0.01, check=conf.do_continuum_function_check):
+def warn_continuum_below_threshold(threshold=0.01):
     """
     Decorator for methods that should warn if the baseline
     of the spectrum does not appear to be below a threshold.
@@ -190,7 +190,7 @@ def warn_continuum_below_threshold(threshold=0.01, check=conf.do_continuum_funct
     def actual_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
-            if check:
+            if conf.do_continuum_function_check:
                 spectrum = args[0]
                 if not is_continuum_below_threshold(spectrum, threshold):
                     warnings.warn('Spectrum is not below the threshold {}.'.format(threshold),

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -127,7 +127,7 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None):
 
 def is_continuum_below_threshold(spectrum, threshold=0.01):
     """
-    Determine if the baseline of this spectrum is less than the threshold.
+    Determine if the baseline of this spectrum is less than a threshold.
     I.e., an estimate of whether or not the continuum has been subtracted.
 
     If the threshold is an `~astropy.units.Quantity` then compare the median

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -193,8 +193,13 @@ def warn_continuum_below_threshold(threshold=0.01):
             if conf.do_continuum_function_check:
                 spectrum = args[0]
                 if not is_continuum_below_threshold(spectrum, threshold):
-                    warnings.warn('Spectrum is not below the threshold {}.'.format(threshold),
-                                  AstropyUserWarning)
+                    message = "Spectrum is not below the threshold {}.\n\n".format(threshold)
+                    message += ("""If you want to suppress this warning either type """
+                                """'specutils.conf.do_continuum_functin_check = False' or """
+                                """see http://docs.astropy.org/en/stable/config/#adding-new-configuration-items """
+                                """for other ways to configure the warning.""")
+
+                    warnings.warn(message, AstropyUserWarning)
             result = function(*args, **kwargs)
             return result
         return wrapper

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -9,8 +9,9 @@ import numpy as np
 from .. import conf
 from ..manipulation import extract_region
 from .utils import computation_wrapper
+import astropy.units as u
 from astropy.stats import sigma_clip
-from astropy.stats import median_absolute_deviation
+from astropy.stats import mad_std
 from astropy.utils.exceptions import AstropyUserWarning
 
 
@@ -168,16 +169,16 @@ def is_continuum_below_threshold(spectrum, threshold=0.01):
     # If the threshold has units then the assumption is that we want
     # to compare the median of the flux regardless of the
     # existence of the uncertainty.
-    if hasattr(threshold, 'unit'):
+    if hasattr(threshold, 'unit') and not threshold.unit == u.dimensionless_unscaled:
         return np.median(flux) < threshold
 
     # If threshold does not have a unit, ie it is not a quantity, then
     # we are going to calculate based on the S/N if the uncertainty
     # exists.
-    if uncertainty:
+    if uncertainty and uncertainty.uncertainty_type != 'std':
         return np.median(flux / uncertainty.quantity) < threshold
     else:
-        return np.median(flux) / median_absolute_deviation(flux) < threshold
+        return np.median(flux) / mad_std(flux) < threshold
 
 def warn_continuum_below_threshold(threshold=0.01):
     """

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -8,7 +8,7 @@ import astropy.units as u
 from astropy.stats import sigma_clipped_stats
 
 from ..manipulation.utils import excise_regions
-from ..analysis import fwhm, centroid, warn_spectrum_continuum_subtracted
+from ..analysis import fwhm, centroid, warn_continuum_below_threshold
 from ..utils import QuantityModel
 from ..manipulation import extract_region, noise_region_uncertainty
 from ..spectra.spectral_region import SpectralRegion
@@ -97,7 +97,7 @@ def _consecutive(data, stepsize=1):
     return np.split(data, np.where(np.diff(data) != stepsize)[0]+1)
 
 
-@warn_spectrum_continuum_subtracted(eps=0.01, check=True)
+@warn_continuum_below_threshold(threshold=0.01, check=True)
 def find_lines_threshold(spectrum, noise_factor=1):
     """
     Find the emission and absorption lines in a spectrum. The method
@@ -171,7 +171,7 @@ def find_lines_threshold(spectrum, noise_factor=1):
     return qtable
 
 
-@warn_spectrum_continuum_subtracted(eps=0.01, check=True)
+@warn_continuum_below_threshold(threshold=0.01, check=True)
 def find_lines_derivative(spectrum, flux_threshold=None):
     """
     Find the emission and absorption lines in a spectrum. The method

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -8,7 +8,7 @@ import astropy.units as u
 from astropy.stats import sigma_clipped_stats
 
 from ..manipulation.utils import excise_regions
-from ..analysis import fwhm, centroid
+from ..analysis import fwhm, centroid, warn_spectrum_continuum_subtracted
 from ..utils import QuantityModel
 from ..manipulation import extract_region, noise_region_uncertainty
 from ..spectra.spectral_region import SpectralRegion
@@ -97,6 +97,7 @@ def _consecutive(data, stepsize=1):
     return np.split(data, np.where(np.diff(data) != stepsize)[0]+1)
 
 
+@warn_spectrum_continuum_subtracted(eps=0.01, check=True)
 def find_lines_threshold(spectrum, noise_factor=1):
     """
     Find the emission and absorption lines in a spectrum. The method
@@ -170,6 +171,7 @@ def find_lines_threshold(spectrum, noise_factor=1):
     return qtable
 
 
+@warn_spectrum_continuum_subtracted
 def find_lines_derivative(spectrum, flux_threshold=None):
     """
     Find the emission and absorption lines in a spectrum. The method

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -171,7 +171,7 @@ def find_lines_threshold(spectrum, noise_factor=1):
     return qtable
 
 
-@warn_spectrum_continuum_subtracted
+@warn_spectrum_continuum_subtracted(eps=0.01, check=True)
 def find_lines_derivative(spectrum, flux_threshold=None):
     """
     Find the emission and absorption lines in a spectrum. The method

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -97,7 +97,7 @@ def _consecutive(data, stepsize=1):
     return np.split(data, np.where(np.diff(data) != stepsize)[0]+1)
 
 
-@warn_continuum_below_threshold(threshold=0.01, check=True)
+@warn_continuum_below_threshold(threshold=0.01)
 def find_lines_threshold(spectrum, noise_factor=1):
     """
     Find the emission and absorption lines in a spectrum. The method
@@ -171,7 +171,7 @@ def find_lines_threshold(spectrum, noise_factor=1):
     return qtable
 
 
-@warn_continuum_below_threshold(threshold=0.01, check=True)
+@warn_continuum_below_threshold(threshold=0.01)
 def find_lines_derivative(spectrum, flux_threshold=None):
     """
     Find the emission and absorption lines in a spectrum. The method

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -11,7 +11,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from ..spectra import Spectrum1D, SpectralRegion
 from ..analysis import (line_flux, equivalent_width, snr, centroid,
                         gaussian_sigma_width, gaussian_fwhm, fwhm,
-                        snr_derived, fwzi, is_continuum_near_zero)
+                        snr_derived, fwzi, is_continuum_below_threshold)
 from ..fitting import find_lines_threshold
 from ..tests.spectral_examples import simulated_spectra
 
@@ -582,19 +582,19 @@ def test_fwzi_multi_spectrum():
     assert quantity_allclose(fwzi(spec), expected)
 
 
-def test_is_continuum_near_zero():
+def test_is_continuum_below_threshold():
 
     # No mask, no uncertainty
     wavelengths = [300, 500, 1000] * u.nm
     data = [0.001, -0.003, 0.003] * u.Jy
     spectrum = Spectrum1D(spectral_axis=wavelengths, flux=data)
-    assert True == is_continuum_near_zero(spectrum, eps=0.1*u.Jy)
+    assert True == is_continuum_below_threshold(spectrum, threshold=0.1*u.Jy)
 
-#    # No mask, no uncertainty, eps is float
+#    # No mask, no uncertainty, threshold is float
 #    wavelengths = [300, 500, 1000] * u.nm
 #    data = [0.0081, 0.0043, 0.0072] * u.Jy
 #    spectrum = Spectrum1D(spectral_axis=wavelengths, flux=data)
-#    assert True == is_continuum_near_zero(spectrum, eps=0.1)
+#    assert True == is_continuum_below_threshold(spectrum, threshold=0.1)
 
     # No mask, with uncertainty
     wavelengths = [300, 500, 1000] * u.nm
@@ -603,7 +603,7 @@ def test_is_continuum_near_zero():
     spectrum = Spectrum1D(spectral_axis=wavelengths, flux=data,
                           uncertainty=uncertainty)
 
-    assert True == is_continuum_near_zero(spectrum, eps=0.1)
+    assert True == is_continuum_below_threshold(spectrum, threshold=0.1)
 
     # With mask, with uncertainty
     wavelengths = [300, 500, 1000] * u.nm
@@ -613,7 +613,7 @@ def test_is_continuum_near_zero():
     spectrum = Spectrum1D(spectral_axis=wavelengths, flux=data,
                           uncertainty=uncertainty, mask=mask)
 
-    assert True == is_continuum_near_zero(spectrum, eps=0.1)
+    assert True == is_continuum_below_threshold(spectrum, threshold=0.1)
 
     # With mask, with uncertainty -- should throw an exception
     wavelengths = [300, 500, 1000] * u.nm

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -626,3 +626,4 @@ def test_is_continuum_below_threshold():
     print('spectrum has flux {}'.format(spectrum.flux))
     with pytest.warns(AstropyUserWarning) as e_info:
         find_lines_threshold(spectrum, noise_factor=1)
+        assert len(e_info)==1 and 'if you want to suppress this warning' in e_info[0].message.args[0].lower()

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -10,7 +10,7 @@ from astropy.tests.helper import quantity_allclose
 from ..spectra import Spectrum1D, SpectralRegion
 from ..analysis import (line_flux, equivalent_width, snr, centroid,
                         gaussian_sigma_width, gaussian_fwhm, fwhm,
-                        snr_derived, fwzi)
+                        snr_derived, fwzi, is_continuum_near_zero)
 from ..tests.spectral_examples import simulated_spectra
 
 
@@ -578,3 +578,27 @@ def test_fwzi_multi_spectrum():
     expected = [113.51706001 * u.AA, 567.21252727 * u.AA, 499.5024546 * u.AA]
 
     assert quantity_allclose(fwzi(spec), expected)
+
+
+def test_is_continuum_near_zero():
+
+    # No mask, no uncertainty
+    wavelengths = [300, 500, 1000] * u.nm
+    data = [0.001, -0.003, 0.003] * u.Jy
+    spectrum = Spectrum1D(spectral_axis=wavelengths, flux=data)
+    assert True == is_continuum_near_zero(spectrum, eps=0.1*u.Jy)
+
+#    # No mask, no uncertainty, eps is float
+#    wavelengths = [300, 500, 1000] * u.nm
+#    data = [0.0081, 0.0043, 0.0072] * u.Jy
+#    spectrum = Spectrum1D(spectral_axis=wavelengths, flux=data)
+#    assert True == is_continuum_near_zero(spectrum, eps=0.1)
+
+    # No mask, with uncertainty
+    wavelengths = [300, 500, 1000] * u.nm
+    data = [0.03, 0.029, 0.033] * u.Jy
+    uncertainty = StdDevUncertainty([1.01, 1.13, 1.1] * u.Jy)
+    spectrum = Spectrum1D(spectral_axis=wavelengths, flux=data,
+                          uncertainty=uncertainty)
+
+    assert True == is_continuum_near_zero(spectrum, eps=0.1)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -598,22 +598,22 @@ def test_is_continuum_below_threshold():
 
     # No mask, with uncertainty
     wavelengths = [300, 500, 1000] * u.nm
-    data = [0.03, 0.029, 0.033] * u.Jy
-    uncertainty = StdDevUncertainty([1.01, 1.13, 1.1] * u.Jy)
+    data = [0.03, 0.029, 0.031] * u.Jy
+    uncertainty = StdDevUncertainty([1.01, 1.03, 1.01] * u.Jy)
     spectrum = Spectrum1D(spectral_axis=wavelengths, flux=data,
                           uncertainty=uncertainty)
 
-    assert True == is_continuum_below_threshold(spectrum, threshold=0.1)
+    assert True == is_continuum_below_threshold(spectrum, threshold=0.1*u.Jy)
 
     # With mask, with uncertainty
     wavelengths = [300, 500, 1000] * u.nm
-    data = [0.03, 1.029, 0.033] * u.Jy
+    data = [0.01, 1.029, 0.013] * u.Jy
     mask = np.array([False, True, False])
     uncertainty = StdDevUncertainty([1.01, 1.13, 1.1] * u.Jy)
     spectrum = Spectrum1D(spectral_axis=wavelengths, flux=data,
                           uncertainty=uncertainty, mask=mask)
 
-    assert True == is_continuum_below_threshold(spectrum, threshold=0.1)
+    assert True == is_continuum_below_threshold(spectrum, threshold=0.1*u.Jy)
 
     # With mask, with uncertainty -- should throw an exception
     wavelengths = [300, 500, 1000] * u.nm


### PR DESCRIPTION
This PR will create a simple spectrum checker to see if the flux baseline is near zero as this is required for several of the other methods (e.g., find_lines which assumes the flux data is continuum subtracted).

Fixes https://github.com/astropy/specutils/issues/535