### PR TITLE
Fix doppler conversion issue

### DIFF
--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -769,7 +769,8 @@ class SpectralCoord(u.Quantity):
             New spectral coordinate object with data converted to the new unit.
         """
         if doppler_rest is not None:
-            self.doppler_rest = doppler_rest
+            self._doppler_conversion = self._doppler_conversion._replace(
+                rest=doppler_rest)
 
         if doppler_convention is not None:
             if doppler_convention not in DOPPLER_CONVENTIONS:
@@ -777,7 +778,8 @@ class SpectralCoord(u.Quantity):
                     "Unrecognized doppler convention: {}.".format(
                         doppler_convention))
 
-            self.doppler_convention = doppler_convention
+            self._doppler_conversion = self._doppler_conversion._replace(
+                convention=doppler_convention)
 
         equivs = u.spectral()
 

--- a/specutils/tests/test_spectral_coord.py
+++ b/specutils/tests/test_spectral_coord.py
@@ -475,3 +475,27 @@ def test_asteroid_velocity_frame_shifts():
     # ensure the "target-rest" use gives the same answer
     # target_sc1_alt = spec_coord1.in_observer_velocity_frame('target-rest')
     # assert_quantity_allclose(target_sc1, target_sc1_alt)
+
+
+def test_change_doppler_conversions():
+    coord = SpectralCoord(22791414.18 * u.m / u.s,
+                          doppler_convention='relativistic',
+                          doppler_rest=110201353000 * u.Hz)
+
+    # Changing the convention explicitly should fail
+    with pytest.raises(ValueError):
+        coord.doppler_convention = 'radio'
+
+    # Changing convention within the `to` method should succeed
+    coord.to(u.km / u.s, doppler_convention='radio')
+
+    assert coord.doppler_convention == 'radio'
+
+    # Changing the rest value explicitly should fail
+    with pytest.raises(ValueError):
+        coord.doppler_rest = 110201353001 * u.Hz
+
+    # Changing rest value within the `to` method should succeed
+    coord.to(u.km / u.s, doppler_rest=110201353001 * u.Hz)
+
+    assert quantity_allclose(coord.doppler_rest, 110201353001 * u.Hz)


### PR DESCRIPTION
This PR addresses the case where the doppler conversions on a `SpectralCoord` were not able to be updated. Explicitly setting the values on the instance (`spec_coord.doppler_rest = 10 * u.AA`) should fail, but doing so within the the unit transformation machinery should update the stored value.