### PR TITLE
Implement SpectralAxis subclass of SpectralCoord with bin edge support

### DIFF
--- a/docs/manipulation.rst
+++ b/docs/manipulation.rst
@@ -334,7 +334,7 @@ the ``spectral_axis``. Therefore one can use a construct like this:
     <Spectrum1D(flux=<Quantity [ 49.6714153 ,  13.82643012,  64.76885381, 152.30298564,
                 23.41533747,  23.41369569, 157.92128155,  76.74347292,
                 46.94743859,  54.25600436] Jy>,
-     spectral_axis=<SpectralCoord [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] um,
+     spectral_axis=<SpectralAxis [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] um,
        radial_velocity=0.0 km / s,
        redshift=0.0,
        doppler_rest=0.0 Angstrom,
@@ -347,7 +347,7 @@ the ``spectral_axis``. Therefore one can use a construct like this:
     >>> new_spec #doctest:+ELLIPSIS
     <Spectrum1D(flux=<Quantity [ 49.6714153 ,  13.82643012,  64.76885381, 152.30298564,
                 23.41533747,  23.41369569, 157.92128155,  76.74347292,
-                46.94743859,  54.25600436] Jy>, spectral_axis=<SpectralCoord [ 1.23,  2.23,  3.23,  4.23,  5.23,  6.23,  7.23,  8.23,
+                46.94743859,  54.25600436] Jy>, spectral_axis=<SpectralAxis [ 1.23,  2.23,  3.23,  4.23,  5.23,  6.23,  7.23,  8.23,
                      9.23, 10.23] um,
        radial_velocity=0.0 km / s,
        redshift=0.0,

--- a/docs/spectral_regions.rst
+++ b/docs/spectral_regions.rst
@@ -166,7 +166,7 @@ An example of a single sub-region `~specutils.SpectralRegion`:
     >>> spectrum = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm, flux=np.random.sample(49)*u.Jy)
     >>> sub_spectrum = extract_region(spectrum, region)
     >>> sub_spectrum.spectral_axis
-    <SpectralCoord [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
+    <SpectralAxis [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
                      20., 21., 22.] nm,
         radial_velocity=0.0 km / s,
         redshift=0.0,
@@ -192,7 +192,7 @@ as would be expected:
     >>> region_angstroms = SpectralRegion(80*u.AA, 220*u.AA)
     >>> sub_spectrum = extract_region(spectrum, region_angstroms)
     >>> sub_spectrum.spectral_axis
-    <SpectralCoord [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
+    <SpectralAxis [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
                     20., 21., 22.] nm,
         radial_velocity=0.0 km / s,
         redshift=0.0,
@@ -203,7 +203,7 @@ as would be expected:
     >>> region_pixels = SpectralRegion(7.5*u.pixel, 21.5*u.pixel)
     >>> sub_spectrum = extract_region(spectrum, region_pixels)
     >>> sub_spectrum.spectral_axis
-    <SpectralCoord [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
+    <SpectralAxis [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
                     20., 21., 22.] nm,
         radial_velocity=0.0 km / s,
         redshift=0.0,
@@ -227,7 +227,7 @@ An example of a multiple sub-region `~specutils.SpectralRegion`:
     >>> spectrum = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm, flux=np.random.sample(49)*u.Jy)
     >>> sub_spectra = extract_region(spectrum, region)
     >>> sub_spectra[0].spectral_axis
-    <SpectralCoord [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
+    <SpectralAxis [ 8.,  9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
                     20., 21., 22.] nm,
         radial_velocity=0.0 km / s,
         redshift=0.0,
@@ -236,7 +236,7 @@ An example of a multiple sub-region `~specutils.SpectralRegion`:
         observer=None,
         target=None>
     >>> sub_spectra[1].spectral_axis
-    <SpectralCoord [34., 35., 36., 37., 38., 39., 40.] nm,
+    <SpectralAxis [34., 35., 36., 37., 38., 39., 40.] nm,
         radial_velocity=0.0 km / s,
         redshift=0.0,
         doppler_rest=0.0 Angstrom,

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -30,8 +30,8 @@ create it explicitly from arrays or `~astropy.units.Quantity` objects:
     >>> ax.set_ylabel("Flux")  # doctest: +SKIP
 
 .. note::
-    Note that the ``spectral_axis`` can also be provided as a :class:`~specutils.SpectralCoord` object, 
-    and in fact will internally convert the spectral_axis to :class:`~specutils.SpectralCoord` if it
+    Note that the ``spectral_axis`` can also be provided as a :class:`~specutils.SpectralAxis` object, 
+    and in fact will internally convert the spectral_axis to :class:`~specutils.SpectralAxis` if it
     is provided as an array or `~astropy.units.Quantity`.
 
 Reading from a File

--- a/specutils/io/asdf/tags/tests/test_spectra.py
+++ b/specutils/io/asdf/tags/tests/test_spectra.py
@@ -11,7 +11,7 @@ from astropy.nddata import StdDevUncertainty
 from asdf.tests.helpers import assert_roundtrip_tree
 import asdf
 
-from specutils import Spectrum1D, SpectrumList
+from specutils import Spectrum1D, SpectrumList, SpectralAxis
 
 
 def create_spectrum1d(xmin, xmax, uncertainty=None):
@@ -37,6 +37,13 @@ def test_asdf_spectrum1d_uncertainty(tmpdir):
     tree = dict(spectrum=spectrum)
     assert_roundtrip_tree(tree, tmpdir)
 
+@pytest.mark.xfail
+def test_asdf_spectralaxis(tmpdir):
+
+    wavelengths  = np.arange(5100, 5300) * 0.1 * u.nm
+    spectral_axis = SpectralAxis(wavelengths, bin_specification="edges")
+    tree = dict(spectral_axis=spectral_axis)
+    assert_roundtrip_tree(tree, tmpdir)
 
 def test_asdf_spectrumlist(tmpdir):
 

--- a/specutils/spectra/__init__.py
+++ b/specutils/spectra/__init__.py
@@ -7,3 +7,4 @@ from .spectral_region import *  # noqa
 from .spectrum_collection import *  #noqa
 from .spectrum_list import * #noqa
 from .spectral_coordinate import *
+from .spectral_axis import *

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -34,8 +34,11 @@ class SpectralAxis(SpectralCoord):
         return obj
 
     @static_method
-    def _edges_from_centers():
-        pass
+    def _edges_from_centers(centers):
+        a = np.insert(centers, 0, 2*centers[0]-centers[1])
+        b = centers.append(2*centers[-1]-centers[-2])
+        edges = (a + b) / 2
+        return edges
 
     @static_method
     def _centers_from_edges(edges):

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -15,21 +15,36 @@ class SpectralAxis(SpectralCoord):
     """
     """
 
-    def __new__():
-        pass
+    def __new__(cls, value, unit=None, observer=None, target=None,
+                 radial_velocity=None, redshift=None, doppler_rest=None,
+                 doppler_convention=None, bin_specification="centers",
+                 **kwargs):
+
+        # Convert to bin centers if bin edges were given, since SpectralCoord
+        # only accepts centers
+        if bin_specification == "edges":
+            value = self._centers_from_edges(value)
+            bin_specification = "bin_centers"
+
+        obj = super().__new__(cls, value, unit=unit, observer=observer,
+                              target=target, radial_velocity=radial_velocity,
+                              redshift=redshift, doppler_rest=doppler_rest,
+                              doppler_convention=doppler_convention, subok=True,
+                              **kwargs)
+        return obj
 
     @static_method
     def _edges_from_centers():
         pass
 
     @static_method
-    def centers_from_edges():
-        pass
+    def _centers_from_edges(edges):
+        return (edges[1:] + edges[:-1]) / 2
 
     @property
     def bin_edges(self):
-        pass
+        return self._edges_from_centers(self.value)
 
     @property
     def bin_centers(self):
-        pass
+        return self.value

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -34,6 +34,14 @@ class SpectralAxis(SpectralCoord):
 
         return obj
 
+    def __quantity_subclass__(self, unit):
+        """:wq
+
+        Overridden by subclasses to change what kind of view is
+        created based on the output unit of an operation.
+        """
+        return SpectralAxis, True
+
     @staticmethod
     def _edges_from_centers(centers):
         a = np.insert(centers, 0, 2*centers[0]-centers[1])

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -53,7 +53,7 @@ class SpectralAxis(SpectralCoord):
         obj = super().__new__(cls, value, *args, **kwargs)
 
         if bin_specification == "edges":
-            obj.bin_edges = bin_edges
+            obj._bin_edges = bin_edges
 
         return obj
 
@@ -65,7 +65,7 @@ class SpectralAxis(SpectralCoord):
         return SpectralAxis, True
 
     @staticmethod
-    def _edges_from_centers(centers):
+    def _edges_from_centers(centers, unit):
         """
         Calculates interior bin edges based on the average of each pair of
         centers, with the two outer edges based on extrapolated centers added
@@ -74,7 +74,7 @@ class SpectralAxis(SpectralCoord):
         a = np.insert(centers, 0, 2*centers[0] - centers[1])
         b = np.append(centers, 2*centers[-1] - centers[-2])
         edges = (a + b) / 2
-        return edges
+        return edges*unit
 
     @staticmethod
     def _centers_from_edges(edges):
@@ -89,4 +89,7 @@ class SpectralAxis(SpectralCoord):
         Calculates bin edges if the spectral axis was created with centers
         specified.
         """
-        return self._edges_from_centers(self.value)
+        if hasattr(self, '_bin_edges'):
+            return self._bin_edges
+        else:
+            return self._edges_from_centers(self.value, self.unit)

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -42,10 +42,7 @@ class SpectralAxis(SpectralCoord):
         are interpreted as bin edges or bin centers. Defaults to "centers".
     """
 
-    def __new__(cls, value, unit=None, observer=None, target=None,
-                 radial_velocity=None, redshift=None, doppler_rest=None,
-                 doppler_convention=None, bin_specification="centers",
-                 **kwargs):
+    def __new__(cls, value, *args, bin_specification="centers", **kwargs):
 
         # Convert to bin centers if bin edges were given, since SpectralCoord
         # only accepts centers
@@ -53,10 +50,7 @@ class SpectralAxis(SpectralCoord):
             bin_edges = value
             value = SpectralAxis._centers_from_edges(value)
 
-        obj = super().__new__(cls, value, unit=unit, observer=observer,
-                              target=target, radial_velocity=radial_velocity,
-                              redshift=redshift, doppler_rest=doppler_rest,
-                              doppler_convention=doppler_convention, **kwargs)
+        obj = super().__new__(cls, value, *args, **kwargs)
 
         if bin_specification == "edges":
             obj.bin_edges = bin_edges

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -20,24 +20,7 @@ class SpectralAxis(SpectralCoord):
 
     Parameters
     ----------
-    value : ndarray or `~astropy.units.Quantity` or `SpectralCoord`
-        Spectral axis data values.
-    unit : str or `~astropy.units.Unit`
-        Unit for the given data.
-    observer : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`, optional
-        The coordinate (position and velocity) of the observer.
-    target : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`, optional
-        The coordinate (position and velocity) of the target.
-    radial_velocity : `~astropy.units.Quantity`, optional
-        The radial velocity of the target with respect to the observer.
-    redshift : float, optional
-        The redshift of the target with respect to the observer.
-    doppler_rest : `~astropy.units.Quantity`, optional
-        The rest value to use for velocity space transformations.
-    doppler_convention : str, optional
-        The convention to use when converting the spectral data to/from
-        velocity space.
-    bin_specificatoin: str, optional
+    bin_specification: str, optional
         Must be "edges" or "centers". Determines whether specified axis values
         are interpreted as bin edges or bin centers. Defaults to "centers".
     """

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -1,0 +1,35 @@
+import warnings
+
+import astropy.units as u
+import numpy as np
+
+from .spectral_coordinate import SpectralCoord
+
+
+__all__ = ['SpectralAxis']
+
+# We don't want to run doctests in the docstrings we inherit from Quantity
+__doctest_skip__ = ['SpectralAxis.*']
+
+class SpectralAxis(SpectralCoord):
+    """
+    """
+
+    def __new__():
+        pass
+
+    @static_method
+    def _edges_from_centers():
+        pass
+
+    @static_method
+    def centers_from_edges():
+        pass
+
+    @property
+    def bin_edges(self):
+        pass
+
+    @property
+    def bin_centers(self):
+        pass

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -25,9 +25,9 @@ class SpectralAxis(SpectralCoord):
     unit : str or `~astropy.units.Unit`
         Unit for the given data.
     observer : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`, optional
-        The coordinate (position and velocity) of observer.
+        The coordinate (position and velocity) of the observer.
     target : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`, optional
-        The coordinate (position and velocity) of observer.
+        The coordinate (position and velocity) of the target.
     radial_velocity : `~astropy.units.Quantity`, optional
         The radial velocity of the target with respect to the observer.
     redshift : float, optional

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -1,6 +1,7 @@
 import warnings
 
 import astropy.units as u
+from astropy.utils.decorators import lazyproperty
 import numpy as np
 
 from .spectral_coordinate import SpectralCoord
@@ -23,6 +24,7 @@ class SpectralAxis(SpectralCoord):
         # Convert to bin centers if bin edges were given, since SpectralCoord
         # only accepts centers
         if bin_specification == "edges":
+            bin_edges = value
             value = SpectralAxis._centers_from_edges(value)
 
         obj = super().__new__(cls, value, unit=unit, observer=observer,
@@ -30,7 +32,8 @@ class SpectralAxis(SpectralCoord):
                               redshift=redshift, doppler_rest=doppler_rest,
                               doppler_convention=doppler_convention, **kwargs)
 
-        #obj.bin_edges = cls._edges_from_centers(value)
+        if bin_specification == "edges":
+            obj.bin_edges = bin_edges
 
         return obj
 
@@ -53,6 +56,6 @@ class SpectralAxis(SpectralCoord):
     def _centers_from_edges(edges):
         return (edges[1:] + edges[:-1]) / 2
 
-    @property
+    @lazyproperty
     def bin_edges(self):
         return self._edges_from_centers(self.value)

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -23,31 +23,28 @@ class SpectralAxis(SpectralCoord):
         # Convert to bin centers if bin edges were given, since SpectralCoord
         # only accepts centers
         if bin_specification == "edges":
-            value = self._centers_from_edges(value)
-            bin_specification = "bin_centers"
+            value = SpectralAxis._centers_from_edges(value)
 
         obj = super().__new__(cls, value, unit=unit, observer=observer,
                               target=target, radial_velocity=radial_velocity,
                               redshift=redshift, doppler_rest=doppler_rest,
-                              doppler_convention=doppler_convention, subok=True,
-                              **kwargs)
+                              doppler_convention=doppler_convention, **kwargs)
+
+        #obj.bin_edges = cls._edges_from_centers(value)
+
         return obj
 
-    @static_method
+    @staticmethod
     def _edges_from_centers(centers):
         a = np.insert(centers, 0, 2*centers[0]-centers[1])
-        b = centers.append(2*centers[-1]-centers[-2])
+        b = np.append(centers, 2*centers[-1]-centers[-2])
         edges = (a + b) / 2
         return edges
 
-    @static_method
+    @staticmethod
     def _centers_from_edges(edges):
         return (edges[1:] + edges[:-1]) / 2
 
     @property
     def bin_edges(self):
         return self._edges_from_centers(self.value)
-
-    @property
-    def bin_centers(self):
-        return self.value

--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -115,7 +115,7 @@ class SpectralCoord(u.Quantity):
                                      "redshift on spectral coordinate.")
 
                 observer = SpectralCoord._target_from_observer(
-                    target, -radial_velocity)
+                    target, radial_velocity)
 
         # If no target is defined, create a default target with any provided
         #  redshift/radial velocities.

--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -41,9 +41,9 @@ class SpectralCoord(u.Quantity):
     unit : str or `~astropy.units.Unit`
         Unit for the given data.
     observer : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`, optional
-        The coordinate (position and velocity) of observer.
+        The coordinate (position and velocity) of the observer.
     target : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`, optional
-        The coordinate (position and velocity) of observer.
+        The coordinate (position and velocity) of the target.
     radial_velocity : `~astropy.units.Quantity`, optional
         The radial velocity of the target with respect to the observer.
     redshift : float, optional

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -8,6 +8,7 @@ from astropy.nddata import NDDataRef
 from astropy.utils.decorators import lazyproperty
 from .spectrum_mixin import OneDSpectrumMixin
 from .spectral_coordinate import SpectralCoord
+from .spectral_axis import SpectralAxis
 from ..utils.wcs_utils import gwcs_from_array
 
 __all__ = ['Spectrum1D']
@@ -156,8 +157,17 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         # Check to make sure the wavelength length is the same in both, or
         # off by one if the spectral axis specifies bin edges
         if flux is not None and spectral_axis is not None:
-            if not spectral_axis.shape[0] == flux.shape[-1] and \
-                    not spectral_axis.shape[0] != flux.shape[-1]+1:
+            if spectral_axis.shape[0] == flux.shape[-1]:
+                if bin_specification == "edges":
+                    raise ValueError("A spectral axis input as bin edges"
+                        "must have length one greater than the flux axis")
+                bin_specification = "centers"
+            elif spectral_axis.shape[0] == flux.shape[-1]+1:
+                if bin_specification == "centers":
+                    raise ValueError("A spectral axis input as bin centers"
+                        "must be the same length as the flux axis")
+                bin_specification = "edges"
+            else:
                 raise ValueError(
                     "Spectral axis length ({}) must be the same size or one "
                     "greater (if specifying bin edges) than that of the last "

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -167,7 +167,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
 
                 self._spectral_axis = spectral_axis
 
-            wcs = gwcs_from_array(spectral_axis)
+            wcs = gwcs_from_array(self._spectral_axis)
         elif wcs is None:
             # If no spectral axis or wcs information is provided, initialize
             # with an empty gwcs based on the flux.

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -28,7 +28,8 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         The flux data for this spectrum.
     spectral_axis : `astropy.units.Quantity` or `specutils.SpectralCoord`
         Dispersion information with the same shape as the last (or only)
-        dimension of flux.
+        dimension of flux, or one greater than the last dimension of flux
+        if specifying bin edges.
     wcs : `astropy.wcs.WCS` or `gwcs.wcs.WCS`
         WCS information object.
     velocity_convention : {"doppler_relativistic", "doppler_optical", "doppler_radio"}

--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -43,7 +43,7 @@ def test_create_with_bin_edges():
     assert spectral_axis[0] == 501*u.AA
 
     # Test irregular bin edges
-    wavelengths = np.array([500,510,550,560,590])*u.AA
+    wavelengths = np.array([500, 510, 550, 560, 590])*u.AA
     spectral_axis = SpectralAxis(wavelengths, bin_specification="edges")
 
     assert np.all(spectral_axis.bin_edges == wavelengths)

--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -119,4 +119,3 @@ def test_create_from_spectral_axis(observer, target):
     assert spec_axis1.radial_velocity == spec_axis2.radial_velocity
     assert spec_axis1.doppler_convention == spec_axis2.doppler_convention
     assert spec_axis1.doppler_rest == spec_axis2.doppler_rest
-

--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -97,8 +97,8 @@ def test_create_from_spectral_coord(observer, target):
     to the SpectralAxis object
     """
     spec_coord = SpectralCoord([100, 200, 300] * u.nm, observer=observer,
-            target=target, radial_velocity=u.Quantity(1000, 'km/s'),
-            doppler_convention = 'optical', doppler_rest = 6000*u.AA)
+                               target=target, doppler_convention = 'optical',
+                               doppler_rest = 6000*u.AA)
     spec_axis = SpectralAxis(spec_coord)
     assert spec_coord.observer == spec_axis.observer
     assert spec_coord.target == spec_axis.target
@@ -111,8 +111,8 @@ def test_create_from_spectral_axis(observer, target):
     Checks that parameters are correctly copied to the new SpectralAxis object
     """
     spec_axis1 = SpectralAxis([100, 200, 300] * u.nm, observer=observer,
-            target=target, radial_velocity=u.Quantity(1000, 'km/s'),
-            doppler_convention = 'optical', doppler_rest = 6000*u.AA)
+                              target=target, doppler_convention = 'optical',
+                              doppler_rest = 6000*u.AA)
     spec_axis2 = SpectralAxis(spec_axis1)
     assert spec_axis1.observer == spec_axis2.observer
     assert spec_axis1.target == spec_axis2.target

--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -1,0 +1,122 @@
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy import time
+from astropy.constants import c
+from astropy.coordinates import (SkyCoord, EarthLocation, ICRS, GCRS, Galactic,
+                                 CartesianDifferential,
+                                 get_body_barycentric_posvel,
+                                 FK5, CartesianRepresentation)
+
+from ..spectra.spectral_coordinate import SpectralCoord
+from ..spectra.spectral_axis import SpectralAxis
+
+
+def get_greenwich_earthlocation():
+    """
+    A helper function to get an EarthLocation for greenwich (without trying to
+    do a download)
+    """
+    site_registry = EarthLocation._get_site_registry(force_builtin=True)
+    return site_registry.get('greenwich')
+
+def test_create_spectral_axis():
+
+    site = get_greenwich_earthlocation()
+    obstime = time.Time('2018-12-13 9:00')
+
+    observer_gcrs = site.get_gcrs(obstime)
+
+    wavelengths = np.linspace(500, 2500, 1001) * u.AA
+    spectral_axis = SpectralAxis(wavelengths, observer=observer_gcrs)
+
+    assert isinstance(spectral_axis, u.Quantity)
+    assert len(spectral_axis) == 1001
+    assert spectral_axis.bin_edges[0] == 499*u.AA
+
+def test_create_with_bin_edges():
+
+    wavelengths = np.linspace(500, 2500, 1001) * u.AA
+    spectral_axis = SpectralAxis(wavelengths, bin_specification="edges")
+
+    assert np.all(spectral_axis.bin_edges == wavelengths)
+    assert spectral_axis[0] == 501*u.AA
+
+    # Test irregular bin edges
+    wavelengths = np.array([500,510,550,560,590])*u.AA
+    spectral_axis = SpectralAxis(wavelengths, bin_specification="edges")
+
+    assert np.all(spectral_axis.bin_edges == wavelengths)
+    assert np.all(spectral_axis == [505., 530., 555., 575.]*u.AA)
+
+
+# GENERAL TESTS
+
+# We first run through a series of cases to test different ways of initializing
+# the observer and target for SpectralAxis, including for example frames,
+# SkyCoords, and making sure that SpectralAxis is not sensitive to the actual
+# frame or representation class.
+
+# Local Standard of Rest
+LSRD = Galactic(u=0 * u.km, v=0 * u.km, w=0 * u.km,
+                U=9 * u.km / u.s, V=12 * u.km / u.s, W=7 * u.km / u.s,
+                representation_type='cartesian', differential_type='cartesian')
+
+LSRD_EQUIV = [
+              LSRD,
+              SkyCoord(LSRD),  # as a SkyCoord
+              LSRD.transform_to(ICRS),  # different frame
+              LSRD.transform_to(ICRS).transform_to(Galactic)  # different representation
+              ]
+
+
+@pytest.fixture(params=[None] + LSRD_EQUIV)
+def observer(request):
+    return request.param
+
+
+# Target located in direction of motion of LSRD with no velocities
+LSRD_DIR_STATIONARY = Galactic(u=9 * u.km, v=12 * u.km, w=7 * u.km,
+                               representation_type='cartesian')
+
+LSRD_DIR_STATIONARY_EQUIV = [
+                             LSRD_DIR_STATIONARY,
+                             SkyCoord(LSRD_DIR_STATIONARY),  # as a SkyCoord
+                             LSRD_DIR_STATIONARY.transform_to(FK5()),  # different frame
+                             LSRD_DIR_STATIONARY.transform_to(ICRS()).transform_to(Galactic())  # different representation
+                            ]
+
+
+@pytest.fixture(params=[None] + LSRD_DIR_STATIONARY_EQUIV)
+def target(request):
+    return request.param
+
+def test_create_from_spectral_coord(observer, target):
+    """
+    Checks that parameters are correctly copied from the SpectralCoord object
+    to the SpectralAxis object
+    """
+    spec_coord = SpectralCoord([100, 200, 300] * u.nm, observer=observer,
+            target=target, radial_velocity=u.Quantity(1000, 'km/s'),
+            doppler_convention = 'optical', doppler_rest = 6000*u.AA)
+    spec_axis = SpectralAxis(spec_coord)
+    assert spec_coord.observer == spec_axis.observer
+    assert spec_coord.target == spec_axis.target
+    assert spec_coord.radial_velocity == spec_axis.radial_velocity
+    assert spec_coord.doppler_convention == spec_axis.doppler_convention
+    assert spec_coord.doppler_rest == spec_axis.doppler_rest
+
+def test_create_from_spectral_axis(observer, target):
+    """
+    Checks that parameters are correctly copied to the new SpectralAxis object
+    """
+    spec_axis1 = SpectralAxis([100, 200, 300] * u.nm, observer=observer,
+            target=target, radial_velocity=u.Quantity(1000, 'km/s'),
+            doppler_convention = 'optical', doppler_rest = 6000*u.AA)
+    spec_axis2 = SpectralAxis(spec_axis1)
+    assert spec_axis1.observer == spec_axis2.observer
+    assert spec_axis1.target == spec_axis2.target
+    assert spec_axis1.radial_velocity == spec_axis2.radial_velocity
+    assert spec_axis1.doppler_convention == spec_axis2.doppler_convention
+    assert spec_axis1.doppler_rest == spec_axis2.doppler_rest
+

--- a/specutils/tests/test_spectral_coord.py
+++ b/specutils/tests/test_spectral_coord.py
@@ -143,14 +143,15 @@ def test_create_from_spectral_coord(observer, target):
     Checks that parameters are correctly copied to the new SpectralCoord object
     """
     spec_coord1 = SpectralCoord([100, 200, 300] * u.nm, observer=observer,
-            target=target, radial_velocity=u.Quantity(1000, 'km/s'),
-            doppler_convention = 'optical', doppler_rest = 6000*u.AA)
+                                target=target, doppler_convention = 'optical',
+                                doppler_rest = 6000*u.AA)
     spec_coord2 = SpectralCoord(spec_coord1)
     assert spec_coord1.observer == spec_coord2.observer
     assert spec_coord1.target == spec_coord2.target
     assert spec_coord1.radial_velocity == spec_coord2.radial_velocity
     assert spec_coord1.doppler_convention == spec_coord2.doppler_convention
     assert spec_coord1.doppler_rest == spec_coord2.doppler_rest
+
 
 # SCIENCE USE CASE TESTS
 

--- a/specutils/tests/test_spectral_coord.py
+++ b/specutils/tests/test_spectral_coord.py
@@ -147,10 +147,10 @@ def test_create_from_spectral_coord(observer, target):
             doppler_convention = 'optical', doppler_rest = 6000*u.AA)
     spec_coord2 = SpectralCoord(spec_coord1)
     assert spec_coord1.observer == spec_coord2.observer
-    assert spec_coord2.target == spec_coord2.target
-    assert spec_coord2.radial_velocity == spec_coord2.radial_velocity
-    assert spec_coord2.doppler_convention == spec_coord2.doppler_convention
-    assert spec_coord2.doppler_rest == spec_coord2.doppler_rest
+    assert spec_coord1.target == spec_coord2.target
+    assert spec_coord1.radial_velocity == spec_coord2.radial_velocity
+    assert spec_coord1.doppler_convention == spec_coord2.doppler_convention
+    assert spec_coord1.doppler_rest == spec_coord2.doppler_rest
 
 # SCIENCE USE CASE TESTS
 

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -51,9 +51,10 @@ def test_create_from_multidimensional_arrays():
     assert (spec.frequency == freqs).all()
     assert (spec.flux == flux).all()
 
-    # Mis-matched lengths should raise an exception
+    # Mis-matched lengths should raise an exception (unless freqs is one longer
+    # than flux, in which case it's interpreted as bin edges)
     freqs = np.arange(50) * u.GHz
-    flux = np.random.random((5, len(freqs)-1)) * u.Jy
+    flux = np.random.random((5, len(freqs)-10)) * u.Jy
     with pytest.raises(ValueError) as e_info:
         spec = Spectrum1D(spectral_axis=freqs, flux=flux)
 
@@ -65,10 +66,11 @@ def test_create_from_quantities():
     assert spec.spectral_axis.unit == u.nm
     assert spec.spectral_axis.size == 49
 
-    # Mis-matched lengths should raise an exception
+    # Mis-matched lengths should raise an exception (unless freqs is one longer
+    # than flux, in which case it's interpreted as bin edges)
     with pytest.raises(ValueError) as e_info:
         spec = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm,
-                      flux=np.random.randn(48) * u.Jy)
+                      flux=np.random.randn(47) * u.Jy)
 
 
 def test_create_implicit_wcs():
@@ -328,7 +330,7 @@ def test_repr():
                                flux=np.random.random(10) * u.Jy)
     result = repr(spec_with_wcs)
     assert result.startswith('<Spectrum1D(flux=<Quantity [')
-    assert 'spectral_axis=<SpectralCoord [' in result
+    assert 'spectral_axis=<SpectralAxis [' in result
 
     spec_with_unc = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
                                flux=np.random.random(10) * u.Jy,
@@ -336,7 +338,7 @@ def test_repr():
                                    np.random.sample(10), unit='Jy'))
     result = repr(spec_with_unc)
     assert result.startswith('<Spectrum1D(flux=<Quantity [')
-    assert 'spectral_axis=<SpectralCoord [' in result
+    assert 'spectral_axis=<SpectralAxis [' in result
     assert 'uncertainty=StdDevUncertainty(' in result
 
 


### PR DESCRIPTION
This currently closes #626, #176, #494. I'm working on bug fixing for additional changes that will address #629 and #495, but wanted to get a PR with the core functionality out for other eyes sooner rather than later in case there are objections to my implementation. #494 was addressed simply by changing `spec.bin_edges` to return `spec.spectral_axis.bin_edges` rather than `spec.wcs.bin_edges()`.

I also plan to have docs and more test coverage added by end of day tomorrow.