### PR TITLE
Change implementation of .quantity to .view

### DIFF
--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -262,8 +262,8 @@ class SpectralCoord(u.Quantity):
 
         Returns
         -------
-        quantity
-            This object viewed as a `Quantity`
+        `~astropy.units.Quantity`
+            This object viewed as a `~astropy.units.Quantity`.
 
         """
         return self.view(u.Quantity)

--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -258,12 +258,15 @@ class SpectralCoord(u.Quantity):
     def quantity(self):
         """
         Convert the ``SpectralCoord`` to a `~astropy.units.Quantity`.
+        Equivalent to ``self.view(u.Quantity)``.
 
         Returns
         -------
+        quantity
+            This object viewed as a `Quantity`
 
         """
-        return u.Quantity(self.value, self.unit)
+        return self.view(u.Quantity)
 
     @property
     def observer(self):


### PR DESCRIPTION
This makes a small change to how `SpectralCoord.quantity` is implemented to use the more standard `view` `ndarray` method.  

It may be we should completely dispense with `.quantity` in favor of just using ``self.view(u.Quantity)`` wherever it's needed...?