### PR TITLE
Extend spectrum information written by `tabular_fits_writer`

### DIFF
--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -80,16 +80,12 @@ def tabular_fits_writer(spectrum, file_name, update_header=False, **kwargs):
     if update_header:
         hdr_types = (str, int, float, complex, bool,
                      np.floating, np.integer, np.complexfloating, np.bool_)
-        header.update([k for k in spectrum.meta.items() if
-                       isinstance(k[1], hdr_types)])
+        header.update([keyword for keyword in spectrum.meta.items() if
+                       isinstance(keyword[1], hdr_types)])
 
-    # Strip header of FITS reserved keywords (strangely, loop does not work!)
-    if 'NAXIS' in header:
-        header.remove('NAXIS')
-    if 'NAXIS1' in header:
-        header.remove('NAXIS1')
-    if 'NAXIS2' in header:
-        header.remove('NAXIS2')
+    # Strip header of FITS reserved keywords
+    for keyword in ['NAXIS', 'NAXIS1', 'NAXIS2']:
+        header.remove(keyword, ignore_missing=True)
 
     # Mapping of spectral_axis types to header TTYPE1
     dispname = disp.unit.physical_type
@@ -98,9 +94,9 @@ def tabular_fits_writer(spectrum, file_name, update_header=False, **kwargs):
 
     columns = [disp, flux]
     colnames = [dispname, "flux"]
-    # Include uncertainty - ToDo: uncertainty units?
+    # Include uncertainty - units to be inferred from spectrum.flux
     if spectrum.uncertainty is not None:
-        columns.append(spectrum.uncertainty.array * spectrum.uncertainty.unit)
+        columns.append(spectrum.uncertainty.quantity)
         colnames.append("uncertainty")
 
     tab = Table(columns, names=colnames, meta=header)


### PR DESCRIPTION
This is an attempt to address some of the issues reported in #531, notably adding the missing unit information to the written spectrum. It also adds the `uncertainty` column, if present, and indicates the type of `spectral_axis` in `TTYPE1`. The last commit adds writing of any other header metadata, taking the 2nd option discussed in
https://github.com/astropy/specutils/issues/531#issuecomment-540605959 (with a new kwarg `update_header`). It also passes other kwargs though to the table writer, allowing e.g. to force overwriting of existing files.
Added tests for all these functions in `test_loaders.py`

Files thus written still fail to be read in as `tabular-fits` on the `WCSWrapper` error, but since they are fully compliant (except for a missing checksum) FITS files with complete spectral information, this really seems to be more of a problem on the reader side.