### PR TITLE
Update custom loading doc to include spectral_axis in Spectrum1D object 

### DIFF
--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -88,9 +88,10 @@ ensure that the data file being loaded is compatible with the loader function.
             meta = {'header': header}
             wcs = WCS(hdulist[0].header)
             uncertainty = StdDevUncertainty(tab["err"])
+            lamb = tab["spectral_axis"] * Unit("Angstrom")
             data = tab["flux"] * Unit("Jy")
 
-        return Spectrum1D(flux=data, wcs=wcs, uncertainty=uncertainty, meta=meta)
+        return Spectrum1D(flux=data, spectral_axis=lamb, wcs=wcs, uncertainty=uncertainty, meta=meta)
 
 
 An ``extensions`` keyword can be provided. This allows for basic filename

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -94,6 +94,9 @@ ensure that the data file being loaded is compatible with the loader function.
         return Spectrum1D(flux=data, spectral_axis=lamb, wcs=wcs, uncertainty=uncertainty, meta=meta)
 
 
+The above is based on the ``Quantity`` formulation, as for any reasonably "generic" format ``Table.read()``
+would extract the units from the FITS header anyway.
+
 An ``extensions`` keyword can be provided. This allows for basic filename
 extension matching in the case that the ``identifier`` function is not
 provided.
@@ -165,6 +168,10 @@ This again will be done in a separate python file and placed in the user's
         tab = Table([disp, flux], names=("spectral_axis", "flux"), meta=meta)
 
         tab.write(file_name, format="fits")
+
+Please note that it is assumed that the axis (of the ``flux`` and ``spectral_axis``)
+units information is stored in the ``meta`` parameter as introduced in the definition
+of ``generic-fits`` as the ``custom_writer()`` above.
 
 The custom writer can be used by passing the name of the custom writer to the
 ``format`` argument of the ``write`` method on the

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -159,8 +159,8 @@ This again will be done in a separate python file and placed in the user's
     from specutils.io.registers import custom_writer
 
 
-    @custom_writer("fits-writer")
-    def generic_fits(spectrum, file_name, **kwargs):
+    @custom_writer("my-format")
+    def my_format_writer(spectrum, file_name, **kwargs):
         flux = spectrum.flux
         disp = spectrum.spectral_axis
         meta = spectrum.meta
@@ -169,7 +169,7 @@ This again will be done in a separate python file and placed in the user's
 
         tab.write(file_name, format="fits")
 
-Please note that it is assumed that the axis (of the ``flux`` and ``spectral_axis``)
+Note that this will store the units information of the ``flux`` and ``spectral_axis`` as attributes of the ``Quantity`` columns in the ``Table``, which is saving them automatically to the FITS file.
 units information is stored in ``Table`` object as introduced in the definition
 of ``generic-fits`` as the ``custom_writer()`` above.
 

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -233,3 +233,6 @@ Reference/API
 -------------
 .. automodapi:: specutils.io.registers
     :no-heading:
+
+.. automodapi:: specutils.io.parsing_utils
+    :no-heading:

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -161,8 +161,8 @@ This again will be done in a separate python file and placed in the user's
 
     @custom_writer("fits-writer")
     def generic_fits(spectrum, file_name, **kwargs):
-        flux = spectrum.flux.value
-        disp = spectrum.spectral_axis.value
+        flux = spectrum.flux
+        disp = spectrum.spectral_axis
         meta = spectrum.meta
 
         tab = Table([disp, flux], names=("spectral_axis", "flux"), meta=meta)
@@ -170,7 +170,7 @@ This again will be done in a separate python file and placed in the user's
         tab.write(file_name, format="fits")
 
 Please note that it is assumed that the axis (of the ``flux`` and ``spectral_axis``)
-units information is stored in the ``meta`` parameter as introduced in the definition
+units information is stored in ``Table`` object as introduced in the definition
 of ``generic-fits`` as the ``custom_writer()`` above.
 
 The custom writer can be used by passing the name of the custom writer to the

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -25,10 +25,10 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
         The table object (e.g. returned from ``Table.read('data_file')``).
     column_mapping : dict
         A dictionary describing the relation between the table columns
-        and the arguments of the `Spectrum1D` class, along with unit
+        and the arguments of the ``Spectrum1D`` class, along with unit
         information. The dictionary keys should be the table column names
         while the values should be a two-tuple where the first element is the
-        associated `Spectrum1D` keyword argument, and the second element is the
+        associated ``Spectrum1D`` keyword argument, and the second element is the
         unit for the file column (or ``None`` to take unit from the table)::
 
             column_mapping = {'FLUX': ('flux', 'Jy'),
@@ -244,7 +244,7 @@ def _fits_identify_by_name(origin, fileinp, *args,
                            pattern=r'(?i).*\.fit[s]?$', **kwargs):
     """
     Check whether input file is FITS and matches a given name pattern.
-    Utility function to construct an `identifier` for Astropy I/O Registry.
+    Utility function to construct an ``identifier`` for Astropy I/O Registry.
 
     Parameters
     ----------
@@ -276,7 +276,7 @@ def _fits_identify_by_name(origin, fileinp, *args,
         fileobj = fileinp
         filepath = fileobj.name
 
-    # Check for `urlopen` object - can only probe content if seekable
+    # Check for ``urlopen`` object - can only probe content if seekable
     if hasattr(fileinp, 'url') and hasattr(fileinp, 'seekable'):
         filepath = urllib.parse.unquote(fileinp.url)
         if fileinp.seekable():

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -93,10 +93,10 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
     Uses the following logic to figure out which column is which:
 
     * Spectral axis (dispersion) is the first column with units
-    compatible with u.spectral() or with length units such as 'pix'.
+      compatible with u.spectral() or with length units such as 'pix'.
     * Flux is taken from the first column with units compatible with
-    u.spectral_density(), or with other likely culprits such as
-    'adu' or 'cts/s'.
+      u.spectral_density(), or with other likely culprits such as
+      'adu' or 'cts/s'.
     * Uncertainty comes from the next column with the same units as flux.
 
     Parameters

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -34,7 +34,7 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
             column_mapping = {'FLUX': ('flux', 'Jy'),
                               'WAVE': ('spectral_axis', 'um')}
 
-    wcs : :class:`~astropy.wcs.WCS` or :class:`gwcs.WCS`
+    wcs : :class:`~astropy.wcs.WCS` or :class:`~gwcs.wcs.WCS`
         WCS object passed to the Spectrum1D initializer.
 
     """

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -36,6 +36,7 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
 
     wcs : :class:`~astropy.wcs.WCS` or :class:`gwcs.WCS`
         WCS object passed to the Spectrum1D initializer.
+
     """
     spec_kwargs = {}
 
@@ -91,14 +92,14 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
     Load spectrum from an Astropy table into a Spectrum1D object.
     Uses the following logic to figure out which column is which:
 
-     * Spectral axis (dispersion) is the first column with units
-     compatible with u.spectral() or with length units such as 'pix'.
+    * Spectral axis (dispersion) is the first column with units
+    compatible with u.spectral() or with length units such as 'pix'.
 
-     * Flux is taken from the first column with units compatible with
-     u.spectral_density(), or with other likely culprits such as
-     'adu' or 'cts/s'.
+    * Flux is taken from the first column with units compatible with
+    u.spectral_density(), or with other likely culprits such as
+    'adu' or 'cts/s'.
 
-     * Uncertainty comes from the next column with the same units as flux.
+    * Uncertainty comes from the next column with the same units as flux.
 
     Parameters
     ----------
@@ -126,6 +127,7 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
         Take the first column that has units compatible with u.spectral()
         equivalencies. If none meet that criterion, look for other likely
         length units such as 'pix'.
+
         """
         additional_valid_units = [u.Unit('pix')]
         found_column = None
@@ -155,6 +157,7 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
         Take the first column that has units compatible with
         u.spectral_density() equivalencies. If none meet that criterion,
         look for other likely length units such as 'adu' or 'cts/s'.
+
         """
         additional_valid_units = [u.Unit('adu'), u.Unit('ct/s')]
         found_column = None
@@ -253,6 +256,7 @@ def _fits_identify_by_name(origin, fileinp, *args,
         File name pattern to be matched.
         Note: loaders should define a pattern sufficiently specific for their
         spectrum file types to avoid ambiguous/multiple matches.
+
     """
     fileobj = None
     filepath = None

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -94,11 +94,9 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
 
     * Spectral axis (dispersion) is the first column with units
     compatible with u.spectral() or with length units such as 'pix'.
-
     * Flux is taken from the first column with units compatible with
     u.spectral_density(), or with other likely culprits such as
     'adu' or 'cts/s'.
-
     * Uncertainty comes from the next column with the same units as flux.
 
     Parameters


### PR DESCRIPTION
Fixes #625. 

To clarify an issue previously encountered when using custom loader defined as described in official docs to load FITS data to file. It appears that the `spectral_axis` is missing from the example, which could cause problems somewhere down the line, when the FITS file loaded this way is then subsequently read with a compatible custom reader as a `Spectrum1D` object then called, as the two essential requirements of any `Spectrum1D` object are the `flux` and the `spectral_axis`. It is in the hope that any confusion stemming from the example can be cleared. 