### PR TITLE
Make default loaders work with fits objects

### DIFF
--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -66,6 +66,7 @@ Note that the same spectrum could be more conveniently downloaded via
 astroquery, if the user has that package installed:
 
 .. code-block:: python
+
      >>> from astroquery.sdss import SDSS # doctest: +SKIP
      >>> specs = SDSS.get_spectra(plate=751, mjd=52251, fiberID=160) # doctest: +SKIP
      >>> Spectrum1D.read(specs[0], format="SDSS-III/IV spec") # doctest: +SKIP

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -53,6 +53,7 @@ internet. Note that in these cases, a format string corresponding to an
 existing loader must be supplied.
 
 .. code-block:: python
+    
     >>> from astroquery.sdss import SDSS
     >>> from specutils import Spectrum1D
     >>> import urllib

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -54,11 +54,11 @@ format string corresponding to an existing loader must be supplied.
 
 .. code-block:: python
     
-    >>> from astroquery.sdss import SDSS
+    >>> from astroquery.sdss import SDSS # doctest: +SKIP
     >>> from specutils import Spectrum1D
     >>> import urllib
-    >>> specs = SDSS.get_spectra(plate=751, mjd=52251, fiberID=160)
-    >>> Spectrum1D.read(specs[0], format="SDSS-III/IV spec")
+    >>> specs = SDSS.get_spectra(plate=751, mjd=52251, fiberID=160) # doctest: +SKIP
+    >>> Spectrum1D.read(specs[0], format="SDSS-III/IV spec") # doctest: +SKIP
     <Spectrum1D(flux=<Quantity [30.596626,...]...>
     >>> specs = urllib.request.urlopen('https://data.sdss.org/sas/dr14/sdss/spectro/redux/26/spectra/0751/spec-0751-52251-0160.fits')
     >>> Spectrum1D.read(specs, format="SDSS-III/IV spec")

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -47,9 +47,9 @@ encouraged to :doc:`create their own loader </custom_loading>`.
     >>> from specutils import Spectrum1D
     >>> spec1d = Spectrum1D.read("/path/to/file.fits")  # doctest: +SKIP
 
-The built-in default loaders can also read an existing 
-`astropy.io.fits.hdu.HDUList` object, or from an open file object as resulting 
-from e.g. streaming a file from the internet. Note that in these cases, a 
+Most of the built-in specutils default loaders can also read an existing 
+`astropy.io.fits.hdu.HDUList` object or an open file object (as resulting 
+from e.g. streaming a file from the internet). Note that in these cases, a 
 format string corresponding to an existing loader must be supplied.
 
 .. code-block:: python

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -47,10 +47,10 @@ encouraged to :doc:`create their own loader </custom_loading>`.
     >>> from specutils import Spectrum1D
     >>> spec1d = Spectrum1D.read("/path/to/file.fits")  # doctest: +SKIP
 
-Spectrum1D can also read from a existing `astropy.io.fits.hdu.HDUList` object, 
-or from an open file object as resulting from e.g. streaming files from the 
-internet. Note that in these cases, a format string corresponding to an 
-existing loader must be supplied.
+The built-in default loaders can also read an existing 
+`astropy.io.fits.hdu.HDUList` object, or from an open file object as resulting 
+from e.g. streaming a file from the internet. Note that in these cases, a 
+format string corresponding to an existing loader must be supplied.
 
 .. code-block:: python
     

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -47,7 +47,21 @@ encouraged to :doc:`create their own loader </custom_loading>`.
     >>> from specutils import Spectrum1D
     >>> spec1d = Spectrum1D.read("/path/to/file.fits")  # doctest: +SKIP
 
+Spectrum1D can also read from a existing `astropy.io.fits.hdu.HDUList` object, 
+or from an open file object as resulting from e.g. streaming files from the 
+internet. Note that in these cases, a format string corresponding to an 
+existing loader must be supplied.
 
+.. code-block:: python
+    >>> from astroquery.sdss import SDSS
+    >>> from specutils import Spectrum1D
+    >>> import urllib
+    >>> specs = SDSS.get_spectra(plate=751, mjd=52251, fiberID=160)
+    >>> Spectrum1D.read(specs[0], format="SDSS-III/IV spec")
+    <Spectrum1D(flux=<Quantity [30.596626,...]...>
+    >>> specs = urllib.request.urlopen('https://data.sdss.org/sas/dr14/sdss/spectro/redux/26/spectra/0751/spec-0751-52251-0160.fits')
+    >>> Spectrum1D.read(specs, format="SDSS-III/IV spec")
+    <Spectrum1D(flux=<Quantity [30.596626,...]...>
 
 Including Uncertainties
 -----------------------

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -50,19 +50,26 @@ encouraged to :doc:`create their own loader </custom_loading>`.
 Most of the built-in specutils default loaders can also read an existing 
 `astropy.io.fits.HDUList` object or an open file object (as resulting 
 from e.g. streaming a file from the internet). Note that in these cases, a 
-format string corresponding to an existing loader must be supplied.
+format string corresponding to an existing loader must be supplied because 
+these objects lack enough contextual information to automatically identify
+a loader.
 
 .. code-block:: python
     
-    >>> from astroquery.sdss import SDSS # doctest: +SKIP
     >>> from specutils import Spectrum1D
     >>> import urllib
-    >>> specs = SDSS.get_spectra(plate=751, mjd=52251, fiberID=160) # doctest: +SKIP
-    >>> Spectrum1D.read(specs[0], format="SDSS-III/IV spec") # doctest: +SKIP
+    >>> specs = urllib.request.urlopen('https://data.sdss.org/sas/dr14/sdss/spectro/redux/26/spectra/0751/spec-0751-52251-0160.fits') # doctest: +REMOTE_DATA
+    >>> Spectrum1D.read(specs, format="SDSS-III/IV spec") # doctest: +REMOTE_DATA
     <Spectrum1D(flux=<Quantity [30.596626,...]...>
-    >>> specs = urllib.request.urlopen('https://data.sdss.org/sas/dr14/sdss/spectro/redux/26/spectra/0751/spec-0751-52251-0160.fits') # doctest: +SKIP
-    >>> Spectrum1D.read(specs, format="SDSS-III/IV spec") # doctest: +SKIP
-    <Spectrum1D(flux=<Quantity [30.596626,...]...>
+
+Note that the same spectrum could be more conveniently downloaded via
+astroquery, if the user has that package installed:
+
+.. code-block:: python
+     >>> from astroquery.sdss import SDSS # doctest: +SKIP
+     >>> specs = SDSS.get_spectra(plate=751, mjd=52251, fiberID=160) # doctest: +SKIP
+     >>> Spectrum1D.read(specs[0], format="SDSS-III/IV spec") # doctest: +SKIP
+     <Spectrum1D(flux=<Quantity [30.596626,...]...>
 
 Including Uncertainties
 -----------------------

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -48,7 +48,7 @@ encouraged to :doc:`create their own loader </custom_loading>`.
     >>> spec1d = Spectrum1D.read("/path/to/file.fits")  # doctest: +SKIP
 
 Most of the built-in specutils default loaders can also read an existing 
-`astropy.io.fits.hdu.HDUList` object or an open file object (as resulting 
+`astropy.io.fits.HDUList` object or an open file object (as resulting 
 from e.g. streaming a file from the internet). Note that in these cases, a 
 format string corresponding to an existing loader must be supplied.
 
@@ -60,8 +60,8 @@ format string corresponding to an existing loader must be supplied.
     >>> specs = SDSS.get_spectra(plate=751, mjd=52251, fiberID=160) # doctest: +SKIP
     >>> Spectrum1D.read(specs[0], format="SDSS-III/IV spec") # doctest: +SKIP
     <Spectrum1D(flux=<Quantity [30.596626,...]...>
-    >>> specs = urllib.request.urlopen('https://data.sdss.org/sas/dr14/sdss/spectro/redux/26/spectra/0751/spec-0751-52251-0160.fits')
-    >>> Spectrum1D.read(specs, format="SDSS-III/IV spec")
+    >>> specs = urllib.request.urlopen('https://data.sdss.org/sas/dr14/sdss/spectro/redux/26/spectra/0751/spec-0751-52251-0160.fits') # doctest: +SKIP
+    >>> Spectrum1D.read(specs, format="SDSS-III/IV spec") # doctest: +SKIP
     <Spectrum1D(flux=<Quantity [30.596626,...]...>
 
 Including Uncertainties

--- a/specutils/io/default_loaders/apogee.py
+++ b/specutils/io/default_loaders/apogee.py
@@ -71,8 +71,9 @@ def apVisit_loader(file_obj, **kwargs):
 
     Parameters
     ----------
-    file_obj: str or file-like
-        FITS file name or object (provided from name by Astropy I/O Registry).
+    file_obj: str, file-like or HDUList
+        FITS file name, object (provided from name by Astropy I/O Registry),
+        or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------
@@ -122,8 +123,9 @@ def apStar_loader(file_obj, **kwargs):
 
     Parameters
     ----------
-    file_obj: str or file-like
-        FITS file name or object (provided from name by Astropy I/O Registry).
+    file_obj: str, file-like, or HDUList
+        FITS file name or object (provided from name by Astropy I/O Registry),
+        or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------

--- a/specutils/io/default_loaders/apogee.py
+++ b/specutils/io/default_loaders/apogee.py
@@ -81,10 +81,8 @@ def apVisit_loader(file_obj, **kwargs):
         The spectrum that is represented by the data in this table.
     """
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        close_hdulist = False
         hdulist = file_obj
     else:
-        close_hdulist = True
         hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
@@ -107,7 +105,7 @@ def apVisit_loader(file_obj, **kwargs):
                                  hdulist[4].data[1, :],
                                  hdulist[4].data[2, :]])
     dispersion_unit = Unit('Angstrom')
-    if close_hdulist:
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
         hdulist.close()
 
     return Spectrum1D(data=data * unit,

--- a/specutils/io/default_loaders/apogee.py
+++ b/specutils/io/default_loaders/apogee.py
@@ -79,7 +79,12 @@ def apVisit_loader(file_obj, **kwargs):
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
     """
-    hdulist = fits.open(file_obj, **kwargs)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        close_hdulist = False
+        hdulist = file_obj
+    else:
+        close_hdulist = True
+        hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
     meta = {'header': header}
@@ -101,7 +106,8 @@ def apVisit_loader(file_obj, **kwargs):
                                  hdulist[4].data[1, :],
                                  hdulist[4].data[2, :]])
     dispersion_unit = Unit('Angstrom')
-    hdulist.close()
+    if close_hdulist:
+        hdulist.close()
 
     return Spectrum1D(data=data * unit,
                       uncertainty=uncertainty,
@@ -124,7 +130,12 @@ def apStar_loader(file_obj, **kwargs):
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
     """
-    hdulist = fits.open(file_obj, **kwargs)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        close_hdulist = False
+        hdulist = file_obj
+    else:
+        close_hdulist = True
+        hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
     meta = {'header': header}
@@ -141,7 +152,8 @@ def apStar_loader(file_obj, **kwargs):
                                                   np.zeros((data.shape[0],)))).T,
                                        0)[:, 0]
     dispersion_unit = Unit('Angstrom')
-    hdulist.close()
+    if close_hdulist:
+        hdulist.close()
 
     return Spectrum1D(data=data * unit,
                       uncertainty=uncertainty,
@@ -165,7 +177,12 @@ def aspcapStar_loader(file_obj, **kwargs):
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
     """
-    hdulist = fits.open(file_obj, **kwargs)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        close_hdulist = False
+        hdulist = file_obj
+    else:
+        close_hdulist = True
+        hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
     meta = {'header': header}
@@ -179,7 +196,8 @@ def aspcapStar_loader(file_obj, **kwargs):
     # dispersion from the WCS but convert out of logspace
     dispersion = 10**wcs.all_pix2world(np.arange(data.shape[0]), 0)[0]
     dispersion_unit = Unit('Angstrom')
-    hdulist.close()
+    if close_hdulist:
+        hdulist.close()
 
     return Spectrum1D(data=data * unit,
                       uncertainty=uncertainty,

--- a/specutils/io/default_loaders/hst_cos.py
+++ b/specutils/io/default_loaders/hst_cos.py
@@ -26,8 +26,9 @@ def cos_spectrum_loader(file_obj, **kwargs):
 
     Parameters
     ----------
-    file_name: str
-        The path to the FITS file
+    file_obj: str, file-like, or HDUList
+         FITS file name, object (provided from name by Astropy I/O Registry),
+         or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------

--- a/specutils/io/default_loaders/hst_cos.py
+++ b/specutils/io/default_loaders/hst_cos.py
@@ -20,7 +20,7 @@ def cos_identify(origin, *args, **kwargs):
 
 
 @data_loader(label="HST/COS", identifier=cos_identify, extensions=['FITS', 'FIT', 'fits', 'fit'])
-def cos_spectrum_loader(file_name, **kwargs):
+def cos_spectrum_loader(file_obj, **kwargs):
     """
     Load COS spectral data from the MAST archive into a spectrum object.
 
@@ -34,22 +34,30 @@ def cos_spectrum_loader(file_name, **kwargs):
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
     """
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        close_hdulist = False
+        hdu = file_obj
+    else:
+        close_hdulist = True
+        hdu = fits.open(file_obj, **kwargs)
 
-    with fits.open(file_name, **kwargs) as hdu:
-        header = hdu[0].header
-        name = header.get('FILENAME')
-        meta = {'header': header}
+    header = hdu[0].header
+    name = header.get('FILENAME')
+    meta = {'header': header}
 
-        unit = Unit("erg/cm**2 Angstrom s")
-        disp_unit = Unit('Angstrom')
-        data = hdu[1].data['FLUX'].flatten() * unit
-        dispersion = hdu[1].data['wavelength'].flatten() * disp_unit
-        uncertainty = StdDevUncertainty(hdu[1].data["ERROR"].flatten() * unit)
+    unit = Unit("erg/cm**2 Angstrom s")
+    disp_unit = Unit('Angstrom')
+    data = hdu[1].data['FLUX'].flatten() * unit
+    dispersion = hdu[1].data['wavelength'].flatten() * disp_unit
+    uncertainty = StdDevUncertainty(hdu[1].data["ERROR"].flatten() * unit)
 
-        sort_idx = dispersion.argsort()
-        dispersion = dispersion[sort_idx]
-        data = data[sort_idx]
-        uncertainty = uncertainty[sort_idx]
+    sort_idx = dispersion.argsort()
+    dispersion = dispersion[sort_idx]
+    data = data[sort_idx]
+    uncertainty = uncertainty[sort_idx]
+
+    if close_hdulist:
+        hdu.close()
 
     return Spectrum1D(flux=data,
                       spectral_axis=dispersion,

--- a/specutils/io/default_loaders/hst_stis.py
+++ b/specutils/io/default_loaders/hst_stis.py
@@ -19,7 +19,7 @@ def stis_identify(origin, *args, **kwargs):
     return False
 
 
-@data_loader(label="HST/STIS",identifier=stis_identify, extensions=['FITS', 'FIT', 'fits', 'fit'])
+@data_loader(label="HST/STIS", identifier=stis_identify, extensions=['FITS', 'FIT', 'fits', 'fit'])
 def stis_spectrum_loader(file_obj, **kwargs):
     """
     Load STIS spectral data from the MAST archive into a spectrum object.

--- a/specutils/io/default_loaders/hst_stis.py
+++ b/specutils/io/default_loaders/hst_stis.py
@@ -26,8 +26,9 @@ def stis_spectrum_loader(file_obj, **kwargs):
 
     Parameters
     ----------
-    file_name: str
-        The path to the FITS file
+    file_obj: str, file-like, or HDUList
+          FITS file name, object (provided from name by Astropy I/O Registry),
+          or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------

--- a/specutils/io/default_loaders/hst_stis.py
+++ b/specutils/io/default_loaders/hst_stis.py
@@ -12,8 +12,8 @@ __all__ = ['stis_identify', 'stis_spectrum_loader']
 
 def stis_identify(origin, *args, **kwargs):
     """Check whether given file contains HST/STIS spectral data."""
-    with fits.open(args[0]) as hdu:
-        if hdu[0].header['TELESCOP'] == 'HST' and hdu[0].header['INSTRUME'] == 'STIS':
+    with fits.open(args[0]) as hdulist:
+        if hdulist[0].header['TELESCOP'] == 'HST' and hdulist[0].header['INSTRUME'] == 'STIS':
             return True
 
     return False
@@ -36,29 +36,27 @@ def stis_spectrum_loader(file_obj, **kwargs):
         The spectrum that is represented by the data in this table.
     """
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        close_hdulist = False
-        hdu = file_obj
+        hdulist = file_obj
     else:
-        close_hdulist = True
-        hdu = fits.open(file_obj, **kwargs)
+        hdulist = fits.open(file_obj, **kwargs)
 
-    header = hdu[0].header
+    header = hdulist[0].header
     name = header.get('FILENAME')
     meta = {'header': header}
 
     unit = Unit("erg/cm**2 Angstrom s")
     disp_unit = Unit('Angstrom')
-    data = hdu[1].data['FLUX'].flatten() * unit
-    dispersion = hdu[1].data['wavelength'].flatten() * disp_unit
-    uncertainty = StdDevUncertainty(hdu[1].data["ERROR"].flatten() * unit)
+    data = hdulist[1].data['FLUX'].flatten() * unit
+    dispersion = hdulist[1].data['wavelength'].flatten() * disp_unit
+    uncertainty = StdDevUncertainty(hdulist[1].data["ERROR"].flatten() * unit)
 
     sort_idx = dispersion.argsort()
     dispersion = dispersion[sort_idx]
     data = data[sort_idx]
     uncertainty = uncertainty[sort_idx]
 
-    if close_hdulist:
-        hdu.close()
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist.close()
 
     return Spectrum1D(flux=data,
                       spectral_axis=dispersion,

--- a/specutils/io/default_loaders/muscles_sed.py
+++ b/specutils/io/default_loaders/muscles_sed.py
@@ -43,16 +43,24 @@ def muscles_sed(file_obj, **kwargs):
     """
     # name is not used; what was it for?
     # name = os.path.basename(file_name.rstrip(os.sep)).rsplit('.', 1)[0]
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        close_hdulist = False
+        hdulist = file_obj
+    else:
+        close_hdulist = True
+        hdulist = fits.open(file_obj, **kwargs)
 
-    with fits.open(file_obj, **kwargs) as hdulist:
-        header = hdulist[0].header
+    header = hdulist[0].header
 
-        tab = Table.read(hdulist[1])
+    tab = Table.read(hdulist[1])
 
-        meta = {'header': header}
-        uncertainty = StdDevUncertainty(tab["ERROR"])
-        data = Quantity(tab["FLUX"])
-        wavelength = Quantity(tab["WAVELENGTH"])
+    meta = {'header': header}
+    uncertainty = StdDevUncertainty(tab["ERROR"])
+    data = Quantity(tab["FLUX"])
+    wavelength = Quantity(tab["WAVELENGTH"])
+
+    if close_hdulist:
+        hdulist.close()
 
     return Spectrum1D(flux=data, spectral_axis=wavelength,
                       uncertainty=uncertainty, meta=meta)

--- a/specutils/io/default_loaders/muscles_sed.py
+++ b/specutils/io/default_loaders/muscles_sed.py
@@ -45,10 +45,8 @@ def muscles_sed(file_obj, **kwargs):
     # name is not used; what was it for?
     # name = os.path.basename(file_name.rstrip(os.sep)).rsplit('.', 1)[0]
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        close_hdulist = False
         hdulist = file_obj
     else:
-        close_hdulist = True
         hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
@@ -60,7 +58,7 @@ def muscles_sed(file_obj, **kwargs):
     data = Quantity(tab["FLUX"])
     wavelength = Quantity(tab["WAVELENGTH"])
 
-    if close_hdulist:
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
         hdulist.close()
 
     return Spectrum1D(flux=data, spectral_axis=wavelength,

--- a/specutils/io/default_loaders/muscles_sed.py
+++ b/specutils/io/default_loaders/muscles_sed.py
@@ -33,8 +33,9 @@ def muscles_sed(file_obj, **kwargs):
 
     Parameters
     ----------
-    file_obj: str or file-like
-        FITS file name or object (provided from name by Astropy I/O Registry).
+    file_obj: str, file-like, or HDUList
+          FITS file name, object (provided from name by Astropy I/O Registry),
+          or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------

--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -66,7 +66,12 @@ def spec_loader(file_obj, **kwargs):
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
     """
-    hdulist = fits.open(file_obj, **kwargs)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        close_hdulist = False
+        hdulist = file_obj
+    else:
+        close_hdulist = True
+        hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
     name = header.get('NAME')
@@ -108,7 +113,12 @@ def spSpec_loader(file_obj, **kwargs):
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
     """
-    hdulist = fits.open(file_obj, **kwargs)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        close_hdulist = False
+        hdulist = file_obj
+    else:
+        close_hdulist = True
+        hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
     name = header.get('NAME')

--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -68,10 +68,8 @@ def spec_loader(file_obj, **kwargs):
         The spectrum that is represented by the data in this table.
     """
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        close_hdulist = False
         hdulist = file_obj
     else:
-        close_hdulist = True
         hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
@@ -90,7 +88,9 @@ def spec_loader(file_obj, **kwargs):
     dispersion_unit = Unit('Angstrom')
 
     mask = hdulist[1].data['and_mask'] != 0
-    hdulist.close()
+
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist.close()
 
     return Spectrum1D(flux=data * unit,
                       spectral_axis=dispersion * dispersion_unit,
@@ -116,10 +116,8 @@ def spSpec_loader(file_obj, **kwargs):
         The spectrum that is represented by the data in this table.
     """
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        close_hdulist = False
         hdulist = file_obj
     else:
-        close_hdulist = True
         hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
@@ -141,7 +139,9 @@ def spSpec_loader(file_obj, **kwargs):
     dispersion_unit = Unit('Angstrom')
 
     mask = hdulist[0].data[3, :] != 0
-    hdulist.close()
+
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist.close()
 
     return Spectrum1D(flux=data * unit,
                       spectral_axis=dispersion * dispersion_unit,

--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -58,8 +58,9 @@ def spec_loader(file_obj, **kwargs):
 
     Parameters
     ----------
-    file_obj: str or file-like
-        FITS file name or object (provided from name by Astropy I/O Registry).
+    file_obj: str, file-like, or HDUList
+          FITS file name, object (provided from name by Astropy I/O Registry),
+          or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------
@@ -105,8 +106,9 @@ def spSpec_loader(file_obj, **kwargs):
 
     Parameters
     ----------
-    file_obj: str or file-like
-        FITS file name or object (provided from name by Astropy I/O Registry).
+    file_obj: str, file-like, or HDUList
+           FITS file name, object (provided from name by Astropy I/O Registry),
+           or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -43,8 +43,9 @@ def tabular_fits_loader(file_obj, column_mapping=None, hdu=1, **kwargs):
 
     Parameters
     ----------
-    file_obj: str or file-like
-        FITS file name or object (provided from name by Astropy I/O Registry).
+    file_obj: str, file-like, or HDUList
+            FITS file name, object (provided from name by Astropy I/O Registry),
+            or HDUList (as resulting from astropy.io.fits.open()).
     hdu: int
         The HDU of the fits file (default: 1st extension) to read from
     column_mapping : dict
@@ -64,8 +65,11 @@ def tabular_fits_loader(file_obj, column_mapping=None, hdu=1, **kwargs):
     """
     # Parse the wcs information. The wcs will be passed to the column finding
     # routines to search for spectral axis information in the file.
-    with fits.open(file_obj) as hdulist:
-        wcs = WCS(hdulist[hdu].header)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        wcs = WCS(file_obj[hdu].header)
+    else:
+        with fits.open(file_obj) as hdulist:
+            wcs = WCS(hdulist[hdu].header)
 
     tab = Table.read(file_obj, format='fits', hdu=hdu)
 

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -17,12 +17,12 @@ __all__ = ['wcs1d_fits_loader', 'wcs1d_fits_writer', 'non_linear_wcs1d_fits']
 def identify_wcs1d_fits(origin, *args, **kwargs):
     # check if file can be opened with this reader
     # args[0] = filename
-    with fits.open(args[0]) as hdu:
+    with fits.open(args[0]) as hdulist:
         # check if number of axes is one
-        return (hdu[0].header['NAXIS'] == 1 and
-                hdu[0].header.get('WCSDIM', 1) == 1 and
+        return (hdulist[0].header['NAXIS'] == 1 and
+                hdulist[0].header.get('WCSDIM', 1) == 1 and
                 # check in CTYPE1 key for linear solution
-                hdu[0].header.get('CTYPE1', '').upper() != 'MULTISPEC')
+                hdulist[0].header.get('CTYPE1', '').upper() != 'MULTISPEC')
 
     return False
 
@@ -60,10 +60,8 @@ def wcs1d_fits_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
     logging.info("Spectrum file looks like wcs1d-fits")
 
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        close_hdulist = False
         hdulist = file_obj
     else:
-        close_hdulist = True
         hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[hdu_idx].header
@@ -84,7 +82,7 @@ def wcs1d_fits_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
 
     meta = {'header': header}
 
-    if close_hdulist:
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
         hdulist.close()
 
     return Spectrum1D(flux=data, wcs=wcs, meta=meta)
@@ -137,10 +135,8 @@ def non_linear_wcs1d_fits(file_obj, spectral_axis_unit=None, flux_unit=None,
     logging.info('Loading 1D non-linear fits solution')
 
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        close_hdulist = False
         hdulist = file_obj
     else:
-        close_hdulist = True
         hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
@@ -181,7 +177,7 @@ def non_linear_wcs1d_fits(file_obj, spectral_axis_unit=None, flux_unit=None,
 
     meta = {'header': header}
 
-    if close_hdulist:
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
         hdulist.close()
 
     return Spectrum1D(flux=data, spectral_axis=spectral_axis, meta=meta)

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -39,8 +39,9 @@ def wcs1d_fits_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
 
     Parameters
     ----------
-    file_obj: str or file-like
-        FITS file name or object (provided from name by Astropy I/O Registry).
+    file_obj: str, file-like or HDUList
+        FITS file name, object (provided from name by Astropy I/O Registry),
+        or HDUList (as resulting from astropy.io.fits.open()).
     spectral_axis_unit: str or `~astropy.Unit`, optional
         Units of the spectral axis. If not given (or None), the unit will be
         inferred from the CUNIT in the WCS.  Not that if this is providded it
@@ -58,24 +59,33 @@ def wcs1d_fits_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
     """
     logging.info("Spectrum file looks like wcs1d-fits")
 
-    with fits.open(file_obj, **kwargs) as hdulist:
-        header = hdulist[hdu_idx].header
-        wcs = WCS(header)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        close_hdulist = False
+        hdulist = file_obj
+    else:
+        close_hdulist = True
+        hdulist = fits.open(file_obj, **kwargs)
 
-        if wcs.naxis != 1:
-            raise ValueError('FITS fle input to wcs1d_fits_loader is not 1D')
+    header = hdulist[hdu_idx].header
+    wcs = WCS(header)
 
-        if 'BUNIT' in header:
-            data = u.Quantity(hdulist[hdu_idx].data, unit=header['BUNIT'])
-            if flux_unit is not None:
-                data = data.to(flux_unit)
-        else:
-            data = u.Quantity(hdulist[hdu_idx].data, unit=flux_unit)
+    if wcs.naxis != 1:
+        raise ValueError('FITS fle input to wcs1d_fits_loader is not 1D')
 
-        if spectral_axis_unit is not None:
-            wcs.wcs.cunit[0] = str(spectral_axis_unit)
+    if 'BUNIT' in header:
+        data = u.Quantity(hdulist[hdu_idx].data, unit=header['BUNIT'])
+        if flux_unit is not None:
+            data = data.to(flux_unit)
+    else:
+        data = u.Quantity(hdulist[hdu_idx].data, unit=flux_unit)
 
-        meta = {'header': header}
+    if spectral_axis_unit is not None:
+        wcs.wcs.cunit[0] = str(spectral_axis_unit)
+
+    meta = {'header': header}
+
+    if close_hdulist:
+        hdulist.close()
 
     return Spectrum1D(flux=data, wcs=wcs, meta=meta)
 
@@ -106,8 +116,9 @@ def non_linear_wcs1d_fits(file_obj, spectral_axis_unit=None, flux_unit=None,
     Parameters
     ----------
 
-    file_obj: str or file-like
-        FITS file name or object (provided from name by Astropy I/O Registry).
+    file_obj: str, file-like or HDUList
+        FITS file name, object (provided from name by Astropy I/O Registry),
+        or HDUList (as resulting from astropy.io.fits.open()).
 
     spectral_axis_unit : `~astropy.Unit`, optional
         Spectral axis unit, default is None in which case will search for it
@@ -125,44 +136,54 @@ def non_linear_wcs1d_fits(file_obj, spectral_axis_unit=None, flux_unit=None,
 
     logging.info('Loading 1D non-linear fits solution')
 
-    with fits.open(file_obj, **kwargs) as hdulist:
-        header = hdulist[0].header
-        for wcsdim in range(1, header['WCSDIM'] + 1):
-            ctypen = header['CTYPE{:d}'.format(wcsdim)]
-            if ctypen == 'LINEAR':
-                logging.info("linear Solution: Try using "
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        close_hdulist = False
+        hdulist = file_obj
+    else:
+        close_hdulist = True
+        hdulist = fits.open(file_obj, **kwargs)
+
+    header = hdulist[0].header
+    for wcsdim in range(1, header['WCSDIM'] + 1):
+        ctypen = header['CTYPE{:d}'.format(wcsdim)]
+        if ctypen == 'LINEAR':
+            logging.info("linear Solution: Try using "
                              "`format='wcs1d-fits'` instead")
-                wcs = WCS(header)
-                spectral_axis = _read_linear_iraf_wcs(wcs=wcs,
-                                                      dc_flag=header['DC-FLAG'])
-            elif ctypen == 'MULTISPE':
-                logging.info("Multi spectral or non-linear solution")
-                spectral_axis = _read_non_linear_iraf_wcs(header=header,
-                                                          wcsdim=wcsdim)
-            else:
-                raise NotImplementedError
-
-        if flux_unit is not None:
-            data = hdulist[0].data * flux_unit
-        elif 'BUNIT' in header:
-            data = u.Quantity(hdulist[0].data, unit=header['BUNIT'])
+            wcs = WCS(header)
+            spectral_axis = _read_linear_iraf_wcs(wcs=wcs,
+                                                  dc_flag=header['DC-FLAG'])
+        elif ctypen == 'MULTISPE':
+            logging.info("Multi spectral or non-linear solution")
+            spectral_axis = _read_non_linear_iraf_wcs(header=header,
+                                                      wcsdim=wcsdim)
         else:
-            logging.info("Flux unit was not provided, neither it was in the"
-                         "header. Assuming ADU.")
-            data = u.Quantity(hdulist[0].data, unit='adu')
+            raise NotImplementedError
 
-        if spectral_axis_unit is not None:
-            spectral_axis *= spectral_axis_unit
-        else:
-            wat_head = header['WAT1_001']
-            wat_dict = dict()
-            for pair in wat_head.split(' '):
-                wat_dict[pair.split('=')[0]] = pair.split('=')[1]
-            if wat_dict['units'] == 'angstroms':
-                logging.info("Found spectral axis units to be angstrom")
-                spectral_axis *= u.angstrom
+    if flux_unit is not None:
+        data = hdulist[0].data * flux_unit
+    elif 'BUNIT' in header:
+        data = u.Quantity(hdulist[0].data, unit=header['BUNIT'])
+    else:
+        logging.info("Flux unit was not provided, neither it was in the"
+                     "header. Assuming ADU.")
+        data = u.Quantity(hdulist[0].data, unit='adu')
 
-        meta = {'header': header}
+    if spectral_axis_unit is not None:
+        spectral_axis *= spectral_axis_unit
+    else:
+        wat_head = header['WAT1_001']
+        wat_dict = dict()
+        for pair in wat_head.split(' '):
+            wat_dict[pair.split('=')[0]] = pair.split('=')[1]
+        if wat_dict['units'] == 'angstroms':
+            logging.info("Found spectral axis units to be angstrom")
+            spectral_axis *= u.angstrom
+
+    meta = {'header': header}
+
+    if close_hdulist:
+        hdulist.close()
+
     return Spectrum1D(flux=data, spectral_axis=spectral_axis, meta=meta)
 
 

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -107,6 +107,11 @@ def test_hst_cos(remote_data_path):
     assert isinstance(spec, Spectrum1D)
     assert spec.flux.size > 0
 
+    # HDUList case
+    hdulist = fits.open(remote_data_path)
+    spec = Spectrum1D.read(hdulist, format="HST/COS")
+    assert isinstance(spec, Spectrum1D)
+    assert spec.flux.size > 0
 
 @remote_access([{'id': '1481192', 'filename':'STIS_FUV.fits'},
                 {'id': '1481185', 'filename': 'STIS_NUV.fits'},
@@ -117,16 +122,34 @@ def test_hst_stis(remote_data_path):
     assert isinstance(spec, Spectrum1D)
     assert spec.flux.size > 0
 
+    # HDUList case
+    hdulist = fits.open(remote_data_path)
+    spec = Spectrum1D.read(hdulist, format="HST/STIS")
+    assert isinstance(spec, Spectrum1D)
+    assert spec.flux.size > 0
 
 @pytest.mark.remote_data
 def test_sdss_spec():
     sp_pattern = 'spec-4055-55359-0596.fits.'
     with urllib.request.urlopen('https://dr14.sdss.org/optical/spectrum/view/data/format%3Dfits/spec%3Dlite?mjd=55359&fiberid=596&plateid=4055') as response:
+        # Read from open file object
+        spec = Spectrum1D.read(response, format="SDSS-III/IV spec")
+        assert isinstance(spec, Spectrum1D)
+        assert spec.flux.size > 0
+
+    with urllib.request.urlopen('https://dr14.sdss.org/optical/spectrum/view/data/format%3Dfits/spec%3Dlite?mjd=55359&fiberid=596&plateid=4055') as response:
         with tempfile.NamedTemporaryFile(prefix=sp_pattern) as tmp_file:
             shutil.copyfileobj(response, tmp_file)
 
+            # Read from filename
             spec = Spectrum1D.read(tmp_file.name)
 
+            assert isinstance(spec, Spectrum1D)
+            assert spec.flux.size > 0
+
+            # Read from HDUList
+            hdulist = fits.open(tmp_file.name)
+            spec = Spectrum1D.read(hdulist, format="SDSS-III/IV spec")
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0
 
@@ -135,9 +158,16 @@ def test_sdss_spec():
 def test_sdss_spspec():
     sp_pattern = 'spSpec-51957-0273-016.fit.'
     with urllib.request.urlopen('http://das.sdss.org/spectro/1d_26/0273/1d/spSpec-51957-0273-016.fit') as response:
+        # Read from open file object
+        spec = Spectrum1D.read(response, format="SDSS-I/II spSpec")
+        assert isinstance(spec, Spectrum1D)
+        assert spec.flux.size > 0
+
+    with urllib.request.urlopen('http://das.sdss.org/spectro/1d_26/0273/1d/spSpec-51957-0273-016.fit') as response:
         with tempfile.NamedTemporaryFile(prefix=sp_pattern) as tmp_file:
             shutil.copyfileobj(response, tmp_file)
 
+            # Read from filename
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', FITSFixedWarning)
                 spec = Spectrum1D.read(tmp_file.name, format="SDSS-I/II spSpec")
@@ -145,6 +175,11 @@ def test_sdss_spspec():
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0
 
+            # Read from HDUList
+            hdulist = fits.open(tmp_file.name)
+            spec = Spectrum1D.read(hdulist, format="SDSS-I/II spSpec")
+            assert isinstance(spec, Spectrum1D)
+            assert spec.flux.size > 0
 
 @pytest.mark.remote_data
 def test_sdss_spec_stream():
@@ -258,6 +293,11 @@ def test_iraf_non_linear_chebyshev(remote_data_path):
     assert isinstance(spectrum_1d, Spectrum1D)
     assert_allclose(wavelength_axis, spectrum_1d.wavelength)
 
+    # Read from HDUList
+    hdulist = fits.open(remote_data_path)
+    spectrum_1d = Spectrum1D.read(hdulist, format='iraf')
+    assert isinstance(spectrum_1d, Spectrum1D)
+    assert_allclose(wavelength_axis, spectrum_1d.wavelength)
 
 @remote_access([{'id':'3359194', 'filename':'non-linear_fits_solution_legendre.fits'}])
 def test_iraf_non_linear_legendre(remote_data_path):
@@ -466,6 +506,10 @@ def test_muscles_loader():
     assert spec.spectral_axis.unit == u.AA
     assert spec.flux.unit == u.erg / (u.s * u.cm**2 * u.AA)
 
+    # Read HDUList
+    hdulist = fits.open(url)
+    spec = Spectrum1D.read(hdulist, format="MUSCLES SED")
+    assert isinstance(spec, Spectrum1D)
 
 @pytest.mark.remote_data
 def test_subaru_pfs_loader(tmpdir):

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -113,6 +113,7 @@ def test_hst_cos(remote_data_path):
     assert isinstance(spec, Spectrum1D)
     assert spec.flux.size > 0
 
+
 @remote_access([{'id': '1481192', 'filename':'STIS_FUV.fits'},
                 {'id': '1481185', 'filename': 'STIS_NUV.fits'},
                 {'id': '1481183', 'filename': 'STIS_CCD.fits'}])
@@ -127,6 +128,7 @@ def test_hst_stis(remote_data_path):
     spec = Spectrum1D.read(hdulist, format="HST/STIS")
     assert isinstance(spec, Spectrum1D)
     assert spec.flux.size > 0
+
 
 @pytest.mark.remote_data
 def test_sdss_spec():
@@ -180,6 +182,7 @@ def test_sdss_spspec():
             spec = Spectrum1D.read(hdulist, format="SDSS-I/II spSpec")
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0
+
 
 @pytest.mark.remote_data
 def test_sdss_spec_stream():
@@ -299,7 +302,8 @@ def test_iraf_non_linear_chebyshev(remote_data_path):
     assert isinstance(spectrum_1d, Spectrum1D)
     assert_allclose(wavelength_axis, spectrum_1d.wavelength)
 
-@remote_access([{'id':'3359194', 'filename':'non-linear_fits_solution_legendre.fits'}])
+
+@remote_access([{'id': '3359194', 'filename': 'non-linear_fits_solution_legendre.fits'}])
 def test_iraf_non_linear_legendre(remote_data_path):
 
     legendre_model = models.Legendre1D(degree=3, domain=[21, 4048])
@@ -510,6 +514,7 @@ def test_muscles_loader():
     hdulist = fits.open(url)
     spec = Spectrum1D.read(hdulist, format="MUSCLES SED")
     assert isinstance(spec, Spectrum1D)
+
 
 @pytest.mark.remote_data
 def test_subaru_pfs_loader(tmpdir):

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -141,13 +141,13 @@ def test_sdss_spec():
         with tempfile.NamedTemporaryFile(prefix=sp_pattern) as tmp_file:
             shutil.copyfileobj(response, tmp_file)
 
-            # Read from filename
+            # Read from local disk via filename
             spec = Spectrum1D.read(tmp_file.name)
 
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0
 
-            # Read from HDUList
+            # Read from HDUList object
             hdulist = fits.open(tmp_file.name)
             spec = Spectrum1D.read(hdulist, format="SDSS-III/IV spec")
             assert isinstance(spec, Spectrum1D)

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -167,7 +167,7 @@ def test_sdss_spspec():
         with tempfile.NamedTemporaryFile(prefix=sp_pattern) as tmp_file:
             shutil.copyfileobj(response, tmp_file)
 
-            # Read from filename
+            # Read from local disk via filename
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', FITSFixedWarning)
                 spec = Spectrum1D.read(tmp_file.name, format="SDSS-I/II spSpec")
@@ -175,7 +175,7 @@ def test_sdss_spspec():
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0
 
-            # Read from HDUList
+            # Read from HDUList object
             hdulist = fits.open(tmp_file.name)
             spec = Spectrum1D.read(hdulist, format="SDSS-I/II spSpec")
             assert isinstance(spec, Spectrum1D)


### PR DESCRIPTION
Adds HDUList handling to the default_loaders where applicable, and adds examples to the docs of using Spectrum1D.read() on both HDUList and open file-like objects.

This closes #450 