### PR TITLE
Fix for regression in issue #586

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -85,8 +85,9 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         # In the case where the arithmetic operation is being performed with
         # a single float, int, or array object, just go ahead and ignore wcs
         # requirements
-        if isinstance(flux, float) or isinstance(flux, int) \
-                or not isinstance(flux, u.Quantity):
+        if np.ndim(flux) == 0 and (isinstance(flux, float)
+            or isinstance(flux, int)
+            or not isinstance(flux, u.Quantity)):
             super(Spectrum1D, self).__init__(data=flux, wcs=wcs, **kwargs)
             return
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -85,9 +85,9 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         # In the case where the arithmetic operation is being performed with
         # a single float, int, or array object, just go ahead and ignore wcs
         # requirements
-        if np.ndim(flux) == 0 and (isinstance(flux, float)
-            or isinstance(flux, int)
-            or not isinstance(flux, u.Quantity)):
+        if (not isinstance(flux, u.Quantity) or isinstance(flux, float)
+            or isinstance(flux, int)) and np.ndim(flux) == 0:
+
             super(Spectrum1D, self).__init__(data=flux, wcs=wcs, **kwargs)
             return
 


### PR DESCRIPTION
The initializer was bailing early when being passed unit-less numpy arrays assuming they are single valued arithmetic operands.