### PR TITLE
Add WCS 1D (including multi-D flux) writer in default_loaders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 New Features
 ^^^^^^^^^^^^
 
+- Added writer to ``wcs1d-fits`` and support for multi-D flux arrays with
+  1D WCS (identical ``spectral_axis`` scale). [#632]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -18,8 +18,12 @@ __all__ = ['tabular_fits_loader', 'tabular_fits_writer']
 
 
 def identify_tabular_fits(origin, *args, **kwargs):
-    # check if file can be opened with this reader
     # args[0] = filename
+    # check if filename conforms to naming convention for writer
+    if origin == 'write':
+        return args[0].endswith(('.fits', '.fit'))
+
+    # check if file can be opened with this reader
     with fits.open(args[0]) as hdulist:
         # Test if fits has extension of type BinTable and check against
         # known keys of already defined specific formats
@@ -36,7 +40,7 @@ def identify_tabular_fits(origin, *args, **kwargs):
 
 
 @data_loader("tabular-fits", identifier=identify_tabular_fits,
-             dtype=Spectrum1D, extensions=['fits'])
+             dtype=Spectrum1D, extensions=['fits'], priority=6)
 def tabular_fits_loader(file_obj, column_mapping=None, hdu=1, **kwargs):
     """
     Load spectrum from a FITS file.
@@ -100,9 +104,15 @@ def tabular_fits_writer(spectrum, file_name, update_header=False, **kwargs):
         The path to the FITS file
     update_header: bool
         Update FITS header with all compatible entries in `spectrum.meta`
+    wunit : str or `~astropy.units.Unit`
+        Unit for the spectral axis (wavelength or frequency-like)
+    funit : str or `~astropy.units.Unit`
+        Unit for the flux (and associated uncertainty)
+    wtype : str or `~numpy.dtype`
+        Floating point type for storing spectral axis array
+    ftype : str or `~numpy.dtype`
+        Floating point type for storing flux array
     """
-    flux = spectrum.flux
-    disp = spectrum.spectral_axis
     header = spectrum.meta.get('header', fits.header.Header()).copy()
 
     if update_header:
@@ -115,16 +125,28 @@ def tabular_fits_writer(spectrum, file_name, update_header=False, **kwargs):
     for keyword in ['NAXIS', 'NAXIS1', 'NAXIS2']:
         header.remove(keyword, ignore_missing=True)
 
+    # Add dispersion array and unit
+    wtype = kwargs.pop('wtype', spectrum.spectral_axis.dtype)
+    wunit = u.Unit(kwargs.pop('wunit', spectrum.spectral_axis.unit))
+    disp = spectrum.spectral_axis.to(wunit, equivalencies=u.spectral())
+
     # Mapping of spectral_axis types to header TTYPE1
-    dispname = disp.unit.physical_type
+    dispname = wunit.physical_type
     if dispname == "length":
         dispname = "wavelength"
 
-    columns = [disp, flux]
+    # Add flux array and unit
+    ftype = kwargs.pop('ftype', spectrum.flux.dtype)
+    funit = u.Unit(kwargs.pop('funit', spectrum.flux.unit))
+    flux = spectrum.flux.to(funit, equivalencies=u.spectral_density(disp))
+
+    columns = [disp.astype(wtype), flux.astype(ftype)]
     colnames = [dispname, "flux"]
+
     # Include uncertainty - units to be inferred from spectrum.flux
     if spectrum.uncertainty is not None:
-        columns.append(spectrum.uncertainty.quantity)
+        unc = spectrum.uncertainty.quantity.to(funit, equivalencies=u.spectral_density(disp))
+        columns.append(unc.astype(ftype))
         colnames.append("uncertainty")
 
     # For 2D data transpose from row-major format

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -4,7 +4,6 @@ import os
 import numpy as np
 
 from astropy.io import fits
-from astropy.nddata import StdDevUncertainty
 from astropy.table import Table
 import astropy.units as u
 from astropy.wcs import WCS
@@ -36,7 +35,7 @@ def identify_tabular_fits(origin, *args, **kwargs):
                  fits.getheader(args[0]).get('FIBERID') > 0) and not
                 (fits.getheader(args[0]).get('TELESCOP') == 'HST' and
                  fits.getheader(args[0]).get('INSTRUME') in ('COS', 'STIS')) and not
-                 fits.getheader(args[0]).get('TELESCOP') == 'JWST')
+                fits.getheader(args[0]).get('TELESCOP') == 'JWST')
 
 
 @data_loader("tabular-fits", identifier=identify_tabular_fits,

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -17,8 +17,13 @@ __all__ = ['wcs1d_fits_loader', 'wcs1d_fits_writer', 'non_linear_wcs1d_fits']
 
 
 def identify_wcs1d_fits(origin, *args, **kwargs):
-    # check if file can be opened with this reader
     # args[0] = filename
+    # check if filename conforms to naming convention for writer
+    if origin == 'write':
+        return (args[0].endswith(('wcs.fits', 'wcs1d.fits', 'wcs.fit')) and not
+                hasattr(args[2], 'uncertainty'))
+
+    # check if file can be opened with this reader
     with fits.open(args[0]) as hdulist:
         # check if number of axes is one
         return (hdulist[0].header['NAXIS'] == 1 and

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -3,7 +3,7 @@ import warnings
 
 from astropy import units as u
 from astropy.io import fits
-from astropy.wcs import WCS
+from astropy.wcs import WCS, _wcs
 from astropy.modeling import models
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.nddata import StdDevUncertainty
@@ -98,7 +98,10 @@ def wcs1d_fits_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
             raise ValueError('FITS file input to wcs1d_fits_loader is > 4D')
         elif wcs.naxis > 1:
             for i in range(wcs.naxis - 1, 0, -1):
-                wcs = wcs.dropaxis(i)
+                try:
+                    wcs = wcs.dropaxis(i)
+                except(_wcs.NonseparableSubimageCoordinateSystemError) as e:
+                    raise ValueError(f'WCS cannot be reduced to 1D: {e} {wcs}')
 
     return Spectrum1D(flux=data, wcs=wcs, meta=meta)
 

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -94,10 +94,11 @@ def wcs1d_fits_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
     if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
         hdulist.close()
 
-        if wcs.naxis == 2:
-            wcs = wcs.dropaxis(1)
-        elif wcs.naxis > 2:
-            raise ValueError('FITS file input to wcs1d_fits_loader is > 2D')
+        if wcs.naxis > 4:
+            raise ValueError('FITS file input to wcs1d_fits_loader is > 4D')
+        elif wcs.naxis > 1:
+            for i in range(wcs.naxis - 1, 0, -1):
+                wcs = wcs.dropaxis(i)
 
     return Spectrum1D(flux=data, wcs=wcs, meta=meta)
 

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -481,11 +481,15 @@ def test_wcs1d_fits_writer(tmpdir, spectral_axis):
     assert quantity_allclose(spec.spectral_axis, disp)
     assert quantity_allclose(spec.flux, spectrum.flux)
 
-    # Construct a 2D flux array, just for demonstration - cannot read it back
+    # Construct a 2D flux array and repeat (no auto-identify)
     flux = flux * np.arange(1, 6).reshape(-1, 1)
     spectrum = Spectrum1D(flux=flux, wcs=WCS(hdr))
     tmpfile = str(tmpdir.join('_2d.fits'))
     spectrum.write(tmpfile, format='wcs1d-fits')
+
+    spec = Spectrum1D.read(tmpfile, format='wcs1d-fits')
+    assert quantity_allclose(spec.spectral_axis, spectrum.spectral_axis)
+    assert quantity_allclose(spec.flux, spectrum.flux)
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
In #625 and related discussion on Slack the lack of a builtin `writer` for `wcs1d-fits` (writing the flux data as an image array) came up again.
This PR implements such an initial generic writer for saving a `Spectrum1D` to the (primary) `IMAGE_HDU` in a FITS file.

- Writing as `wcs1d-fits` only works for `Spectrum1D` objects that have a fully functional WCS (specifically having a `spectrum.wcs.to_fits` method; it's up to the user to provide this.

- The writer also supports on-the-fly change of flux units or dtype (e.g. to save space by setting `dtype='f4'`) via kwargs; the same options have been added to `tabular-fits`, but may need some discussion (this implementation adds separate kwargs `[fw]type` for the dtypes of flux and spectral_axis, and there are no tests yet).

- `wcs1d-fits` actually happily accepts 2D flux arrays, and the resulting files can be opened e.g. in `SAOImageDS9`, but `Spectrum1D` cannot read them back in, as there is no unambiguous way to handle the WCS-constructed spectral axis. Deferring this to a separate PR or issue on handling multi-D spectra.

- Also following the discussion on Slack I have added auto-identification functionality one `write` to `tabular-fits`; from what I understood this is of limited use, as it can basically just check if the file naming scheme conforms to the rules. For `wcs1d` it would be helpful to check for a working `wcs`, but since the spectrum object is not passed to the identifier, I see no way to implement this.