### PR TITLE
Fix `from_center` descending spectral axis handling

### DIFF
--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -48,6 +48,9 @@ class SpectralRegion:
         if width.value <= 0:
             raise ValueError('SpectralRegion width must be positive.')
 
+        if center.unit.physical_type == 'frequency':
+            return cls(center + width, center - width)
+
         return cls(center - width, center + width)
 
     def __init__(self, *args):

--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -48,7 +48,7 @@ class SpectralRegion:
         if width.value <= 0:
             raise ValueError('SpectralRegion width must be positive.')
 
-        if center.unit.physical_type == 'frequency':
+        if center.unit.physical_type != 'length':
             return cls(center + width, center - width)
 
         return cls(center - width, center + width)

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -47,6 +47,13 @@ def test_from_center():
     with pytest.raises(ValueError) as exc:
         sr = SpectralRegion.from_center(center=6563*u.AA, width=0*u.AA)
 
+    # Test with frequency spectral axis
+    sr = SpectralRegion.from_center(center=1*u.GHz, width=0.1*u.GHz)
+
+    with pytest.raises(ValueError) as e:
+        sr = SpectralRegion.from_center(center=1*u.GHz, width=-0.1*u.GHz)
+
+
 def test_adding_spectral_regions():
 
     # Combine two Spectral regions into one:


### PR DESCRIPTION
This PR partially address #615. The `from_center` method of the `SpectralRegion` object did not handle non-descending cases (e.g. GHz).