### PR TITLE
Fix incorrect uncertainty/weights conversion

### DIFF
--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -395,8 +395,9 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
         if weights == 'unc':
             uncerts = spectrum.uncertainty
 
+            # Astropy fitters expect weights in 1/sigma
             if uncerts is not None:
-                weights = uncerts.array ** -2
+                weights = uncerts.array ** -1
             else:
                 logging.warning("Uncertainty values are not defined, but are "
                                 "trying to be used in model fitting.")

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -225,7 +225,7 @@ def test_single_peak_fit_with_uncertainties():
             spec = Spectrum1D(spectral_axis=x, flux=y * u.Jy,
                               uncertainty=StdDevUncertainty(unc * u.Jy))
 
-            weights = 'unc' if implicit_weights else unc ** -2
+            weights = 'unc' if implicit_weights else unc ** -1
 
             spec_fit = fit_lines(spec, init_mod, weights=weights)
 
@@ -234,9 +234,9 @@ def test_single_peak_fit_with_uncertainties():
         return np.median(rms)
 
     assert np.allclose(calculate_rms(x, init_mod, implicit_weights=True),
-                       5.113708262419985)
+                       5.101611033799086)
     assert np.allclose(calculate_rms(x, init_mod, implicit_weights=False),
-                       5.147348340711497)
+                       5.113697654869089)
 
 
 def test_single_peak_fit_window():


### PR DESCRIPTION
Fixes issue described in #587 wherein the conversion between uncertainty to weights was using `1/sigma^2` instead of the expected `1/sigma` that astropy fitters required.