### PR TITLE
Fix SpectralCoordType ASDF schema; turn on schema tester in repo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ norecursedirs = build docs/_build
 doctest_plus = enabled
 remote_data_strict = True
 asdf_schema_root = specutils/io/asdf/schemas
+asdf_schema_tests_enabled = true
 # The remote data tests will run by default. Passing --remote-data=none on the
 # command line will override this setting.
 addopts = --remote-data=any --doctest-rst

--- a/specutils/io/asdf/schemas/astropy.org/specutils/spectra/spectral_coord-1.0.0.yaml
+++ b/specutils/io/asdf/schemas/astropy.org/specutils/spectra/spectral_coord-1.0.0.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/specutils/spectra/spectral_coord-1.0.0"
+tag: "tag:astropy.org:specutils/spectra/spectral_coord-1.0.0"
+
+title: >
+  Represents a spectral coordinate
+description:
+  This schema represents a SpectralCoord object from specutils
+
+type: object
+properties:
+  $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+...

--- a/specutils/io/asdf/schemas/astropy.org/specutils/spectra/spectral_coord-1.0.0.yaml
+++ b/specutils/io/asdf/schemas/astropy.org/specutils/spectra/spectral_coord-1.0.0.yaml
@@ -6,10 +6,20 @@ tag: "tag:astropy.org:specutils/spectra/spectral_coord-1.0.0"
 
 title: >
   Represents a spectral coordinate
-description:
+description: |
   This schema represents a SpectralCoord object from specutils
 
 type: object
 properties:
-  $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+required: [value, unit]
 ...

--- a/specutils/io/asdf/schemas/astropy.org/specutils/spectra/spectrum1d-1.0.0.yaml
+++ b/specutils/io/asdf/schemas/astropy.org/specutils/spectra/spectrum1d-1.0.0.yaml
@@ -4,20 +4,6 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://astropy.org/schemas/specutils/spectra/spectrum1d-1.0.0"
 tag: "tag:astropy.org:specutils/spectra/spectrum1d-1.0.0"
 
-definitions:
-  uncertainty:
-    type: object
-    properties:
-      uncertainty_type:
-        description: |
-          String describing the type of uncertainty data
-        type: string
-        enum: ["std", "var", "ivar", "unknown"]
-      data:
-        description: |
-          Array representing the uncertainty data
-        $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
-
 title: >
   Represents a one-dimensional spectrum
 description: |
@@ -28,14 +14,26 @@ properties:
   flux:
     description: |
       Quantity that represents the flux component of the spectrum
-    $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+    $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
   spectral_axis:
     description: |
       SpectralCoord that represents the spectral axis of the spectrum
-    $ref: "spectral_coord-1.0.0"
+    anyOf:
+      - $ref: "spectral_coord-1.0.0"
+      - $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
   uncertainty:
     description: |
       Uncertainty information about the spectrum
-    $ref: "#/definitions/uncertainty"
+    type: object
+    properties:
+      uncertainty_type:
+        description: |
+          String describing the type of uncertainty data
+        type: string
+        enum: ["std", "var", "ivar", "unknown"]
+      data:
+        description: |
+          Array representing the uncertainty data
+        $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
 required: [flux, spectral_axis]
 ...

--- a/specutils/io/asdf/schemas/astropy.org/specutils/spectra/spectrum1d-1.0.0.yaml
+++ b/specutils/io/asdf/schemas/astropy.org/specutils/spectra/spectrum1d-1.0.0.yaml
@@ -31,8 +31,8 @@ properties:
     $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
   spectral_axis:
     description: |
-      Quantity that represents the spectral axis of the spectrum
-    $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+      SpectralCoord that represents the spectral axis of the spectrum
+    $ref: "spectral_coord-1.0.0"
   uncertainty:
     description: |
       Uncertainty information about the spectrum

--- a/specutils/io/asdf/tags/spectra.py
+++ b/specutils/io/asdf/tags/spectra.py
@@ -7,7 +7,7 @@ import astropy.nddata
 from asdf.tags.core import NDArrayType
 from asdf.yamlutil import (custom_tree_to_tagged_tree,
                            tagged_tree_to_custom_tree)
-from astropy.io.misc.asdf.tags.unit import UnitType
+from astropy.io.misc.asdf.tags.unit.unit import UnitType
 
 from ....spectra import SpectralCoord, Spectrum1D, SpectrumList
 from ..types import SpecutilsType

--- a/specutils/io/asdf/tags/spectra.py
+++ b/specutils/io/asdf/tags/spectra.py
@@ -4,14 +4,15 @@ Contains classes that serialize spectral data types into ASDF representations.
 from numpy.testing import assert_allclose
 from astropy.units import allclose
 import astropy.nddata
-from asdf.yamlutil import custom_tree_to_tagged_tree, tagged_tree_to_custom_tree
+from asdf.tags.core import NDArrayType
+from asdf.yamlutil import (custom_tree_to_tagged_tree,
+                           tagged_tree_to_custom_tree)
+from astropy.io.misc.asdf.tags.unit import UnitType
 
+from ....spectra import SpectralCoord, Spectrum1D, SpectrumList
 from ..types import SpecutilsType
-from ....spectra import Spectrum1D, SpectrumList
 
-
-__all__ = ['Spectrum1DType', 'SpectrumListType']
-
+__all__ = ['Spectrum1DType', 'SpectrumListType', 'SpectralCoordType']
 
 UNCERTAINTY_TYPE_MAPPING = {
     'std': astropy.nddata.StdDevUncertainty,
@@ -36,10 +37,12 @@ class Spectrum1DType(SpecutilsType):
         """
         node = {}
         node['flux'] = custom_tree_to_tagged_tree(obj.flux, ctx)
-        node['spectral_axis'] = custom_tree_to_tagged_tree(obj.spectral_axis, ctx)
+        node['spectral_axis'] = custom_tree_to_tagged_tree(obj.spectral_axis,
+                                                           ctx)
         if obj.uncertainty is not None:
             node['uncertainty'] = {}
-            node['uncertainty']['uncertainty_type'] = obj.uncertainty.uncertainty_type
+            node['uncertainty'][
+                'uncertainty_type'] = obj.uncertainty.uncertainty_type
             data = custom_tree_to_tagged_tree(obj.uncertainty.array, ctx)
             node['uncertainty']['data'] = data
 
@@ -75,7 +78,6 @@ class Spectrum1DType(SpecutilsType):
             assert_allclose(old.uncertainty.array, new.uncertainty.array)
 
 
-
 class SpectrumListType(SpecutilsType):
     """
     ASDF tag implementation used to serialize/deserialize SpectrumList objects
@@ -107,3 +109,32 @@ class SpectrumListType(SpecutilsType):
         assert len(old) == len(new)
         for x, y in zip(old, new):
             Spectrum1DType.assert_equal(x, y)
+
+
+class SpectralCoordType(SpecutilsType):
+    """
+    ASDF tag implementation used to serialize/derialize SpectralCoord objects
+    """
+    name = 'spectra/spectral_coord'
+    types = [SpectralCoord]
+    version = '1.0.0'
+
+    @classmethod
+    def to_tree(cls, spec_coord, ctx):
+        node = {}
+        if isinstance(spec_coord, SpectralCoord):
+            node['value'] = custom_tree_to_tagged_tree(spec_coord.value, ctx)
+            node['unit'] = custom_tree_to_tagged_tree(spec_coord.unit, ctx)
+            return node
+        raise TypeError(f"'{spec_coord}' is not a valid SpectralCoord")
+
+    @classmethod
+    def from_tree(cls, node, ctx):
+        if isinstance(node, SpectralCoord):
+            return node
+
+        unit = UnitType.from_tree(node['unit'], ctx)
+        value = node['value']
+        if isinstance(value, NDArrayType):
+            value = value._make_array()
+        return SpectralCoord(value, unit=unit)


### PR DESCRIPTION
- Add an ASDF schema, ASDF Type and ASDF tag for `SpectralCoord`
- Enable on the ASDF schema tester pytest plugin.

Replaces and closes #623