### PR TITLE
mexican hat to ricker

### DIFF
--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -166,7 +166,7 @@ parameter estimators, or if one wants to use different parameter estimators then
 one can create a dictionary where the key is the parameter name and the value is
 a function that operates on a spectrum (lambda functions are very useful for
 this purpose). For example if one wants to estimate the line parameters of a
-line fit for a `~astropy.modeling.functional_models.MexicanHat1D` one can
+line fit for a `~astropy.modeling.functional_models.RickerWavelet1D` one can
 define the ``estimators`` dictionary and attach in the model's ``_constraints``
 dictionary:
 
@@ -180,15 +180,15 @@ dictionary:
    >>> sub_region = SpectralRegion(4*u.um, 5*u.um)
    >>> sub_spectrum = extract_region(spectrum, sub_region)
 
-   >>> mh = models.MexicanHat1D()
+   >>> ricker = models.RickerWavelet1D()
    >>> estimators = { 'amplitude': lambda s: max(s.flux), 'x_0': lambda s: centroid(s, region=None), 'sigma': lambda s: fwhm(s) }
    >>>
-   >>> for name in mh.param_names:
-   ...     par = getattr(mh, name)
+   >>> for name in ricker.param_names:
+   ...     par = getattr(ricker, name)
    ...     setattr(par, "estimator", estimators[name])
 
-   >>> print(estimate_line_parameters(spectrum, mh))  # doctest:+FLOAT_CMP
-   Model: MexicanHat1D
+   >>> print(estimate_line_parameters(spectrum, ricker))  # doctest:+FLOAT_CMP
+   Model: RickerWavelet1D
    Inputs: ('x',)
    Outputs: ('y',)
    Model set size: 1

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -167,8 +167,8 @@ one can create a dictionary where the key is the parameter name and the value is
 a function that operates on a spectrum (lambda functions are very useful for
 this purpose). For example if one wants to estimate the line parameters of a
 line fit for a `~astropy.modeling.functional_models.RickerWavelet1D` one can
-define the ``estimators`` dictionary and attach in the model's ``_constraints``
-dictionary:
+define the ``estimators`` dictionary and use it to populate the ``estimator``
+attribute of the model's parameters:
 
 .. code-block:: python
 
@@ -198,11 +198,6 @@ dictionary:
       ------------------ ------------------ -------------------
       2.4220683957581444 3.6045476935889367 0.24416769183724707
 
-.. warning::
-   Be aware the use of ``_constraints`` to store the estimators may change in
-   future versions of astropy or specutils to something more natural (i.e., not
-   a "private" attribute), as this is a workaround for a known limitation in
-   `astropy.modeling`.
 
 Model (Line) Fitting
 --------------------

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -181,11 +181,9 @@ attribute of the model's parameters:
    >>> sub_spectrum = extract_region(spectrum, sub_region)
 
    >>> ricker = models.RickerWavelet1D()
-   >>> estimators = { 'amplitude': lambda s: max(s.flux), 'x_0': lambda s: centroid(s, region=None), 'sigma': lambda s: fwhm(s) }
-   >>>
-   >>> for name in ricker.param_names:
-   ...     par = getattr(ricker, name)
-   ...     setattr(par, "estimator", estimators[name])
+   >>> ricker.amplitude.estimator = lambda s: max(s.flux)
+   >>> ricker.x_0.estimator = lambda s: centroid(s, region=None)
+   >>> ricker.sigma.estimator = lambda s: fwhm(s)
 
    >>> print(estimate_line_parameters(spectrum, ricker))  # doctest:+FLOAT_CMP
    Model: RickerWavelet1D

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -45,8 +45,8 @@ def _to_edge_pixel(subregion, spectrum):
             try:
                 left_index = int(np.ceil(spectrum.wcs.world_to_pixel(left_reg_in_spec_unit)))
             except Exception as e:
-                raise ValueError("Lower value, {}, could not convert using spectrum's WCS {}".format(
-                    left_reg_in_spec_unit, spectrum.wcs))
+                raise ValueError("Lower value, {}, could not convert using spectrum's WCS {}. Exception: {}".format(
+                    left_reg_in_spec_unit, spectrum.wcs, e))
 
     #
     # Right/upper side of sub region
@@ -66,8 +66,8 @@ def _to_edge_pixel(subregion, spectrum):
             try:
                 right_index = int(np.floor(spectrum.wcs.world_to_pixel(right_reg_in_spec_unit))) + 1
             except Exception as e:
-                raise ValueError("Upper value, {}, could not convert using spectrum's WCS {}".format(
-                    right_reg_in_spec_unit, spectrum.wcs))
+                raise ValueError("Upper value, {}, could not convert using spectrum's WCS {}. Exception: {}".format(
+                    right_reg_in_spec_unit, spectrum.wcs, e))
 
     return left_index, right_index
 


### PR DESCRIPTION
This PR addresses a problem @nmearl pointed out in https://github.com/astropy/specutils/pull/519#issuecomment-569531856 - that the renaming of `MexicanHat1D` to `Ricker1D` breaks one of the docs links.  I'm treating this as a stand-alone PR because we will want to not have this in a potential last-compatible-with-Astropy 3.x release, since the change is in Astropy 4.0.