### PR TITLE
Clarify interrelation of SpectrumCollection, SpectrumList, and Spectrum1d in relevant docstrings

### DIFF
--- a/docs/types_of_spectra.rst
+++ b/docs/types_of_spectra.rst
@@ -1,5 +1,8 @@
 .. currentmodule:: specutils
 
+.. _specutils-representation-overview:
+
+
 Overview of How Specutils Represents Spectra
 --------------------------------------------
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -28,7 +28,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     ``spectral_axis``.
 
     For multidimensional spectra that are all the same shape but have different
-    spectral axes, use a :class:`~specutils.SpectralCollection`.  For a
+    spectral axes, use a :class:`~specutils.SpectrumCollection`.  For a
     collection of spectra that have different shapes, use
     :class:`~specutils.SpectrumList`. For more on this topic, see
     :ref:`specutils-representation-overview`.

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -29,8 +29,9 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
 
     For multidimensional spectra that are all the same shape but have different
     spectral axes, use a :class:`~specutils.SpectralCollection`.  For a
-    collection of spectra that have different shapes, see
-    :class:`~specutils.SpectrumList`.
+    collection of spectra that have different shapes, use
+    :class:`~specutils.SpectrumList`. For more on this topic, see
+    :ref:`specutils-representation-overview`.
 
     Parameters
     ----------

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -21,6 +21,17 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     """
     Spectrum container for 1D spectral data.
 
+    Note that "1d" in this case refers to the fact that there is only one
+    spectral axis.  `Spectrum1D` can contain "vector 1d spectra" by having the
+    ``flux`` have a shape with dimension great than 1 - the requirement then
+    is that the last dimension of ``flux`` match the length of the
+    ``spectral_axis``.
+
+    For multidimensional spectra that are all the same shape but have different
+    spectral axes, use a :class:`~specutils.SpectralCollection`.  For a
+    collection of spectra that have different shapes, see
+    :class:`~specutils.SpectrumList`.
+
     Parameters
     ----------
     flux : `astropy.units.Quantity` or astropy.nddata.NDData`-like

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -20,8 +20,9 @@ class SpectrumCollection:
 
     For multidimensional spectra that all have the *same* spectral axis, use a
     :class:`~specutils.Spectrum1D` with dimension greater than 1.  For a
-    collection of spectra that have different shapes, see
-    :class:`~specutils.SpectrumList`.
+    collection of spectra that have different shapes, use
+    :class:`~specutils.SpectrumList`. For more on this topic, see
+    :ref:`specutils-representation-overview`.
 
     The attributes on this class uses the same names and conventions as
     :class:`~specutils.Spectrum1D`, allowing some operations to work the same.

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -18,6 +18,11 @@ class SpectrumCollection:
     on them faster than if they are treated as individual
     :class:`~specutils.Spectrum1D` objects.
 
+    For multidimensional spectra that all have the *same* spectral axis, use a
+    :class:`~specutils.Spectrum1D` with dimension greater than 1.  For a
+    collection of spectra that have different shapes, see
+    :class:`~specutils.SpectrumList`.
+
     The attributes on this class uses the same names and conventions as
     :class:`~specutils.Spectrum1D`, allowing some operations to work the same.
     Where this does not work, the user can use standard indexing notation to

--- a/specutils/spectra/spectrum_list.py
+++ b/specutils/spectra/spectrum_list.py
@@ -6,8 +6,11 @@ __all__ = ['SpectrumList']
 
 class SpectrumList(list, NDIOMixin):
     """
-    A list that is used to hold a list of Spectrum1D objects
+    A list that is used to hold a list of `~specutils.Spectrum1D` objects
 
     The primary purpose of this class is to allow loaders to return a list of
-    heterogenous spectra that do have a spectral axis of the same length.
+    spectra that have different shapes.  For spectra that have the same shape
+    but different spectral axes, see `~specutils.SpectrumCollection`.  For
+    a spectrum or spectra that all share the same spectral axis, see
+    `~specutils.Spectrum1D`.
     """

--- a/specutils/spectra/spectrum_list.py
+++ b/specutils/spectra/spectrum_list.py
@@ -11,6 +11,7 @@ class SpectrumList(list, NDIOMixin):
     The primary purpose of this class is to allow loaders to return a list of
     spectra that have different shapes.  For spectra that have the same shape
     but different spectral axes, see `~specutils.SpectrumCollection`.  For
-    a spectrum or spectra that all share the same spectral axis, see
-    `~specutils.Spectrum1D`.
+    a spectrum or spectra that all share the same spectral axis, use
+    `~specutils.Spectrum1D`.  For more on this topic, see
+    :ref:`specutils-representation-overview`.
     """


### PR DESCRIPTION
This was prompted by a comment in Slack from @weaverba137 about the docstring of `SpectrumList` having a typo (a misssing "not") that led to it being very misleading about how it differes from `SpectrumCollection`.  This PR fixes that but also adds some words to the docstrings linking the three classes together in words as well as linking them each to the relevant section of the narrative docs.