### PR TITLE
Fix to stacking behavior in SpectrumCollection.from_spectra

### DIFF
--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -123,10 +123,8 @@ class SpectrumCollection:
             raise ValueError("Shape of all elements must be the same.")
 
         # Compose multi-dimensional ndarrays for each property
-        flux = np.vstack(
-            [spec.flux.value for spec in spectra]) * spectra[0].flux.unit
-        spectral_axis = np.vstack(
-            [spec.spectral_axis.value for spec in spectra]) * spectra[0].spectral_axis.unit
+        flux = u.Quantity([spec.flux for spec in spectra])
+        spectral_axis = u.Quantity([spec.spectral_axis.value for spec in spectra])
 
         # Check that either all spectra have associated uncertainties, or that
         # none of them do. If only some do, log an error and ignore the
@@ -134,7 +132,7 @@ class SpectrumCollection:
         if not all((x.uncertainty is None for x in spectra)) and \
             any((x.uncertainty is not None for x in spectra)):
             uncertainty = spectra[0].uncertainty.__class__(
-                np.vstack([spec.uncertainty.array for spec in spectra]),
+                np.array([spec.uncertainty.array for spec in spectra]),
                 unit=spectra[0].uncertainty.unit)
         else:
             uncertainty = None
@@ -146,7 +144,7 @@ class SpectrumCollection:
         # none of them do. If only some do, log an error and ignore the masks.
         if not all((x.mask is None for x in spectra)) and \
             any((x.mask is not None for x in spectra)):
-            mask = np.vstack([spec.mask for spec in spectra])
+            mask = np.array([spec.mask for spec in spectra])
         else:
             mask = None
 

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -130,15 +130,18 @@ class SpectrumCollection:
         # none of them do. If only some do, log an error and ignore the
         # uncertainties.
         if not all((x.uncertainty is None for x in spectra)) and \
-            any((x.uncertainty is not None for x in spectra)):
-            uncertainty = spectra[0].uncertainty.__class__(
-                np.array([spec.uncertainty.array for spec in spectra]),
-                unit=spectra[0].uncertainty.unit)
+            any((x.uncertainty is not None for x in spectra)) and \
+            all((x.uncertainty.uncertainty_type ==
+                 spectra[0].uncertainty.uncertainty_type
+                 for x in spectra)):
+
+            quncs = u.Quantity([spec.uncertainty.quantity for spec in spectra])
+            uncertainty = spectra[0].uncertainty.__class__(quncs)
         else:
             uncertainty = None
 
-            logging.warning("Not all spectra have associated uncertainties, "
-                            "skipping uncertainties.")
+            logging.warning("Not all spectra have associated uncertainties of "
+                            "the same type, skipping uncertainties.")
 
         # Check that either all spectra have associated masks, or that
         # none of them do. If only some do, log an error and ignore the masks.

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -124,7 +124,7 @@ class SpectrumCollection:
 
         # Compose multi-dimensional ndarrays for each property
         flux = u.Quantity([spec.flux for spec in spectra])
-        spectral_axis = u.Quantity([spec.spectral_axis.value for spec in spectra])
+        spectral_axis = u.Quantity([spec.spectral_axis for spec in spectra])
 
         # Check that either all spectra have associated uncertainties, or that
         # none of them do. If only some do, log an error and ignore the

--- a/specutils/tests/test_spectrum_collection.py
+++ b/specutils/tests/test_spectrum_collection.py
@@ -90,6 +90,8 @@ def test_create_collection_from_spectrum1D():
     assert spec_coll.nspectral == 50
     assert isinstance(spec_coll.flux, u.Quantity)
     assert isinstance(spec_coll.spectral_axis, u.Quantity)
+    assert spec.spectral_axis.unit == spec_coll.spectral_axis.unit
+    assert spec.flux.unit == spec_coll.flux.unit
 
 
 def test_create_collection_from_collections():
@@ -115,6 +117,8 @@ def test_create_collection_from_collections():
     assert spec_coll.nspectral == 50
     assert isinstance(spec_coll.flux, u.Quantity)
     assert isinstance(spec_coll.spectral_axis, u.Quantity)
+    assert spec.spectral_axis.unit == spec_coll.spectral_axis.unit
+    assert spec.flux.unit == spec_coll.flux.unit
 
 
 def test_create_collection_from_spectra_without_uncertainties():

--- a/specutils/tests/test_spectrum_collection.py
+++ b/specutils/tests/test_spectrum_collection.py
@@ -92,6 +92,31 @@ def test_create_collection_from_spectrum1D():
     assert isinstance(spec_coll.spectral_axis, u.Quantity)
 
 
+def test_create_collection_from_collections():
+    spec = Spectrum1D(spectral_axis=np.linspace(0, 50, 50) * u.AA,
+                      flux=np.random.randn(50) * u.Jy,
+                      uncertainty=StdDevUncertainty(np.random.sample(50), unit='Jy'))
+    spec1 = Spectrum1D(spectral_axis=np.linspace(20, 60, 50) * u.AA,
+                       flux=np.random.randn(50) * u.Jy,
+                       uncertainty=StdDevUncertainty(np.random.sample(50), unit='Jy'))
+
+    spec_coll1 = SpectrumCollection.from_spectra([spec, spec1])
+
+    spec2 = Spectrum1D(spectral_axis=np.linspace(40, 80, 50) * u.AA,
+                       flux=np.random.randn(50) * u.Jy,
+                       uncertainty=StdDevUncertainty(np.random.sample(50), unit='Jy'))
+
+    spec_coll2 = SpectrumCollection.from_spectra([spec, spec2])
+
+    spec_coll = SpectrumCollection.from_spectra([spec_coll1, spec_coll2, spec_coll1])
+
+    assert spec_coll.ndim == 2
+    assert spec_coll.shape == (3, 2)
+    assert spec_coll.nspectral == 50
+    assert isinstance(spec_coll.flux, u.Quantity)
+    assert isinstance(spec_coll.spectral_axis, u.Quantity)
+
+
 def test_create_collection_from_spectra_without_uncertainties():
     spec = Spectrum1D(spectral_axis=np.linspace(0, 50, 50) * u.AA,
                       flux=np.random.randn(50) * u.Jy)


### PR DESCRIPTION
This PR updates the `SpectrumCollection.from_spectra` machinery primarily for the case where a `SpectrumCollection` is the argument to the method.

To be more specific, it addresses the fact that previous `vstack` was used to combine multiple spectra.  This worked find for `Spectrum1D` inputs, but for a `SpectrumCollection` it effectively flattens the collection instead of adding a second dimension.  This changes it to creating a new dimension instead of stacking.

This approach also fixes the units treatment - previously `from_spectra` implicitly assumed all the spectra were the same unit as the first one, which is not guaranteed to be true.  With this implementation, instead all the units are converted to match whatever the first one is (implicitly, through the `Quantity` initializer).