### PR TITLE
Add len to SpectrumCollection

### DIFF
--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -221,6 +221,9 @@ class SpectrumCollection:
         """
         return self.flux.shape[:-1]
 
+    def __len__(self):
+        return self.shape[0]
+
     @property
     def ndim(self):
         """

--- a/specutils/tests/test_spectrum_collection.py
+++ b/specutils/tests/test_spectrum_collection.py
@@ -12,7 +12,7 @@ from ..utils.wcs_utils import gwcs_from_array
 @pytest.fixture
 def spectrum_collection():
     flux = u.Quantity(np.random.sample((5, 10)), unit='Jy')
-    spectral_axis = u.Quantity(np.arange(50).reshape((5, 10)), unit='AA')
+    spectral_axis = u.Quantity(np.arange(50).reshape((5, 10)) + 1, unit='AA')
     wcs = np.array([gwcs_from_array(x) for x in spectral_axis])
     uncertainty = StdDevUncertainty(np.random.sample((5, 10)), unit='Jy')
     mask = np.ones((5, 10)).astype(bool)
@@ -55,7 +55,7 @@ def test_spectrum_collection_slicing(spectrum_collection):
 def test_collection_without_optional_arguments():
     # Without uncertainties
     flux = u.Quantity(np.random.sample((5, 10)), unit='Jy')
-    spectral_axis = u.Quantity(np.arange(50).reshape((5, 10)), unit='AA')
+    spectral_axis = u.Quantity(np.arange(50).reshape((5, 10)) + 1, unit='AA')
     uncertainty = StdDevUncertainty(np.random.sample((5, 10)), unit='Jy')
     wcs = np.array([gwcs_from_array(x) for x in spectral_axis])
     mask = np.ones((5, 10)).astype(bool)
@@ -104,7 +104,7 @@ def test_create_collection_from_spectra_without_uncertainties():
 @pytest.mark.parametrize('scshape,expected_len', [((5, 10), 5), ((4, 5, 10), 4)])
 def test_len(scshape, expected_len):
     flux = u.Quantity(np.random.sample(scshape), unit='Jy')
-    spectral_axis = u.Quantity(np.arange(np.prod(scshape)).reshape(scshape), unit='AA')
+    spectral_axis = u.Quantity(np.arange(np.prod(scshape)).reshape(scshape) + 1, unit='AA')
     sc2d = SpectrumCollection(flux=flux, spectral_axis=spectral_axis)
 
     assert sc2d.shape == scshape[:-1]

--- a/specutils/tests/test_spectrum_collection.py
+++ b/specutils/tests/test_spectrum_collection.py
@@ -98,4 +98,14 @@ def test_create_collection_from_spectra_without_uncertainties():
     spec1 = Spectrum1D(spectral_axis=np.linspace(20, 60, 50) * u.AA,
                        flux=np.random.randn(50) * u.Jy)
 
-    spec_coll = SpectrumCollection.from_spectra([spec, spec1])
+    SpectrumCollection.from_spectra([spec, spec1])
+
+
+@pytest.mark.parametrize('scshape,expected_len', [((5, 10), 5), ((4, 5, 10), 4)])
+def test_len(scshape, expected_len):
+    flux = u.Quantity(np.random.sample(scshape), unit='Jy')
+    spectral_axis = u.Quantity(np.arange(np.prod(scshape)).reshape(scshape), unit='AA')
+    sc2d = SpectrumCollection(flux=flux, spectral_axis=spectral_axis)
+
+    assert sc2d.shape == scshape[:-1]
+    assert len(sc2d) == expected_len


### PR DESCRIPTION
This closes #574 by adding a ``__len__`` to SpectrumCollection which just gets the first dimension (which is consistent with numpy array,s quantities, and the like).