### PR TITLE
Handle malformed distances in SkyCoords

### DIFF
--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -219,6 +219,10 @@ class SpectralCoord(u.Quantity):
         if hasattr(coord, 'distance') and \
                 coord.distance.unit.physical_type == 'dimensionless':
             coord = SkyCoord(coord, distance=1e6 * u.kpc)
+            warnings.warn(
+                "Distance on coordinate object is dimensionless, an "
+                "abritrary distance value of 1e6 kpc will be set instead.",
+                AstropyUserWarning)
 
         # If the observer frame does not contain information about the
         # velocity of the system, assume that the velocity is zero in the

--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -216,6 +216,7 @@ class SpectralCoord(u.Quantity):
 
         # If the distance is not well-defined, ensure that it works properly
         # for generating differentials
+        # TODO: change this to not set the distance and yield a warning once there's a good way to address this in astropy.coordinates
         if hasattr(coord, 'distance') and \
                 coord.distance.unit.physical_type == 'dimensionless':
             coord = SkyCoord(coord, distance=1e6 * u.kpc)

--- a/specutils/spectra/spectral_coordinate.py
+++ b/specutils/spectra/spectral_coordinate.py
@@ -214,6 +214,12 @@ class SpectralCoord(u.Quantity):
                                  "`~astropy.coordinates.BaseCoordinateFrame` or "
                                  "`~astropy.coordinates.SkyCoord`.".format(coord))
 
+        # If the distance is not well-defined, ensure that it works properly
+        # for generating differentials
+        if hasattr(coord, 'distance') and \
+                coord.distance.unit.physical_type == 'dimensionless':
+            coord = SkyCoord(coord, distance=1e6 * u.kpc)
+
         # If the observer frame does not contain information about the
         # velocity of the system, assume that the velocity is zero in the
         # system.

--- a/specutils/tests/test_spectral_coord.py
+++ b/specutils/tests/test_spectral_coord.py
@@ -500,3 +500,11 @@ def test_change_doppler_conversions():
     coord.to(u.km / u.s, doppler_rest=110201353001 * u.Hz)
 
     assert quantity_allclose(coord.doppler_rest, 110201353001 * u.Hz)
+
+
+def test_regression_658():
+    # see https://github.com/astropy/specutils/issues/658 for issue context
+    obs = SkyCoord(0 * u.m, 0 * u.m, 0 * u.m, representation_type='cartesian')
+    coord = SpectralCoord([1, 2, 3] * u.micron, observer=obs)
+    # coord.target = SkyCoord.from_name('m31')  # <- original issue, but below is the same but requires no remote data access
+    coord.target = SkyCoord(ra=10.68470833*u.deg, dec=41.26875*u.deg)

--- a/specutils/tests/test_spectral_coord.py
+++ b/specutils/tests/test_spectral_coord.py
@@ -502,7 +502,7 @@ def test_change_doppler_conversions():
     assert quantity_allclose(coord.doppler_rest, 110201353001 * u.Hz)
 
 
-def test_regression_658():
+def test_spectral_coord_from_sky_coord_without_distance():
     # see https://github.com/astropy/specutils/issues/658 for issue context
     obs = SkyCoord(0 * u.m, 0 * u.m, 0 * u.m, representation_type='cartesian')
     coord = SpectralCoord([1, 2, 3] * u.micron, observer=obs)


### PR DESCRIPTION
Resolves #658. The issue is that `SkyCoord.from_name` does not also define a useable distance and instead defaults to `1 dimensionless`. In this case, just assign some really large value and continue the parsing.