### PR TITLE
Fix APOGEE loaders

### DIFF
--- a/specutils/io/default_loaders/apogee.py
+++ b/specutils/io/default_loaders/apogee.py
@@ -94,7 +94,7 @@ def apVisit_loader(file_name, **kwargs):
 
     return Spectrum1D(data=data * unit,
                       uncertainty=uncertainty,
-                      dispersion=dispersion * dispersion_unit,
+                      spectral_axis=dispersion * dispersion_unit,
                       meta=meta)
 
 
@@ -135,7 +135,7 @@ def apStar_loader(file_name, **kwargs):
 
     return Spectrum1D(data=data * unit,
                       uncertainty=uncertainty,
-                      dispersion=dispersion * dispersion_unit,
+                      spectral_axis=dispersion * dispersion_unit,
                       meta=meta,
                       wcs=wcs)
 
@@ -162,7 +162,7 @@ def aspcapStar_loader(file_name, **kwargs):
     meta = {'header': header}
     wcs = WCS(hdulist[1].header)
 
-    data = hdulist[1].data # spectrum in the first extension
+    data = hdulist[1].data  # spectrum in the first extension
     unit = def_unit('arbitrary units')
 
     uncertainty = StdDevUncertainty(hdulist[2].data)
@@ -174,6 +174,6 @@ def aspcapStar_loader(file_name, **kwargs):
 
     return Spectrum1D(data=data * unit,
                       uncertainty=uncertainty,
-                      dispersion=dispersion * dispersion_unit,
+                      spectral_axis=dispersion * dispersion_unit,
                       meta=meta,
                       wcs=wcs)

--- a/specutils/io/default_loaders/tests/test_apogee.py
+++ b/specutils/io/default_loaders/tests/test_apogee.py
@@ -1,0 +1,36 @@
+# Third-party
+from astropy.utils.data import download_file
+from astropy.config import set_temp_cache
+import pytest
+
+# Package
+from specutils.io.default_loaders.apogee import (apStar_loader, apVisit_loader,
+                                                 aspcapStar_loader)
+
+
+@pytest.mark.remote_data
+def test_apStar_loader(tmpdir):
+    apstar_url = ("https://data.sdss.org/sas/dr16/apogee/spectro/redux/r12/"
+                  "stars/apo25m/N7789/apStar-r12-2M00005414+5522241.fits")
+    with set_temp_cache(path=str(tmpdir)):
+        filename = download_file(apstar_url, cache=True)
+        spectrum = apStar_loader(filename)
+
+
+@pytest.mark.remote_data
+def test_apVisit_loader(tmpdir):
+    apvisit_url = ("https://data.sdss.org/sas/dr16/apogee/spectro/redux/r12/"
+                   "visit/apo25m/N7789/5094/55874/"
+                   "apVisit-r12-5094-55874-123.fits")
+    with set_temp_cache(path=str(tmpdir)):
+        filename = download_file(apvisit_url, cache=True)
+        spectrum = apVisit_loader(filename)
+
+
+@pytest.mark.remote_data
+def test_aspcapStar_loader(tmpdir):
+    aspcap_url = ("https://data.sdss.org/sas/dr16/apogee/spectro/aspcap/r12/"
+                  "l33/apo25m/N7789/aspcapStar-r12-2M00005414+5522241.fits")
+    with set_temp_cache(path=str(tmpdir)):
+        filename = download_file(aspcap_url, cache=True)
+        spectrum = aspcapStar_loader(filename)


### PR DESCRIPTION
This fixes #559 by switching the kwargs from `dispersion` to `spectral_axis` in the APOGEE data loaders.

I also added very basic tests that at least download APOGEE data files and try the loaders on the data files. 