### PR TITLE
Fix typo on L98 of docs/analysis.rst

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -95,7 +95,7 @@ of a spectrum.  Both are demonstrated below:
     >>> line_flux(noisy_gaussian, SpectralRegion(3*u.GHz, 7*u.GHz))  # doctest:+FLOAT_CMP
     <Quantity 4.92933252 GHz Jy>
 
-For the equivalen width, note the need to add a continuum level:
+For the equivalent width, note the need to add a continuum level:
 
 .. code-block:: python
 


### PR DESCRIPTION
Change "equivalen" into "equivalent" on L98 to correct misspelling. 