### PR TITLE
WIP: Display loaders in RTD using sphinx extensions

### DIFF
--- a/docs/_ext/listformats.py
+++ b/docs/_ext/listformats.py
@@ -1,0 +1,30 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from specutils import Spectrum1D
+
+class ListFormats(Directive):
+
+    def run(self):
+        with open('read_formats.txt', 'w') as f:
+            Spectrum1D.read.list_formats(out=f)
+
+        file = open('read_formats.txt', 'r')
+
+        formats = file.readlines()
+        formats_as_str = ""
+
+        for line in formats:
+            formats_as_str += line
+
+        literal_block_node = nodes.literal_block(text=formats_as_str)
+        file.close()
+        return [literal_block_node]
+
+def setup(app):
+    app.add_directive('listformats', ListFormats)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/_ext/read_formats.txt
+++ b/docs/_ext/read_formats.txt
@@ -1,0 +1,20 @@
+      Format      Read Write Auto-identify
+----------------- ---- ----- -------------
+    APOGEE apStar  Yes    No           Yes
+   APOGEE apVisit  Yes    No           Yes
+APOGEE aspcapStar  Yes    No           Yes
+            ASCII  Yes    No           Yes
+             ECSV  Yes    No           Yes
+          HST/COS  Yes    No           Yes
+         HST/STIS  Yes    No           Yes
+             IPAC  Yes    No           Yes
+         JWST s2d  Yes    No           Yes
+         JWST s3d  Yes    No           Yes
+         JWST x1d  Yes    No           Yes
+      MUSCLES SED  Yes    No           Yes
+ SDSS-I/II spSpec  Yes    No           Yes
+ SDSS-III/IV spec  Yes    No           Yes
+ Subaru-pfsObject  Yes    No           Yes
+             iraf  Yes    No           Yes
+     tabular-fits  Yes   Yes           Yes
+       wcs1d-fits  Yes    No           Yes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,6 +172,11 @@ man_pages = [('index', project.lower(), project + u' Documentation',
               [author], 1)]
 
 
+sys.path.append(os.path.abspath("./_ext"))
+
+extensions = ['listformats']
+
+
 # -- Options for the edit_on_github extension ---------------------------------
 
 if eval(setup_cfg.get('edit_on_github')):

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -183,7 +183,7 @@ A list of loaders is as follows:
 
 .. listformats::
 
-The list was generated using `specutils.SpectrumList.read <astropy.nddata.NDIOMixin.read>`.
+The list was generated using `~specutils.SpectrumList.read <astropy.nddata.NDIOMixin.read>`.
 
 
 Reference/API

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -177,6 +177,13 @@ The custom writer can be used by passing the name of the custom writer to the
     spec.write("my_output.fits", format="fits-writer")
 
 
+List of loaders
+^^^^^^^^^^^^^^^
+A list of loaders is as follows:
+
+.. listformats::
+
+
 Reference/API
 -------------
 .. automodapi:: specutils.io.registers

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -183,10 +183,10 @@ A list of loaders is as follows:
 
 .. listformats::
 
-The list was generated using `~specutils.SpectrumList.read <astropy.nddata.NDIOMixin.read>`.
-
+The list was generated using `specutils.SpectrumList.read <astropy.nddata.NDIOMixin.read>`.
 
 Reference/API
 -------------
+
 .. automodapi:: specutils.io.registers
     :no-heading:

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -184,6 +184,7 @@ A list of loaders is as follows:
 .. listformats::
 
 
+
 Reference/API
 -------------
 .. automodapi:: specutils.io.registers

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -182,7 +182,8 @@ List of loaders
 A list of loaders is as follows:
 
 .. listformats::
-    :no-heading:
+
+The list was generated using `specutils.SpectrumList.read <astropy.nddata.NDIOMixin.read>`.
 
 
 Reference/API

--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -182,7 +182,7 @@ List of loaders
 A list of loaders is as follows:
 
 .. listformats::
-
+    :no-heading:
 
 
 Reference/API


### PR DESCRIPTION
Using [Sphinx extensions](https://www.sphinx-doc.org/en/master/development/tutorials/helloworld.html), I am displaying the loader formats that are printed out with `Spectrum1D.read.list_formats(out=f)` in read the docs.

Resolves #394