### PR TITLE
ENH: make default_loaders use `is_fits` to identify FITS and support compressed FITS 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ matrix:
 
     # check on somewhat older versions LTS version
     - os: linux
-      env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts NUMPY_VERSION=1.16
+      env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts NUMPY_VERSION=1.17
 
     # Add a job that runs from cron only and tests against astropy dev and
     # numpy dev to give a change for early discovery of issues and feedback

--- a/specutils/io/default_loaders/apogee.py
+++ b/specutils/io/default_loaders/apogee.py
@@ -28,8 +28,8 @@ def apVisit_identify(origin, *args, **kwargs):
     Registry.
     """
     return (isinstance(args[0], str) and
-            args[0].lower().split('.')[-1] == 'fits' and
-            args[0].startswith('apVisit'))
+            args[0].startswith('apVisit') and
+            fits.connect.is_fits(origin, *args))
 
 
 def apStar_identify(origin, *args, **kwargs):

--- a/specutils/io/default_loaders/generic_cube.py
+++ b/specutils/io/default_loaders/generic_cube.py
@@ -22,7 +22,7 @@ from ...spectra import Spectrum1D
 # need to add `format="my-format"` in the `Spectrum1D.read` call.
 def identify_generic_fits(origin, *args, **kwargs):
     return (isinstance(args[0], str) and
-            os.path.splitext(args[0].lower())[1] == '.fits' and
+            fits.connect.is_fits(origin, *args) and
             fits.getheader(args[0])['NAXIS'] == 3)
 
 

--- a/specutils/io/default_loaders/hst_cos.py
+++ b/specutils/io/default_loaders/hst_cos.py
@@ -35,10 +35,9 @@ def cos_spectrum_loader(file_name, **kwargs):
         The spectrum that is represented by the data in this table.
     """
 
-    name = os.path.basename(file_name)
-
     with fits.open(file_name, **kwargs) as hdu:
         header = hdu[0].header
+        name = header.get('FILENAME')
         meta = {'header': header}
 
         unit = Unit("erg/cm**2 Angstrom s")

--- a/specutils/io/default_loaders/hst_stis.py
+++ b/specutils/io/default_loaders/hst_stis.py
@@ -35,10 +35,9 @@ def stis_spectrum_loader(file_name, **kwargs):
         The spectrum that is represented by the data in this table.
     """
 
-    name = os.path.basename(file_name)
-
     with fits.open(file_name, **kwargs) as hdu:
         header = hdu[0].header
+        name = header.get('FILENAME')
         meta = {'header': header}
 
         unit = Unit("erg/cm**2 Angstrom s")

--- a/specutils/io/default_loaders/muscles_sed.py
+++ b/specutils/io/default_loaders/muscles_sed.py
@@ -16,8 +16,9 @@ def identify_muscles_sed(origin, *args, **kwargs):
     # args[0] = filename
     # fits.open(args[0]) = hdulist
     return (isinstance(args[0], str) and
+            args[0].split('.')[0].endswith('sed') and
             # check if file is .fits
-            args[0].endswith('sed.fits') and
+            fits.connect.is_fits(origin, *args) and
             # check hdulist has more than one extension
             len(fits.open(args[0])) > 1 and
             # check if fits has BinTable extension

--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -30,7 +30,8 @@ def spec_identify(origin, *args, **kwargs):
     Registry.
     """
     return (isinstance(args[0], str) and
-            _spec_pattern.match(args[0]) is not None)
+            _spec_pattern.match(os.path.basename(args[0])) is not None and
+            fits.connect.is_fits(origin, *args))
 
 
 def spSpec_identify(origin, *args, **kwargs):
@@ -39,7 +40,8 @@ def spSpec_identify(origin, *args, **kwargs):
     Registry.
     """
     return (isinstance(args[0], str) and
-            _spSpec_pattern.match(args[0]) is not None)
+            _spSpec_pattern.match(os.path.basename(args[0])) is not None and
+            fits.connect.is_fits(origin, *args))
 
 
 @data_loader(label="SDSS-III/IV spec", identifier=spec_identify, extensions=['fits'])
@@ -57,10 +59,10 @@ def spec_loader(file_name, **kwargs):
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
     """
-    name = os.path.basename(file_name.rstrip(os.sep)).rsplit('.', 1)[0]
     hdulist = fits.open(file_name, **kwargs)
 
     header = hdulist[0].header
+    name = header.get('NAME')
     meta = {'header': header}
 
     # spectrum is in HDU 1
@@ -99,10 +101,10 @@ def spSpec_loader(file_name, **kwargs):
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
     """
-    name = os.path.basename(file_name.rstrip(os.sep)).rsplit('.', 1)[0]
     hdulist = fits.open(file_name, **kwargs)
 
     header = hdulist[0].header
+    name = header.get('NAME')
     meta = {'header': header}
     wcs = WCS(hdulist[0].header)
 

--- a/specutils/io/default_loaders/subaru_pfs_spec.py
+++ b/specutils/io/default_loaders/subaru_pfs_spec.py
@@ -32,7 +32,8 @@ def spec_identify(origin, *args, **kwargs):
     Registry.
     """
     return (isinstance(args[0], str) and
-            _spec_pattern.match(args[0]) is not None)
+            _spec_pattern.match(args[0]) is not None and
+            fits.connect.is_fits(origin, *args))
 
 
 @data_loader(label="Subaru-pfsObject", identifier=spec_identify,

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -23,17 +23,21 @@ def identify_tabular_fits(origin, *args, **kwargs):
     # fits.open(args[0]) = hdulist
     return (isinstance(args[0], str) and
             # check if file is .fits
-            os.path.splitext(args[0].lower())[1] == '.fits' and
+            fits.connect.is_fits(origin, *args) and
             # check hdulist has more than one extension
             len(fits.open(args[0])) > 1 and
             # check if fits has BinTable extension
-            isinstance(fits.open(args[0])[1], fits.BinTableHDU)
+            isinstance(fits.open(args[0])[1], fits.BinTableHDU) and not
+            (fits.getheader(args[0])['TELESCOP'] == 'SDSS 2.5-M' and
+             fits.getheader(args[0])['FIBERID'] > 0) and not
+            (fits.getheader(args[0])['TELESCOP'] == 'HST' and
+             fits.getheader(args[0])['INSTRUME'] in ('COS', 'STIS'))
             )
 
 
 @data_loader("tabular-fits", identifier=identify_tabular_fits,
              dtype=Spectrum1D, extensions=['fits'])
-def tabular_fits_loader(file_name, column_mapping=None, **kwargs):
+def tabular_fits_loader(file_name, column_mapping=None, hdu=1, **kwargs):
     """
     Load spectrum from a FITS file.
 
@@ -41,6 +45,8 @@ def tabular_fits_loader(file_name, column_mapping=None, **kwargs):
     ----------
     file_name: str
         The path to the FITS file
+    hdu: int
+        The HDU of the fits file (default: 1st extension) to read from
     column_mapping : dict
         A dictionary describing the relation between the FITS file columns
         and the arguments of the `Spectrum1D` class, along with unit
@@ -59,9 +65,9 @@ def tabular_fits_loader(file_name, column_mapping=None, **kwargs):
     # Parse the wcs information. The wcs will be passed to the column finding
     # routines to search for spectral axis information in the file.
     with fits.open(file_name) as hdulist:
-        wcs = WCS(hdulist[0].header)
+        wcs = WCS(hdulist[hdu].header)
 
-    tab = Table.read(file_name, format='fits')
+    tab = Table.read(file_name, format='fits', hdu=hdu)
 
     # If no column mapping is given, attempt to parse the file using
     # unit information
@@ -73,6 +79,17 @@ def tabular_fits_loader(file_name, column_mapping=None, **kwargs):
 
 @custom_writer("tabular-fits")
 def tabular_fits_writer(spectrum, file_name, update_header=False, **kwargs):
+    """
+    Write spectrum to BINTABLE extension of a FITS file.
+
+    Parameters
+    ----------
+    spectrum: Spectrum1D
+    file_name: str
+        The path to the FITS file
+    update_header: bool
+        Update FITS header with all compatible entries in `spectrum.meta`
+    """
     flux = spectrum.flux
     disp = spectrum.spectral_axis
     header = spectrum.meta.get('header', fits.header.Header()).copy()

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import shutil
 import tempfile
 import urllib
@@ -46,7 +47,8 @@ def test_spectrum1d_GMOSfits(remote_data_path):
 def test_spectrumlist_GMOSfits(remote_data_path, caplog):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', (VerifyWarning, UnitsWarning))
-        spectrum_list = SpectrumList.read(remote_data_path, format='wcs1d-fits')
+        spectrum_list = SpectrumList.read(remote_data_path,
+                                          format='wcs1d-fits')
 
     assert len(spectrum_list) == 1
 
@@ -99,7 +101,7 @@ def test_generic_ecsv_reader(tmpdir):
 @remote_access([{'id': '1481119', 'filename': 'COS_FUV.fits'},
                 {'id': '1481181', 'filename': 'COS_NUV.fits'}])
 def test_hst_cos(remote_data_path):
-    spec = Spectrum1D.read(remote_data_path, format='HST/COS')
+    spec = Spectrum1D.read(remote_data_path)
 
     assert isinstance(spec, Spectrum1D)
     assert spec.flux.size > 0
@@ -109,7 +111,7 @@ def test_hst_cos(remote_data_path):
                 {'id': '1481185', 'filename': 'STIS_NUV.fits'},
                 {'id': '1481183', 'filename': 'STIS_CCD.fits'}])
 def test_hst_stis(remote_data_path):
-    spec = Spectrum1D.read(remote_data_path, format='HST/STIS')
+    spec = Spectrum1D.read(remote_data_path)
 
     assert isinstance(spec, Spectrum1D)
     assert spec.flux.size > 0
@@ -117,11 +119,12 @@ def test_hst_stis(remote_data_path):
 
 @pytest.mark.remote_data
 def test_sdss_spec():
+    sp_pattern = 'spec-4055-55359-0596.fits.'
     with urllib.request.urlopen('https://dr14.sdss.org/optical/spectrum/view/data/format%3Dfits/spec%3Dlite?mjd=55359&fiberid=596&plateid=4055') as response:
-        with tempfile.NamedTemporaryFile() as tmp_file:
+        with tempfile.NamedTemporaryFile(prefix=sp_pattern) as tmp_file:
             shutil.copyfileobj(response, tmp_file)
 
-            spec = Spectrum1D.read(tmp_file.name, format="SDSS-III/IV spec")
+            spec = Spectrum1D.read(tmp_file.name)
 
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0
@@ -129,13 +132,35 @@ def test_sdss_spec():
 
 @pytest.mark.remote_data
 def test_sdss_spspec():
+    sp_pattern = 'spSpec-51957-0273-016.fit.'
     with urllib.request.urlopen('http://das.sdss.org/spectro/1d_26/0273/1d/spSpec-51957-0273-016.fit') as response:
-        with tempfile.NamedTemporaryFile() as tmp_file:
+        with tempfile.NamedTemporaryFile(prefix=sp_pattern) as tmp_file:
             shutil.copyfileobj(response, tmp_file)
 
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', FITSFixedWarning)
                 spec = Spectrum1D.read(tmp_file.name, format="SDSS-I/II spSpec")
+
+            assert isinstance(spec, Spectrum1D)
+            assert spec.flux.size > 0
+
+
+@pytest.mark.skipif('sys.platform.startswith("win")',
+                    reason='Uncertain availability of compression utilities')
+@pytest.mark.remote_data
+@pytest.mark.parametrize('compress', ['gzip', 'bzip2'])
+def test_sdss_compressed(compress):
+    ext = {'gzip': '.gz', 'bzip2': '.bz2'}
+    sp_pattern = 'spSpec-51957-0273-016.fit.'
+    with urllib.request.urlopen('http://das.sdss.org/spectro/1d_26/0273/1d/spSpec-51957-0273-016.fit') as response:
+        with tempfile.NamedTemporaryFile(prefix=sp_pattern) as tmp_file:
+            shutil.copyfileobj(response, tmp_file)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', FITSFixedWarning)
+                os.system(f'{compress} {tmp_file.name}')
+                spec = Spectrum1D.read(tmp_file.name + ext[compress])
+                os.system(f'{compress} -d {tmp_file.name}{ext[compress]}')
 
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0


### PR DESCRIPTION
Currently all `default_loaders` try to identify FITS files based on filenames and extensions only. This is arguably less robust than using information from the files themselves, e.g. will not recognise downloads assigned a random tempfile name. It also breaks the potential to use `astropy.io.fits`'s transparent decompression of gzip and bzip2 files.
This PR proposes to use instead the `is_fits` function provided by Astropy, which is first looking for the FITS signature in the file before falling back to all the possible filename suffix variants. It also adds checks to `tabular_fits` to reject alternative formats (notably HST and SDSS ones) to allow auto-detection of the latter.
The tests try to automatically detect the format where possible; a test for compressed .fits is added.

Points for discussion:

- The two SDSS formats are still identified based on the filename; one could probably extract sufficient information from the header instead.

- Waiting whether to add `is_fits` use to `custom_loading.rst` or replace the current code example.

- Is there a better way to call `gzip` and `bzip2` in the tests (perhaps one that might even work on Windows)?