### PR TITLE
Update SpectrumList loader for JWST data

### DIFF
--- a/specutils/io/default_loaders/ascii.py
+++ b/specutils/io/default_loaders/ascii.py
@@ -39,7 +39,7 @@ def ascii_loader(file_name, column_mapping=None, **kwargs):
         associated `Spectrum1D` keyword argument, and the second element is the
         unit for the ASCII file column::
 
-            column_mapping = {'FLUX': ('flux': 'Jy')}
+            column_mapping = {'FLUX': ('flux', 'Jy')}
 
     Returns
     -------

--- a/specutils/io/default_loaders/generic_ecsv_reader.py
+++ b/specutils/io/default_loaders/generic_ecsv_reader.py
@@ -36,7 +36,7 @@ def generic_ecsv(file_name, column_mapping=None, **kwargs):
         associated `Spectrum1D` keyword argument, and the second element is the
         unit for the ECSV file column::
 
-            column_mapping = {'FLUX': ('flux': 'Jy')}
+            column_mapping = {'FLUX': ('flux', 'Jy')}
 
     Returns
     -------

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -34,11 +34,51 @@ def identify_jwst_x1d_fits(origin, *args, **kwargs):
         return False
 
 
-@data_loader("JWST", identifier=identify_jwst_x1d_fits, dtype=SpectrumList,
+@data_loader("JWST x1d", identifier=identify_jwst_x1d_fits, dtype=Spectrum1D,
              extensions=['fits'])
-def jwst_loader(filename, **kwargs):
+def jwst_x1d_single_loader(filename, **kwargs):
     """
     Loader for JWST x1d 1-D spectral data in FITS format
+
+    Parameters
+    ----------
+    filename: str
+        The path to the FITS file
+
+    Returns
+    -------
+    Spectrum1D
+        The spectrum contained in the file.
+    """
+    spectrum_list = _jwst_x1d_loader(filename, **kwargs)
+    if len(spectrum_list) == 1:
+        return spectrum_list[0]
+    else:
+        raise RuntimeError(f"{filename} has {len(spectrum_list)} spectra. "
+            "Use the SpectrumList.read.")
+
+
+@data_loader("JWST x1d multi", identifier=identify_jwst_x1d_fits, dtype=SpectrumList,
+             extensions=['fits'])
+def jwst_x1d_multi_loader(filename, **kwargs):
+    """
+    Loader for JWST x1d 1-D spectral data in FITS format
+
+    Parameters
+    ----------
+    filename: str
+        The path to the FITS file
+
+    Returns
+    -------
+    SpectrumList
+        A list of the spectra that are contained in the file.
+    """
+    return _jwst_x1d_loader(filename, **kwargs)
+
+
+def _jwst_x1d_loader(filename, **kwargs):
+    """Implementation of loader for JWST x1d 1-D spectral data in FITS format
 
     Parameters
     ----------

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -71,14 +71,14 @@ def jwst_loader(filename, **kwargs):
                 # SRCTYPE is in primary header because there is only one spectrum
                 srctype = hdulist.header.get("srctype")
 
-            if srctype == "point":
+            if srctype == "POINT":
                 flux_units = u.Unit(hdu.columns["flux"].unit)
                 flux = hdu.data["flux"] * flux_units
 
                 error_units = u.Unit(hdu.columns["error"].unit)
                 uncertainty = StdDevUncertainty(hdu.data["error"] * error_units)
 
-            elif srctype == "extended":
+            elif srctype == "EXTENDED":
                 flux_units = u.Unit(hdu.columns["surf_bright"].unit)
                 flux = hdu.data["surf_bright"] * flux_units
 
@@ -87,8 +87,8 @@ def jwst_loader(filename, **kwargs):
 
             else:
                 raise RuntimeError(f"Keyword SRCTYPE is {srctype}.  It should "
-                    "be 'point' or 'extended'. Can't decide between flux and "
-                    "surface brightness columns")
+                    "be 'POINT' or 'EXTENDED'. Can't decide between `flux` and "
+                    "`surf_bright` columns.")
 
             if np.min(uncertainty.array) <= 0.:
                 warnings.warn("Standard Deviation has values of 0 or less",

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -1,17 +1,21 @@
+import warnings
+
 import astropy.units as u
 from astropy.io import fits
+from astropy.nddata import StdDevUncertainty
+from astropy.utils.exceptions import AstropyUserWarning
+import numpy as np
 
 from ...spectra import Spectrum1D, SpectrumList
 from ..registers import data_loader
 
 
-def identify_jwst_fits(origin, *args, **kwargs):
-    """
-    Check whether the given file is a JWST spectral data product.
+__all__ = ["jwst_loader"]
 
-    This check is fairly simple. It expects FITS files that contain an ASDF
-    header (which is not used here, but indicates a JWST data product). It then
-    looks for at least one EXTRACT1D header, which contains spectral data.
+
+def identify_jwst_x1d_fits(origin, *args, **kwargs):
+    """
+    Check whether the given file is a JWST x1d spectral data product.
     """
 
     try:
@@ -22,52 +26,78 @@ def identify_jwst_fits(origin, *args, **kwargs):
             # This indicates the data product contains  spectral data
             if not 'EXTRACT1D' in hdulist:
                 return False
+            if not hdulist[0].header["TELESCOP"] == "JWST":
+                return False
         return True
     # This probably means we didn't have a FITS file
     except Exception:
         return False
 
 
-@data_loader("JWST", identifier=identify_jwst_fits, dtype=SpectrumList,
+@data_loader("JWST", identifier=identify_jwst_x1d_fits, dtype=SpectrumList,
              extensions=['fits'])
-def jwst_loader(filename, spectral_axis_unit=None, **kwargs):
+def jwst_loader(filename, **kwargs):
     """
-    Loader for JWST data files.
+    Loader for JWST x1d 1-D spectral data in FITS format
 
     Parameters
     ----------
-    file_name: str
+    filename: str
         The path to the FITS file
 
     Returns
     -------
-    data: SpectrumList
-        A list of the spectra that are contained in this file.
+    SpectrumList
+        A list of the spectra that are contained in the file.
     """
 
     spectra = []
 
     with fits.open(filename) as hdulist:
+
         for hdu in hdulist:
+            # Read only the BinaryTableHDUs named EXTRACT1D
             if hdu.name != 'EXTRACT1D':
                 continue
 
-            # Provide reasonable defaults based on the units assigned by the
-            # extract1d step of the JWST pipeline. TUNIT fields should be
-            # populated by the pipeline, but it's apparently possible for them
-            # to be missing in some files.
-            wavelength_units = u.Unit(hdu.header.get('TUNIT1', 'um'))
-            flux_units = u.Unit(hdu.header.get('TUNIT2', 'mJy'))
-            error_units = u.Unit(hdu.header.get('TUNIT3', 'mJy'))
+            wavelength_units = u.Unit(hdu.columns["wavelength"].unit)
+            wavelength = hdu.data["wavelength"] * wavelength_units
 
-            wavelength = hdu.data['WAVELENGTH'] * wavelength_units
-            flux = hdu.data['FLUX'] * flux_units
-            error = hdu.data['ERROR'] * error_units
+            # Determine if FLUX or SURF_BRIGHT column should be returned
+            # based on whether it is point or extended source
+            try:
+                srctype = hdu.header.get("srctype")
+            except KeyError:
+                # SRCTYPE is in primary header because there is only one spectrum
+                srctype = hdulist.header.get("srctype")
+
+            if srctype == "point":
+                flux_units = u.Unit(hdu.columns["flux"].unit)
+                flux = hdu.data["flux"] * flux_units
+
+                error_units = u.Unit(hdu.columns["error"].unit)
+                uncertainty = StdDevUncertainty(hdu.data["error"] * error_units)
+
+            elif srctype == "extended":
+                flux_units = u.Unit(hdu.columns["surf_bright"].unit)
+                flux = hdu.data["surf_bright"] * flux_units
+
+                error_units = u.Unit(hdu.columns["sb_error"].unit)
+                uncertainty = StdDevUncertainty(hdu.data["sb_error"] * error_units)
+
+            else:
+                raise RuntimeError(f"Keyword SRCTYPE is {srctype}.  It should "
+                    "be 'point' or 'extended'. Can't decide between flux and "
+                    "surface brightness columns")
+
+            if np.min(uncertainty.array) <= 0.:
+                warnings.warn("Standard Deviation has values of 0 or less",
+                    AstropyUserWarning)
 
             meta = dict(slitname=hdu.header.get('SLTNAME', ''))
 
-            # TODO: pass uncertainty using the error from the HDU
-            spec = Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)
+            spec = Spectrum1D(flux=flux, spectral_axis=wavelength,
+                uncertainty=uncertainty, meta=meta)
             spectra.append(spec)
 
     return SpectrumList(spectra)

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -31,7 +31,8 @@ def identify_tabular_fits(origin, *args, **kwargs):
             (fits.getheader(args[0])['TELESCOP'] == 'SDSS 2.5-M' and
              fits.getheader(args[0])['FIBERID'] > 0) and not
             (fits.getheader(args[0])['TELESCOP'] == 'HST' and
-             fits.getheader(args[0])['INSTRUME'] in ('COS', 'STIS'))
+             fits.getheader(args[0])['INSTRUME'] in ('COS', 'STIS')) and not
+            (fits.getheader(args[0])['TELESCOP'] == 'JWST')
             )
 
 

--- a/specutils/io/default_loaders/tests/test_jwst_loader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_loader.py
@@ -1,16 +1,17 @@
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table
+from astropy.io.registry import IORegistryError
+from astropy.utils.exceptions import AstropyUserWarning
 import pytest
 
 from specutils import Spectrum1D, SpectrumList
 
 
-def create_spectrum_hdu(data_len, srctype=None):
-    # Create a minimal header for the purposes of testing
-
+def create_spectrum_hdu(data_len, srctype=None, ver=1):
+    """Mock a JWST x1d BinTableHDU"""
     data = np.random.random((data_len, 5))
-    table = Table(data=data, names=['WAVELENGTH', 'FLUX', 'ERROR', 'SURF_BRIGHT',
+    table = Table(data=data,names=['WAVELENGTH', 'FLUX', 'ERROR', 'SURF_BRIGHT',
         'SB_ERROR'])
 
     hdu = fits.BinTableHDU(table, name='EXTRACT1D')
@@ -20,32 +21,35 @@ def create_spectrum_hdu(data_len, srctype=None):
     hdu.header['TUNIT4'] = 'MJy/sr'
     hdu.header['TUNIT5'] = 'MJy/sr'
     hdu.header['SRCTYPE'] = srctype
+    hdu.ver = ver
 
     return hdu
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def x1d_single():
+    """Mock a JWST x1d HDUList with a single spectrum"""
     hdulist = fits.HDUList()
     hdulist.append(fits.PrimaryHDU())
     hdulist["PRIMARY"].header["TELESCOP"] = "JWST"
-    # Add several BinTableHDUs that contain spectral data
-    hdulist.append(create_spectrum_hdu(100, 'POINT'))
+    # Add a BinTableHDU that contains spectral data
+    hdulist.append(create_spectrum_hdu(100, 'POINT', ver=1))
     # Mock the ASDF extension
     hdulist.append(fits.BinTableHDU(name='ASDF'))
 
     return hdulist
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def x1d_multi():
+    """Mock a JWST x1d multispec HDUList with 3 spectra"""
     hdulist = fits.HDUList()
     hdulist.append(fits.PrimaryHDU())
     hdulist["PRIMARY"].header["TELESCOP"] = "JWST"
-    # Add several BinTableHDUs that contain spectral data
-    hdulist.append(create_spectrum_hdu(100, 'POINT'))
-    hdulist.append(create_spectrum_hdu(120, 'EXTENDED'))
-    hdulist.append(create_spectrum_hdu(110, 'POINT'))
+    # Add a few BinTableHDUs that contain spectral data
+    hdulist.append(create_spectrum_hdu(100, 'POINT', ver=1))
+    hdulist.append(create_spectrum_hdu(120, 'EXTENDED', ver=2))
+    hdulist.append(create_spectrum_hdu(110, 'POINT', ver=3))
     # Mock the ASDF extension
     hdulist.append(fits.BinTableHDU(name='ASDF'))
 
@@ -89,13 +93,30 @@ def test_jwst_x1d_single_loader_no_format(tmpdir, x1d_single):
     assert data.shape == (100,)
 
 
-def test_jwst_x1d_singel_loader_fail_on_multi(tmpdir, x1d_multi):
+def test_jwst_x1d_multi_loader_no_format(tmpdir, x1d_multi):
+    """Test Spectrum1D.read for JWST x1d data without format arg"""
+    tmpfile = str(tmpdir.join('jwst.fits'))
+    x1d_multi.writeto(tmpfile)
+
+    data = SpectrumList.read(tmpfile)
+    assert type(data) is SpectrumList
+    assert len(data) == 3
+
+    for item in data:
+        assert isinstance(item, Spectrum1D)
+
+    assert data[0].shape == (100,)
+    assert data[1].shape == (120,)
+    assert data[2].shape == (110,)
+
+
+def test_jwst_x1d_single_loader_fail_on_multi(tmpdir, x1d_multi):
     """Make sure Spectrum1D.read on JWST x1d with many spectra errors out"""
     tmpfile = str(tmpdir.join('jwst.fits'))
     x1d_multi.writeto(tmpfile)
 
-    with pytest.raises(RuntimeError, match="SpectrumList"):
-        Spectrum1D.read(tmpfile, format='JWST x1d')
+    with pytest.raises(IORegistryError):
+        Spectrum1D.read(tmpfile)
 
 
 @pytest.mark.parametrize("srctype", [None, "UNKNOWN"])
@@ -103,9 +124,24 @@ def test_jwst_loader_fail(tmpdir, x1d_single, srctype):
     """Check that the loader fails when SRCTYPE is not set or is UNKNOWN"""
     tmpfile = str(tmpdir.join('jwst.fits'))
     hdulist = x1d_single
-    # Add a spectrum with unknown SRCTYPE
-    hdulist.append(create_spectrum_hdu(100, srctype))
+    # Add a spectrum with bad SRCTYPE (mutate the fixture)
+    hdulist.append(create_spectrum_hdu(100, srctype, ver=2))
     hdulist.writeto(tmpfile)
 
     with pytest.raises(RuntimeError, match="^Keyword"):
-        SpectrumList.read(tmpfile, format='JWST x1d')
+        SpectrumList.read(tmpfile, format='JWST x1d multi')
+
+
+def test_jwst_loader_warning_stddev(tmpdir, x1d_single):
+    """Check that the loader raises warning when stddev is zeros"""
+    tmpfile = str(tmpdir.join('jwst.fits'))
+    hdulist = x1d_single
+    # Put zeros in ERROR column
+    hdulist["EXTRACT1D"].data["ERROR"] = 0
+    hdulist.writeto(tmpfile)
+
+    with pytest.warns(AstropyUserWarning) as record:
+        Spectrum1D.read(tmpfile)
+        for r in record:
+            if r.message is AstropyUserWarning:
+                assert "Standard Deviation has values of 0" in r.message

--- a/specutils/io/default_loaders/tests/test_jwst_loader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_loader.py
@@ -24,8 +24,8 @@ def create_spectrum_hdu(data_len, srctype=None):
     return hdu
 
 
-def test_jwst_loader(tmpdir):
-
+def test_jwst_x1d_loader(tmpdir):
+    """Test SpectrumList.read for JWST x1d data"""
     tmpfile = str(tmpdir.join('jwst.fits'))
 
     hdulist = fits.HDUList()
@@ -49,8 +49,9 @@ def test_jwst_loader(tmpdir):
     assert data[1].shape == (120,)
     assert data[2].shape == (110,)
 
-def test_jwst_loader_fail(tmpdir):
 
+def test_jwst_loader_fail(tmpdir):
+    """Check that the loader fails when SRCTYPE is not set or is UNKNOWN"""
     tmpfile = str(tmpdir.join('jwst.fits'))
 
     hdulist = fits.HDUList()

--- a/specutils/io/default_loaders/tests/test_jwst_loader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_loader.py
@@ -32,7 +32,7 @@ def x1d_single():
     """Mock a JWST x1d HDUList with a single spectrum"""
     hdulist = fits.HDUList()
     hdulist.append(fits.PrimaryHDU())
-    hdulist["PRIMARY"].header["TELESCOP"] = "JWST"
+    hdulist["PRIMARY"].header["TELESCOP"] = ("JWST", "comment")
     # Add a BinTableHDU that contains spectral data
     hdulist.append(create_spectrum_hdu(100, 'POINT', ver=1))
     # Mock the ASDF extension
@@ -118,6 +118,16 @@ def test_jwst_x1d_multi_loader_no_format(tmpdir, x1d_multi):
     assert data[0].unit == u.Jy
     assert data[1].unit == u.MJy / u.sr
     assert data[2].unit == u.Jy
+
+
+def test_jwst_x1d_loader_meta(tmpdir, x1d_single):
+    """Test that the Primary and EXTRACT1D extension headers are merged in meta"""
+    tmpfile = str(tmpdir.join('jwst.fits'))
+    x1d_single.writeto(tmpfile)
+
+    data = Spectrum1D.read(tmpfile)
+    assert ('TELESCOP', 'JWST') in data.meta.items()
+    assert ('SRCTYPE', 'POINT') in data.meta.items()
 
 
 def test_jwst_x1d_single_loader_fail_on_multi(tmpdir, x1d_multi):

--- a/specutils/io/default_loaders/tests/test_jwst_loader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_loader.py
@@ -1,6 +1,7 @@
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table
+import astropy.units as u
 from astropy.io.registry import IORegistryError
 from astropy.utils.exceptions import AstropyUserWarning
 import pytest
@@ -91,6 +92,8 @@ def test_jwst_x1d_single_loader_no_format(tmpdir, x1d_single):
     data = Spectrum1D.read(tmpfile)
     assert type(data) is Spectrum1D
     assert data.shape == (100,)
+    assert data.unit == u.Jy
+    assert data.spectral_axis.unit == u.um
 
 
 def test_jwst_x1d_multi_loader_no_format(tmpdir, x1d_multi):
@@ -105,9 +108,16 @@ def test_jwst_x1d_multi_loader_no_format(tmpdir, x1d_multi):
     for item in data:
         assert isinstance(item, Spectrum1D)
 
-    assert data[0].shape == (100,)
-    assert data[1].shape == (120,)
-    assert data[2].shape == (110,)
+
+def test_jwst_x1d_multi_loader_no_format(tmpdir, x1d_multi):
+    """Test units for Spectrum1D.read for JWST x1d data"""
+    tmpfile = str(tmpdir.join('jwst.fits'))
+    x1d_multi.writeto(tmpfile)
+
+    data = SpectrumList.read(tmpfile)
+    assert data[0].unit == u.Jy
+    assert data[1].unit == u.MJy / u.sr
+    assert data[2].unit == u.Jy
 
 
 def test_jwst_x1d_single_loader_fail_on_multi(tmpdir, x1d_multi):

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -22,7 +22,7 @@ from astropy.nddata import NDUncertainty, StdDevUncertainty
 
 from numpy.testing import assert_allclose
 
-from .conftest import remote_data_path, remote_access
+from .conftest import remote_access
 from .. import Spectrum1D, SpectrumList
 from ..io import get_loaders_by_extension
 


### PR DESCRIPTION
- Allow the reader to read either `flux` or `surf_bright`
- Generalize the extraction of units to track column name, not column number
- Read in the uncertainty array
- Fix up some docstrings elsewhere
- Write tests, tests, tests

Note that `extract1d` spectral products in the pipeline currently do not have populated uncertainty arrays.  They are all zeros.  That will be changing in the next month or so.