### PR TITLE
Preserve flux unit in `resample1d` in older numpy versions

### DIFF
--- a/specutils/manipulation/resample.py
+++ b/specutils/manipulation/resample.py
@@ -301,20 +301,19 @@ class LinearInterpolatedResampler(ResamplerBase):
             An output spectrum containing the resampled `~specutils.Spectrum1D`
         """
 
-
-        fill_val = np.nan #bin_edges=nan_fill case
+        fill_val = np.nan  # bin_edges=nan_fill case
         if self.extrapolation_treatment == 'zero_fill':
             fill_val = 0
 
         orig_axis_in_fin = orig_spectrum.spectral_axis.to(fin_spec_axis.unit)
 
-        out_flux = np.interp(fin_spec_axis, orig_axis_in_fin,
-                             orig_spectrum.flux, left=fill_val, right=fill_val)
-
+        out_flux_arr = np.interp(fin_spec_axis.value, orig_axis_in_fin.value,
+                                 orig_spectrum.flux.value, left=fill_val, right=fill_val)
+        out_flux = Quantity(out_flux_arr, unit=orig_spectrum.flux.unit)
 
         new_unc = None
         if orig_spectrum.uncertainty is not None:
-            out_unc_arr = np.interp(fin_spec_axis, orig_axis_in_fin,
+            out_unc_arr = np.interp(fin_spec_axis.value, orig_axis_in_fin.value,
                                     orig_spectrum.uncertainty.array,
                                     left=fill_val, right=fill_val)
             new_unc = orig_spectrum.uncertainty.__class__(array=out_unc_arr,


### PR DESCRIPTION
Fixes #647 where `LinearInterpolatedResampler` was failing in `resample1d` if the installed numpy version is < 1.17.
Reason is that `np.interp` in earlier version cannot handle quantities and returns a dimensionless array. We might discontinue support for these numpy versions, but the fix also avoids first creating `out_flux` as a `SpectralCoord` object (which is later recast as `Quantity` in `Spectrum1D`, but smells of a possible source of trouble).
This fixes 9 out of 12 test failures with numpy 1.16.3; remaining failures in `test_slicing_with_fits` (`np.allclose` does not work on quantities), `test_los_shift` with `radial_velocity=None` and `test_asteroid_velocity_frame_shifts` (both I think subtracting a dimensionless and a quantity RV).