### PR TITLE
Deprecate spectral_axis_unit property

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,4 +54,4 @@ edit_on_github = False
 github_project = astropy/specutils
 install_requires = astropy>=4.0, gwcs>=0.12, scipy, asdf>=2.5
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 1.0.dev
+version = 1.1.dev

--- a/specutils/manipulation/resample.py
+++ b/specutils/manipulation/resample.py
@@ -246,7 +246,7 @@ class FluxConservingResampler(ResamplerBase):
         # calculation, which is probably easiest. Matrix math algorithm is
         # geometry based, so won't work to just let quantity math handle it.
         resampled_spectrum = Spectrum1D(flux=out_flux,
-                                        spectral_axis=np.array(fin_spec_axis) * orig_spectrum.spectral_axis_unit,
+                                        spectral_axis=np.array(fin_spec_axis) * orig_spectrum.spectral_axis.unit,
                                         uncertainty=out_uncertainty)
 
         return resampled_spectrum

--- a/specutils/manipulation/smoothing.py
+++ b/specutils/manipulation/smoothing.py
@@ -96,7 +96,7 @@ def convolution_smooth(spectrum, kernel):
     # Return a new object with the smoothed flux.
     return Spectrum1D(flux=u.Quantity(smoothed_flux, spectrum.unit),
                       spectral_axis=u.Quantity(spectrum.spectral_axis,
-                                               spectrum.spectral_axis_unit),
+                                               spectrum.spectral_axis.unit),
                       wcs=spectrum.wcs,
                       uncertainty=uncertainty,
                       velocity_convention=spectrum.velocity_convention,
@@ -245,7 +245,7 @@ def median_smooth(spectrum, width):
     # Return a new object with the smoothed flux.
     return Spectrum1D(flux=u.Quantity(smoothed_flux, spectrum.unit),
                       spectral_axis=u.Quantity(spectrum.spectral_axis,
-                                               spectrum.spectral_axis_unit),
+                                               spectrum.spectral_axis.unit),
                       wcs=spectrum.wcs,
                       velocity_convention=spectrum.velocity_convention,
                       rest_value=spectrum.rest_value)

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -65,7 +65,7 @@ class OneDSpectrumMixin:
         return self._spectral_axis
 
     @property
-    @deprecated('v1.0', alternative="spectral_axis.unit")
+    @deprecated('v1.1', alternative="spectral_axis.unit")
     def spectral_axis_unit(self):
         """
         Returns the units of the spectral axis.

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import astropy.units.equivalencies as eq
 import numpy as np
 from astropy import units as u
-from astropy.utils.decorators import lazyproperty
+from astropy.utils.decorators import lazyproperty, deprecated
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 
 from specutils.utils.wcs_utils import gwcs_from_array
@@ -65,6 +65,7 @@ class OneDSpectrumMixin:
         return self._spectral_axis
 
     @property
+    @deprecated('v1.0', alternative="spectral_axis.unit")
     def spectral_axis_unit(self):
         """
         Returns the units of the spectral axis.


### PR DESCRIPTION
Resolves #582. Removes references to `spectral_axis_unit` in analysis and manipulation functions, and adds a deprecation warning to the property.