### PR TITLE
update doc sidebar to be more useful

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,6 +131,9 @@ html_theme_options = {
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
+# add to/modify the defaults already provided by astropy
+html_sidebars['**'] = ['localtoc.html']
+html_sidebars['index'] = ['globaltoc.html', 'localtoc.html']
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.


### PR DESCRIPTION
This PR makes a simple change to the specutils docs - it makes the left sidebar more useful (IMHO).  Currently the starting page sidebar looks like this:
![image](https://user-images.githubusercontent.com/346587/70069816-6b84f080-15c0-11ea-87fb-0761d7942bba.png)
while the PR changes it to:
![image](https://user-images.githubusercontent.com/346587/70069848-793a7600-15c0-11ea-8a2d-5442bd0795d4.png)

(the "interior" pages are unchanged, although that's now explicit rather than implicit)
