### PR TITLE
SDSS loader updates and extensions

### DIFF
--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -5,12 +5,13 @@ Loader for SDSS individual spectrum files: spec_ files.
 """
 import os
 import re
+import _io
 
 from astropy.io import fits
 from astropy.table import Table
 from astropy.wcs import WCS
 from astropy.units import Unit, def_unit
-from astropy.nddata import StdDevUncertainty
+from astropy.nddata import StdDevUncertainty, InverseVariance
 
 import numpy as np
 
@@ -26,29 +27,50 @@ _spec_pattern = re.compile(r'spec-\d{4,5}-\d{5}-\d{4}\.fits')
 
 def spec_identify(origin, *args, **kwargs):
     """
-    Check whether given file is FITS and has SDSS-III/IV spec type
+    Check whether given input is FITS and has SDSS-III/IV spec type
     BINTABLE in first extension. This is used for Astropy I/O Registry.
     """
-    with fits.open(args[0]) as hdulist:
-        # Test if fits has extension of type BinTable and check for
-        # spec-specific keys
-        return (hdulist[0].header['TELESCOP'] == 'SDSS 2.5-M' and
-                len(hdulist) > 1 and
-                isinstance(hdulist[1], fits.BinTableHDU) and
-                hdulist[1].header['TTYPE3'] == 'ivar')
+    if isinstance(args[2], fits.hdu.hdulist.HDUList):
+        hdulist = args[2]
+    elif isinstance(args[2], _io.BufferedReader):
+        hdulist = fits.open(args[2])
+    else:
+        hdulist = fits.open(args[0], **kwargs)
+
+    # Test if fits has extension of type BinTable and check for spec-specific keys
+    is_sdss = (hdulist[0].header['TELESCOP'] == 'SDSS 2.5-M' and
+               hdulist[0].header.get('FIBERID', 0) > 0 and
+               len(hdulist) > 1 and
+               isinstance(hdulist[1], fits.BinTableHDU) and
+               hdulist[1].header['TTYPE3'] == 'ivar')
+
+    if not isinstance(args[2], (fits.hdu.hdulist.HDUList, _io.BufferedReader)):
+        hdulist.close()
+    return is_sdss
 
 
 def spSpec_identify(origin, *args, **kwargs):
     """
-    Check whether given file is FITS with SDSS-I/II spSpec type data.
+    Check whether given input is FITS with SDSS-I/II spSpec tyamepe data.
     This is used for Astropy I/O Registry.
     """
-    with fits.open(args[0]) as hdulist:
-        # Test telescope keyword and check if primary HDU contains data
-        # consistent with spSpec format
-        return (hdulist[0].header['TELESCOP'] == 'SDSS 2.5-M' and
-                isinstance(hdulist[0].data, np.ndarray) and
-                hdulist[0].data.shape[0] == 5)
+    if isinstance(args[2], fits.hdu.hdulist.HDUList):
+        hdulist = args[2]
+    elif isinstance(args[2], _io.BufferedReader):
+        hdulist = fits.open(args[2])
+    else:
+        hdulist = fits.open(args[0])
+
+    # Test telescope keyword and check if primary HDU contains data
+    # consistent with spSpec format
+    is_sdss = (hdulist[0].header['TELESCOP'] == 'SDSS 2.5-M' and
+               hdulist[0].header.get('FIBERID', 0) > 0 and
+               isinstance(hdulist[0].data, np.ndarray) and
+               hdulist[0].data.shape[0] == 5)
+
+    if not isinstance(args[2], (fits.hdu.hdulist.HDUList, _io.BufferedReader)):
+        hdulist.close()
+    return is_sdss
 
 
 @data_loader(label="SDSS-III/IV spec", identifier=spec_identify, extensions=['fits'])
@@ -65,7 +87,8 @@ def spec_loader(file_obj, **kwargs):
     Returns
     -------
     data: Spectrum1D
-        The spectrum that is represented by the data in this table.
+        The spectrum that is represented by the 'loglam' (wavelength) and 'flux'
+        data columns in the BINTABLE extension of the FITS `file_obj`.
     """
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
         hdulist = file_obj
@@ -76,13 +99,15 @@ def spec_loader(file_obj, **kwargs):
     name = header.get('NAME')
     meta = {'header': header}
 
-    # spectrum is in HDU 1
-    data = hdulist[1].data['flux']
-    unit = Unit('1e-17 erg / (Angstrom cm2 s)')
+    bunit = header.get('BUNIT', '1e-17 erg / (Angstrom cm2 s)')
+    if 'Ang' in bunit and 'strom' not in bunit:
+        bunit = bunit.replace('Ang', 'Angstrom')
+    flux_unit = Unit(bunit)
 
-    # Because there is no object that explicitly supports inverse variance.
-    stdev = np.sqrt(1.0/hdulist[1].data['ivar'])
-    uncertainty = StdDevUncertainty(stdev * unit)
+    # spectrum is in HDU 1
+    flux = hdulist[1].data['flux'] * flux_unit
+
+    uncertainty = InverseVariance(hdulist[1].data['ivar'] / flux_unit**2)
 
     dispersion = 10**hdulist[1].data['loglam']
     dispersion_unit = Unit('Angstrom')
@@ -92,14 +117,11 @@ def spec_loader(file_obj, **kwargs):
     if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
         hdulist.close()
 
-    return Spectrum1D(flux=data * unit,
-                      spectral_axis=dispersion * dispersion_unit,
-                      uncertainty=uncertainty,
-                      meta=meta,
-                      mask=mask)
+    return Spectrum1D(flux=flux, spectral_axis=dispersion * dispersion_unit,
+                      uncertainty=uncertainty, meta=meta, mask=mask)
 
 
-@data_loader(label="SDSS-I/II spSpec", identifier=spSpec_identify, extensions=['fits'])
+@data_loader(label="SDSS-I/II spSpec", identifier=spSpec_identify, extensions=['fit', 'fits'])
 def spSpec_loader(file_obj, **kwargs):
     """
     Loader for SDSS-I/II spSpec files.
@@ -113,7 +135,8 @@ def spSpec_loader(file_obj, **kwargs):
     Returns
     -------
     data: Spectrum1D
-        The spectrum that is represented by the data in this table.
+        The spectrum that is represented by the wavelength solution from the
+        header WCS and data array of the primary HDU.
     """
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
         hdulist = file_obj
@@ -121,21 +144,25 @@ def spSpec_loader(file_obj, **kwargs):
         hdulist = fits.open(file_obj, **kwargs)
 
     header = hdulist[0].header
-    name = header.get('NAME')
+    # name = header.get('NAME')
     meta = {'header': header}
-    wcs = WCS(hdulist[0].header)
+    wcs = WCS(header).dropaxis(1)
 
-    data = hdulist[0].data[0, :]
-    unit = Unit('1e-17 erg / (Angstrom cm2 s)')
+    bunit = header.get('BUNIT', '1e-17 erg / (Angstrom cm2 s)')
+    # fix mutilated flux unit
+    bunit = bunit.replace('/cm/s/Ang', '/ (Angstrom cm2 s)')
+    if 'Ang' in bunit and 'strom' not in bunit:
+        bunit = bunit.replace('Ang', 'Angstrom')
+    flux_unit = Unit(bunit)
+    flux = hdulist[0].data[0, :] * flux_unit
 
-    uncertainty = StdDevUncertainty(hdulist[0].data[2, :] * unit)
+    uncertainty = StdDevUncertainty(hdulist[0].data[2, :] * flux_unit)
 
-    # dispersion from the WCS but convert out of logspace
-    # dispersion = 10**wcs.all_pix2world(np.arange(data.shape[0]), 0)[0]
-    dispersion = 10**wcs.all_pix2world(np.vstack((np.arange(data.shape[0]),
-                                                  np.zeros((data.shape[0],)))).T,
-                                       0)[:, 0]
-    # dispersion = 10**hdulist[1].data['loglam']
+    # dispersion along NAXIS1 from the WCS
+    dispersion = wcs.pixel_to_world(np.arange(flux.shape[0]))
+    # convert out of logspace (default for spSpec/spPlate spectra)?
+    if header.get('DC-Flag', 1) == 1:
+        dispersion = 10**dispersion
     dispersion_unit = Unit('Angstrom')
 
     mask = hdulist[0].data[3, :] != 0
@@ -143,8 +170,5 @@ def spSpec_loader(file_obj, **kwargs):
     if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
         hdulist.close()
 
-    return Spectrum1D(flux=data * unit,
-                      spectral_axis=dispersion * dispersion_unit,
-                      uncertainty=uncertainty,
-                      meta=meta,
-                      mask=mask)
+    return Spectrum1D(flux=flux, spectral_axis=dispersion * dispersion_unit,
+                      uncertainty=uncertainty, meta=meta, mask=mask)

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -140,10 +140,10 @@ def test_sdss_spec():
         assert spec.flux.size > 0
 
     with urllib.request.urlopen('https://dr14.sdss.org/optical/spectrum/view/data/format%3Dfits/spec%3Dlite?mjd=55359&fiberid=596&plateid=4055') as response:
-        with tempfile.NamedTemporaryFile(prefix=sp_pattern) as tmp_file:
+        with tempfile.NamedTemporaryFile() as tmp_file:
             shutil.copyfileobj(response, tmp_file)
 
-            # Read from local disk via filename
+            # Read from local disk via file signature
             spec = Spectrum1D.read(tmp_file.name)
 
             assert isinstance(spec, Spectrum1D)
@@ -151,7 +151,13 @@ def test_sdss_spec():
 
             # Read from HDUList object
             hdulist = fits.open(tmp_file.name)
-            spec = Spectrum1D.read(hdulist, format="SDSS-III/IV spec")
+            spec = Spectrum1D.read(hdulist)
+            assert isinstance(spec, Spectrum1D)
+            assert spec.flux.size > 0
+
+            # Read from file handle
+            fileio = open(tmp_file.name, mode='rb')
+            spec = Spectrum1D.read(fileio)
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0
 
@@ -166,23 +172,28 @@ def test_sdss_spspec():
         assert spec.flux.size > 0
 
     with urllib.request.urlopen('http://das.sdss.org/spectro/1d_26/0273/1d/spSpec-51957-0273-016.fit') as response:
-        with tempfile.NamedTemporaryFile(prefix=sp_pattern) as tmp_file:
+        with tempfile.NamedTemporaryFile() as tmp_file:
             shutil.copyfileobj(response, tmp_file)
 
-            # Read from local disk via filename
+            # Read from local disk via file signature
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', FITSFixedWarning)
-                spec = Spectrum1D.read(tmp_file.name, format="SDSS-I/II spSpec")
+                spec = Spectrum1D.read(tmp_file.name)
 
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0
 
             # Read from HDUList object
             hdulist = fits.open(tmp_file.name)
-            spec = Spectrum1D.read(hdulist, format="SDSS-I/II spSpec")
+            spec = Spectrum1D.read(hdulist)
             assert isinstance(spec, Spectrum1D)
             assert spec.flux.size > 0
 
+            # Read from file handle
+            fileio = open(tmp_file.name, mode='rb')
+            spec = Spectrum1D.read(fileio)
+            assert isinstance(spec, Spectrum1D)
+            assert spec.flux.size > 0
 
 @pytest.mark.remote_data
 def test_sdss_spec_stream():


### PR DESCRIPTION
1st commit has some clean-up of the "spSpec" and "spec" loaders, trying to read the flux units from file where possible, and switching to use just the 1st axis of the WCS for creating `spectral_axis`. The `_identify` functions are extended to allow automatic identification in HDULists and open file handles (the latter need to have been opened in `mode='rb'`, since FITS contents cannot be read from `_io.TextIOWrapper` objects).

2nd commit is adding @weaverba137's "spPlate" loader for `prospect` from the [PyAstro20 hackday](https://github.com/desihub/prospect/commit/ce435b7) to the SDSS loaders.

1. Since `InverseVariance` is now supported, `spec_loader` is now storing its `uncertainty` in the native form (same as `spPlate_loader` does). This avoids division-by-zero issues in creating the `Spectrum1D`, but perhaps needs to be checked if it breaks existing applications of the `SDSS-III/IV` type spectra.

2. The test for reading `spPlate` with the fluxes for all 640 fibres is reading something between 70 and 160 MB in `remote_data`, probably depending on OS caching (actual file size is 60 MB). I was hoping limiting the read to the first 20 or 30 spectra might reduce this a bit at least for the direct read, but since the loader is accessing the first 6 HDUs, reading the entire file is probably unavoidable. We might remove either the direct read or the `tempfile` read, if this is deemed too much network traffic - or is there an option for setting something like `HUGE_DATA` access in the tests?