### PR TITLE
Add 2SLAQ-LRG loader

### DIFF
--- a/specutils/io/default_loaders/twoslaq_lrg.py
+++ b/specutils/io/default_loaders/twoslaq_lrg.py
@@ -1,0 +1,115 @@
+import astropy.io.fits as fits
+from astropy.units import Unit
+from astropy.wcs import WCS
+from specutils.io.registers import data_loader
+from specutils import Spectrum1D, SpectrumList
+
+
+def identify_2slaq_lrg(origin, *args, **kwargs):
+    """
+    Identify if the current file is a 2SLAQ-LRG file
+    """
+    file_obj = args[0]
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist = file_obj
+    else:
+        hdulist = fits.open(file_obj, **kwargs)
+
+    if hdulist[0].header["MSTITLE"].startswith("2dF-SDSS LRG/QSO survey"):
+        # apparently the QSO part doesn't have MSTITLE, so we should be safe
+        # with just the above condition, but just in case, we know they have
+        # a different structure (LRG has one ext, QSO has more; LRG is 3d,
+        # QSO is 1d
+        if len(hdulist) == 1 and hdulist[0].data.ndim == 3:
+            if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
+                hdulist.close()
+            return True
+
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist.close()
+    return False
+
+
+@data_loader("2SLAQ-LRG", identifier=identify_2slaq_lrg,dtype=SpectrumList,
+             extensions=["fit", "fits"])
+def twoslaq_lrg_fits_loader(file_obj, **kwargs):
+    """
+    Load a file from the LRG subset of the 2dF-SDSS LRG/QSO survey (2SLAQ-LRG)
+    file.
+
+    2SLAQ was one of a number of surveys that used the 2dF instrument on the
+    Anglo-Australian Telescope (AAT) at Siding Spring Observatory (SSO) near
+    Coonabarabran, Australia, and followed up the 2QZ survey. Further details
+    can be seen at http://www.physics.usyd.edu.au/2slaq/ or at
+    https://docs.datacentral.org.au/.
+
+    The LRG and QSO data appear to be in different formats, this only loads the
+    LRG version. As there is a science and sky spectrum, the `SpectrumList`
+    loader provides both, whereas the `Spectrum1D` loader only provides the
+    science.
+
+    Parameters
+    ----------
+    file_name: str
+        The path to the FITS file
+    Returns
+    -------
+    data: SpectrumList
+        The 2SLAQ-LRG spectrum that is represented by the data in this file.
+    """
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist = file_obj
+    else:
+        hdulist = fits.open(file_obj, **kwargs)
+
+    header = hdulist[0].header
+    spectrum = hdulist[0].data[0,0] * Unit("count/s")
+    sky = hdulist[0].data[1,0] * Unit("count/s")
+
+    # Due to the odd structure of the file, the WCS needs to be read in
+    # manually
+    wcs = WCS(naxis=1)
+    wcs.wcs.cdelt[0] = header["CD1_1"]
+    wcs.wcs.crval[0] = header["CRVAL1"]
+    wcs.wcs.crpix[0] = header["CRPIX1"]
+    wcs.wcs.cunit[0] = Unit("Angstrom")
+
+    meta = {"header": header}
+
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist.close()
+
+    return SpectrumList([
+        Spectrum1D(flux=spectrum, wcs=wcs, meta=meta),
+        Spectrum1D(flux=sky, wcs=wcs, meta=meta),
+    ])
+
+# Commented out until discussion about whether to provide science-only or not
+# @data_loader("2SLAQ-LRG", identifier=identify_2slaq_lrg,dtype=Spectrum1D,
+#              extensions=["fit", "fits"])
+# def twoslaq_lrg_fits_loader_only_science(filename, **kwargs):
+#     """
+#     Load a file from the LRG subset of the 2dF-SDSS LRG/QSO survey (2SLAQ-LRG)
+#     file.
+#
+#     2SLAQ was one of a number of surveys that used the 2dF instrument on the
+#     Anglo-Australian Telescope (AAT) at Siding Spring Observatory (SSO) near
+#     Coonabarabran, Australia, and followed up the 2QZ survey. Further details
+#     can be seen at http://www.physics.usyd.edu.au/2slaq/ or at
+#     https://docs.datacentral.org.au/.
+#
+#     The LRG and QSO data appear to be in different formats, this only loads the
+#     LRG version. As there is a science and sky spectrum, the `SpectrumList`
+#     loader provides both, whereas the `Spectrum1D` loader only provides the
+#     science.
+#
+#     Parameters
+#     ----------
+#     file_name: str
+#         The path to the FITS file
+#     Returns
+#     -------
+#     data: Spectrum1D
+#         The 2SLAQ-LRG spectrum that is represented by the data in this file.
+#     """
+#     return SpectrumList.read(filename, format="2SLAQ-LRG")[0]

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -688,3 +688,34 @@ def test_spectrum1d_6dfgs_split_combined(remote_data_path):
     assert len(specs) == 3
 
     hdulist.close()
+
+
+# Commented out until science only is discussed
+# @pytest.mark.remote_data
+# def test_2slaq_lrg_loader_science_only():
+#     """Test remote read and automatic recognition of 2SLAQ-LRG data from URL.
+#     """
+#     url = ("https://datacentral.org.au/services/sov/81480/download/"
+#            "gama.dr2.spectra.2slaq-lrg.spectrum_1d/J143529.78-004306.4_1.fit/")
+#     spec = Spectrum1D.read(url)
+#
+#     assert spec.spectral_axis.unit == u.AA
+#     assert spec.flux.unit == u.count / u.s
+#     assert spec.uncertainty is None
+
+
+@pytest.mark.remote_data
+def test_2slaq_lrg_loader_science_and_sky():
+    """Test remote read and automatic recognition of 2SLAQ-LRG data from URL.
+    """
+    url = ("https://datacentral.org.au/services/sov/81480/download/"
+           "gama.dr2.spectra.2slaq-lrg.spectrum_1d/J143529.78-004306.4_1.fit/")
+    science, sky = SpectrumList.read(url)
+
+    assert science.spectral_axis.unit == u.AA
+    assert science.flux.unit == u.count / u.s
+    assert science.uncertainty is None
+
+    assert sky.spectral_axis.unit == u.AA
+    assert sky.flux.unit == u.count / u.s
+    assert sky.uncertainty is None


### PR DESCRIPTION
This adds a loader for the LRG subset of the 2dF-SDSS LRG/QSO survey.

There's no uncertainty data contained within the fits file, and the test uses Data Central as the source of the data.

As the data includes both the science spectrum and the sky spectrum, I extracted both. I did try to create a loader which only loaded the science spectrum, which is currently commented out, is that useful, or should I remove that code.