### PR TITLE
Clean code of spurious references related to SpectralCoord

### DIFF
--- a/specutils/analysis/correlation.py
+++ b/specutils/analysis/correlation.py
@@ -115,8 +115,8 @@ def _apodize(spectrum, template, apodization_window):
         else:
             def window(wlen):
                 return tukey(wlen, alpha=apodization_window)
-        clean_spectrum = spectrum * window(len(spectrum.wavelength))
-        clean_template = template * window(len(template.wavelength))
+        clean_spectrum = spectrum * window(len(spectrum.spectral_axis))
+        clean_template = template * window(len(template.spectral_axis))
 
     return clean_spectrum, clean_template
 
@@ -164,7 +164,10 @@ def template_logwl_resample(spectrum, template, wblue=None, wred=None,
     # sampling, since it's the one that counts for the final accuracy
     # of the correlation. Alternatively, use the wred and wblue limits,
     # and delta log wave provided by the user.
-
+    #
+    # We work with separate float and units entities instead of Quantity
+    # instances, due to the profusion of log10 and power function calls
+    # (they only work on floats)
     if wblue:
         w0 = np.log10(wblue)
     else:

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -97,7 +97,7 @@ def _compute_line_flux(spectrum, regions=None):
         calc_spectrum = spectrum
 
     # Average dispersion in the line region
-    avg_dx = np.abs(np.diff(calc_spectrum.spectral_axis.quantity))
+    avg_dx = np.abs(np.diff(calc_spectrum.spectral_axis))
 
     line_flux = np.sum(calc_spectrum.flux[1:] * avg_dx)
 
@@ -115,7 +115,7 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None):
     if continuum == 1:
         continuum = 1*calc_spectrum.flux.unit
 
-    spectral_axis = calc_spectrum.spectral_axis.quantity
+    spectral_axis = calc_spectrum.spectral_axis
 
     # Ensure that the
     dx = np.abs(spectral_axis[-1] - spectral_axis[0])
@@ -178,7 +178,8 @@ def is_continuum_below_threshold(spectrum, threshold=0.01):
     # we are going to calculate based on the S/N if the uncertainty
     # exists.
     if uncertainty and uncertainty.uncertainty_type != 'std':
-        return np.median(flux / uncertainty.quantity) < threshold
+        # return np.median(flux / uncertainty.quantity) < threshold
+        return np.median(flux / uncertainty) < threshold
     else:
         return np.median(flux) / mad_std(flux) < threshold
 

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -80,7 +80,7 @@ def _centroid_single_region(spectrum, region=None):
         calc_spectrum = spectrum
 
     flux = calc_spectrum.flux
-    dispersion = calc_spectrum.spectral_axis.quantity
+    dispersion = calc_spectrum.spectral_axis
 
     if len(flux.shape) > 1:
         dispersion = np.tile(dispersion, [flux.shape[0], 1])

--- a/specutils/analysis/template_comparison.py
+++ b/specutils/analysis/template_comparison.py
@@ -86,7 +86,7 @@ def _chi_square_for_templates(observed_spectrum, template_spectrum, resample_met
     if _resample(resample_method) != 0:
         fluxc_resample = _resample(resample_method)
         template_obswavelength = fluxc_resample(template_spectrum,
-                                                observed_spectrum.wavelength)
+                                                observed_spectrum.spectral_axis)
 
     # Normalize spectra
     normalization = _normalize_for_template_matching(observed_spectrum,

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -146,7 +146,7 @@ def _compute_fwzi(spectrum, regions=None):
 
     # Create a copy of the flux array to ensure the value on the spectrum
     # object is not altered.
-    disp = calc_spectrum.spectral_axis.quantity
+    disp = calc_spectrum.spectral_axis
     flux = calc_spectrum.flux.copy()
 
     # For noisy data, ensure that the search from the centroid stops on
@@ -199,7 +199,7 @@ def _compute_gaussian_sigma_width(spectrum, regions=None):
         calc_spectrum = spectrum
 
     flux = calc_spectrum.flux
-    spectral_axis = calc_spectrum.spectral_axis.quantity
+    spectral_axis = calc_spectrum.spectral_axis
 
     centroid_result = centroid(spectrum, regions)
 

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -2,7 +2,6 @@ import itertools
 import logging
 import operator
 
-import astropy.units as u
 import numpy as np
 from astropy.modeling import fitting, Model, models
 from astropy.table import QTable
@@ -10,7 +9,6 @@ from scipy.signal import convolve
 
 
 import astropy.units as u
-from astropy.stats import sigma_clipped_stats
 
 from ..spectra.spectral_region import SpectralRegion
 from ..spectra.spectrum1d import Spectrum1D

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -480,7 +480,6 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
 
     spectrum = Spectrum1D(
         flux=flux.value * flux_unit,
-        # spectral_axis=dispersion.value * dispersion_unit,
         spectral_axis=dispersion,
         wcs=input_spectrum.wcs,
         velocity_convention=input_spectrum.velocity_convention,

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -409,7 +409,6 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
     mask = spectrum.mask
 
     dispersion = spectrum.spectral_axis
-    dispersion_unit = spectrum.spectral_axis.unit
 
     flux = spectrum.flux
     flux_unit = spectrum.flux.unit
@@ -481,7 +480,8 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
 
     spectrum = Spectrum1D(
         flux=flux.value * flux_unit,
-        spectral_axis=dispersion.value * dispersion_unit,
+        # spectral_axis=dispersion.value * dispersion_unit,
+        spectral_axis=dispersion,
         wcs=input_spectrum.wcs,
         velocity_convention=input_spectrum.velocity_convention,
         rest_value=input_spectrum.rest_value)


### PR DESCRIPTION
As part of the adaptation of code in analysis/manipulation functions to use SpectralCoord, we cleaned up the code from references that pointed directly to underlying attributes of the spectral_axis object. These references now point to the object itself, thus ensuring that existing underlying machinery will be used (if present).

The remaining part of this issue, namely, integrating bin edge functionality in SpectralCoord, will be handled in a separate PR. 

