### PR TITLE
Implement SpectralCoord in SpectrumCollection

### DIFF
--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -69,6 +69,20 @@ class SpectralCoord(u.Quantity):
         if isinstance(value, u.Quantity) and unit is None:
             obj._unit = value.unit
 
+        # If we're initializing from an existing SpectralCoord, keep any
+        # parameters that aren't being overridden
+        if isinstance(value, SpectralCoord):
+            if observer is None:
+                observer = value.observer
+            if target is None:
+                target = value.target
+            if radial_velocity is None and redshift is None:
+                radial_velocity = value.radial_velocity
+            if doppler_rest is None:
+                doppler_rest = value.doppler_rest
+            if doppler_convention is None:
+                doppler_convention = value.doppler_convention
+
         # Store state about whether the observer and target were defined
         #  explicitly (True), or implicity from rv/redshift (False)
         obj._frames_state = dict(observer=observer is not None,

--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -243,7 +243,7 @@ class SpectralCoord(u.Quantity):
     @property
     def quantity(self):
         """
-        Convert the ``SpectralCoord`` to a simple `~astropy.units.Quantity`.
+        Convert the ``SpectralCoord`` to a `~astropy.units.Quantity`.
 
         Returns
         -------

--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -243,7 +243,7 @@ class SpectralCoord(u.Quantity):
     @property
     def quantity(self):
         """
-        Convert the ``SpectralCoord`` to a simple ``~astropy.units.Quantity``.
+        Convert the ``SpectralCoord`` to a simple `~astropy.units.Quantity`.
 
         Returns
         -------

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -133,18 +133,20 @@ class SpectrumCollection:
         # Check that the spectral parameters are the same for each input
         # spectral_axis and create the multi-dimensional SpectralCoord
         sa = [x.spectral_axis for x in spectra]
-        sa_0 = spectra[0].spectral_axis
-        if not all(x.radial_velocity == sa_0.radial_velocity for x in sa) or \
-            not all(x.target == sa_0.target for x in sa) or \
-            not all(x.doppler_convention == sa_0.doppler_convention for
+        if not all(x.radial_velocity == sa[0].radial_velocity for x in sa) or \
+            not all(x.target == sa[0].target for x in sa) or \
+            not all(x.observer == sa[0].observer for x in sa) or \
+            not all(x.doppler_convention == sa[0].doppler_convention for
                     x in sa) or \
-            not all(x.doppler_rest == sa_0.doppler_rest for x in sa):
-                raise ValueError("All input spectral axes must have the same "
-                                "parameters")
-        spectral_axis = SpectralCoord([spec.spectral_axis for spec in spectra],
-                        radial_velocity = spectra[0].spectral_axis.radial_velocity,
-                        doppler_rest = spectra[0].spectral_axis.doppler_rest,
-                        doppler_convention = spectra[0].spectral_axis.doppler_convention)
+            not all(x.doppler_rest == sa[0].doppler_rest for x in sa):
+                raise ValueError("All input spectral_axis SpectralCoord "
+                                 "objects must have the same parameters.")
+        spectral_axis = SpectralCoord(sa,
+                            radial_velocity=sa[0].radial_velocity,
+                            doppler_rest=sa[0].doppler_rest,
+                            doppler_convention=sa[0].doppler_convention,
+                            observer=sa[0].observer,
+                            target=sa[0].target)
 
         # Check that either all spectra have associated uncertainties, or that
         # none of them do. If only some do, log an error and ignore the

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -54,14 +54,11 @@ class SpectrumCollection:
         if spectral_axis is not None:
             if not isinstance(spectral_axis, u.Quantity):
                 raise u.UnitsError("Spectral axis must be a `Quantity`.")
+            spectral_axis = SpectralCoord(spectral_axis)
 
             # Ensure that the input values are the same shape
             if not (flux.shape == spectral_axis.shape):
                 raise ValueError("Shape of all data elements must be the same.")
-
-            # Convert to SpectralCoord if simple Quantity was input
-            if not isinstance(spectral_axis, SpectralCoord):
-                spectral_axis = SpectralCoord(spectral_axis)
 
         if uncertainty is not None and uncertainty.array.shape != flux.shape:
             raise ValueError("Uncertainty must be the same shape as flux and "
@@ -121,7 +118,8 @@ class SpectrumCollection:
         ----------
         spectra : list, ndarray
             A list of :class:`~specutils.Spectrum1D` objects to be held in the
-            collection.
+            collection. Currently the spectral_axis parameters (e.g. observer,
+            radial_velocity) must be the same for each spectrum.
         """
         # Enforce that the shape of each item must be the same
         if not all((x.shape == spectra[0].shape for x in spectra)):

--- a/specutils/tests/test_spectral_coord.py
+++ b/specutils/tests/test_spectral_coord.py
@@ -138,6 +138,19 @@ def test_create_spectral_coord_observer_target(observer, target):
     else:
         raise NotImplementedError()
 
+def test_create_from_spectral_coord(observer, target):
+    """
+    Checks that parameters are correctly copied to the new SpectralCoord object
+    """
+    spec_coord1 = SpectralCoord([100, 200, 300] * u.nm, observer=observer,
+            target=target, radial_velocity=u.Quantity(1000, 'km/s'),
+            doppler_convention = 'optical', doppler_rest = 6000*u.AA)
+    spec_coord2 = SpectralCoord(spec_coord1)
+    assert spec_coord1.observer == spec_coord2.observer
+    assert spec_coord2.target == spec_coord2.target
+    assert spec_coord2.radial_velocity == spec_coord2.radial_velocity
+    assert spec_coord2.doppler_convention == spec_coord2.doppler_convention
+    assert spec_coord2.doppler_rest == spec_coord2.doppler_rest
 
 # SCIENCE USE CASE TESTS
 


### PR DESCRIPTION
Now converts input `spectral_axis` to `SpectralCoord` if it isn't one already. Also checks that the `spectral_axis` parameters (radial_velocity, observer, etc) in the spectra provided to `from_spectra` match, otherwise throws an error.

EDIT by @eteq: this closes #616 (adding this note to the description will make it auto-close when we merge this PR)

EDIT2 by @rosteen: also closes #622 