### PR TITLE
Restrict `u.spectral` equivalency to contexts where it is required

### DIFF
--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -155,9 +155,10 @@ class SpectralRegion:
     def _valid(self):
 
         # Lower bound < Upper bound for all sub regions in length physical type
-        sub_regions = [(x[0].to('m'), x[1].to('m'))
-                       if x[0].unit.is_equivalent(u.m) else x
-                       for x in self._subregions]
+        with u.set_enabled_equivalencies(u.spectral()):
+            sub_regions = [(x[0].to('m'), x[1].to('m'))
+                           if x[0].unit.is_equivalent(u.m) else x
+                           for x in self._subregions]
 
         if any(x[0] >= x[1] for x in sub_regions):
             raise ValueError('Lower bound must be strictly less than the upper bound')

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -15,8 +15,6 @@ __all__ = ['Spectrum1D']
 
 __doctest_skip__ = ['Spectrum1D.spectral_resolution']
 
-u.set_enabled_equivalencies(u.spectral())
-
 
 class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     """
@@ -106,15 +104,16 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             else:
                 rest_value = 0 * u.AA
         else:
-            if not isinstance(rest_value, u.Quantity):
-                logging.info("No unit information provided with rest value. "
-                             "Assuming units of spectral axis ('%s').",
-                             spectral_axis.unit)
-                rest_value = u.Quantity(rest_value, spectral_axis.unit)
-            elif not rest_value.unit.is_equivalent(u.AA) \
-                    and not rest_value.unit.is_equivalent(u.Hz):
-                raise u.UnitsError("Rest value must be "
-                                   "energy/wavelength/frequency equivalent.")
+            with u.set_enabled_equivalencies(u.spectral()):
+                if not isinstance(rest_value, u.Quantity):
+                    logging.info("No unit information provided with rest value."
+                                 "Assuming units of spectral axis ('%s').",
+                                 spectral_axis.unit)
+                    rest_value = u.Quantity(rest_value, spectral_axis.unit)
+                elif not (rest_value.unit.is_equivalent(u.AA)
+                          or rest_value.unit.is_equivalent(u.Hz)):
+                    raise u.UnitsError("Rest value must be "
+                                       "energy/wavelength/frequency equivalent.")
 
         # If flux and spectral axis are both specified, check that their lengths
         # match or are off by one (implying the spectral axis stores bin edges)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -104,16 +104,14 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             else:
                 rest_value = 0 * u.AA
         else:
-            with u.set_enabled_equivalencies(u.spectral()):
-                if not isinstance(rest_value, u.Quantity):
-                    logging.info("No unit information provided with rest value."
-                                 "Assuming units of spectral axis ('%s').",
-                                 spectral_axis.unit)
-                    rest_value = u.Quantity(rest_value, spectral_axis.unit)
-                elif not (rest_value.unit.is_equivalent(u.AA)
-                          or rest_value.unit.is_equivalent(u.Hz)):
-                    raise u.UnitsError("Rest value must be "
-                                       "energy/wavelength/frequency equivalent.")
+            if not isinstance(rest_value, u.Quantity):
+                logging.info("No unit information provided with rest value. "
+                             "Assuming units of spectral axis ('%s').",
+                             spectral_axis.unit)
+                rest_value = u.Quantity(rest_value, spectral_axis.unit)
+            elif not rest_value.unit.is_equivalent(u.AA, equivalencies=u.spectral()):
+                raise u.UnitsError("Rest value must be "
+                                   "energy/wavelength/frequency equivalent.")
 
         # If flux and spectral axis are both specified, check that their lengths
         # match or are off by one (implying the spectral axis stores bin edges)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -51,7 +51,8 @@ def test_equivalent_width():
 
     result = equivalent_width(spectrum)
 
-    assert result.unit.is_equivalent(spectrum.wcs.unit)
+    with u.set_enabled_equivalencies(u.spectral()):
+        assert result.unit.is_equivalent(spectrum.wcs.unit)
 
     # Since this is an emission line, we expect the equivalent width value to
     # be negative
@@ -69,13 +70,14 @@ def test_equivalent_width_regions():
     noise = np.random.normal(0., 0.001, frequencies.shape) * u.Jy
     flux = g(frequencies) + noise + 1*u.Jy
 
-    spec = Spectrum1D(spectral_axis=frequencies, flux=flux)
-    cont_norm_spec = spec / np.median(spec.flux)
-    result = equivalent_width(cont_norm_spec, regions=SpectralRegion(97*u.GHz, 3*u.GHz))
+    with u.set_enabled_equivalencies(u.spectral()):
+        spec = Spectrum1D(spectral_axis=frequencies, flux=flux)
+        cont_norm_spec = spec / np.median(spec.flux)
+        result = equivalent_width(cont_norm_spec, regions=SpectralRegion(97*u.GHz, 3*u.GHz))
 
-    expected = -(np.sqrt(2*np.pi) * u.GHz)
+        expected = -(np.sqrt(2*np.pi) * u.GHz)
 
-    assert quantity_allclose(result, expected, atol=0.02*u.GHz)
+        assert quantity_allclose(result, expected, atol=0.02*u.GHz)
 
 
 @pytest.mark.parametrize('continuum', [1*u.Jy, 2*u.Jy, 5*u.Jy])
@@ -92,7 +94,8 @@ def test_equivalent_width_continuum(continuum):
 
     result = equivalent_width(spectrum, continuum=continuum)
 
-    assert result.unit.is_equivalent(spectrum.wcs.unit)
+    with u.set_enabled_equivalencies(u.spectral()):
+        assert result.unit.is_equivalent(spectrum.wcs.unit)
 
     # Since this is an emission line, we expect the equivalent width value to
     # be negative
@@ -116,11 +119,12 @@ def test_equivalent_width_absorption():
 
     result = equivalent_width(spectrum)
 
-    assert result.unit.is_equivalent(spectrum.wcs.unit)
+    with u.set_enabled_equivalencies(u.spectral()):
+        assert result.unit.is_equivalent(spectrum.wcs.unit)
 
-    expected = amplitude*np.sqrt(2*np.pi) * u.GHz
+        expected = amplitude*np.sqrt(2*np.pi) * u.GHz
 
-    assert quantity_allclose(result, expected, atol=0.01*u.GHz)
+        assert quantity_allclose(result, expected, atol=0.01*u.GHz)
 
 
 def test_snr(simulated_spectra):
@@ -378,29 +382,30 @@ def test_gaussian_sigma_width_regions():
     compound = g1 + g2 + g3
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=compound(frequencies))
 
-    region1 = SpectralRegion(15*u.GHz, 5*u.GHz)
-    result1 = gaussian_sigma_width(spectrum, regions=region1)
+    with u.set_enabled_equivalencies(u.spectral()):
+        region1 = SpectralRegion(15*u.GHz, 5*u.GHz)
+        result1 = gaussian_sigma_width(spectrum, regions=region1)
 
-    exp1 = g1.stddev
-    assert quantity_allclose(result1, exp1, atol=0.25*exp1)
+        exp1 = g1.stddev
+        assert quantity_allclose(result1, exp1, atol=0.25*exp1)
 
-    region2 = SpectralRegion(3*u.GHz, 1*u.GHz)
-    result2 = gaussian_sigma_width(spectrum, regions=region2)
+        region2 = SpectralRegion(3*u.GHz, 1*u.GHz)
+        result2 = gaussian_sigma_width(spectrum, regions=region2)
 
-    exp2 = g2.stddev
-    assert quantity_allclose(result2, exp2, atol=0.25*exp2)
+        exp2 = g2.stddev
+        assert quantity_allclose(result2, exp2, atol=0.25*exp2)
 
-    region3 = SpectralRegion(100*u.GHz, 40*u.GHz)
-    result3 = gaussian_sigma_width(spectrum, regions=region3)
+        region3 = SpectralRegion(100*u.GHz, 40*u.GHz)
+        result3 = gaussian_sigma_width(spectrum, regions=region3)
 
-    exp3 = g3.stddev
-    assert quantity_allclose(result3, exp3, atol=0.25*exp3)
+        exp3 = g3.stddev
+        assert quantity_allclose(result3, exp3, atol=0.25*exp3)
 
-    # Test using a list of regions
-    result_list = gaussian_sigma_width(spectrum, regions=[region1, region2, region3])
-    for model, result in zip((g1, g2, g3), result_list):
-        exp = model.stddev
-        assert quantity_allclose(result, exp, atol=0.25*exp)
+        # Test using a list of regions
+        result_list = gaussian_sigma_width(spectrum, regions=[region1, region2, region3])
+        for model, result in zip((g1, g2, g3), result_list):
+            exp = model.stddev
+            assert quantity_allclose(result, exp, atol=0.25*exp)
 
 
 def test_gaussian_sigma_width_multi_spectrum():

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -70,14 +70,13 @@ def test_equivalent_width_regions():
     noise = np.random.normal(0., 0.001, frequencies.shape) * u.Jy
     flux = g(frequencies) + noise + 1*u.Jy
 
-    with u.set_enabled_equivalencies(u.spectral()):
-        spec = Spectrum1D(spectral_axis=frequencies, flux=flux)
-        cont_norm_spec = spec / np.median(spec.flux)
-        result = equivalent_width(cont_norm_spec, regions=SpectralRegion(97*u.GHz, 3*u.GHz))
+    spec = Spectrum1D(spectral_axis=frequencies, flux=flux)
+    cont_norm_spec = spec / np.median(spec.flux)
+    result = equivalent_width(cont_norm_spec, regions=SpectralRegion(97*u.GHz, 3*u.GHz))
 
-        expected = -(np.sqrt(2*np.pi) * u.GHz)
+    expected = -(np.sqrt(2*np.pi) * u.GHz)
 
-        assert quantity_allclose(result, expected, atol=0.02*u.GHz)
+    assert quantity_allclose(result, expected, atol=0.02*u.GHz)
 
 
 @pytest.mark.parametrize('continuum', [1*u.Jy, 2*u.Jy, 5*u.Jy])
@@ -122,9 +121,9 @@ def test_equivalent_width_absorption():
     with u.set_enabled_equivalencies(u.spectral()):
         assert result.unit.is_equivalent(spectrum.wcs.unit)
 
-        expected = amplitude*np.sqrt(2*np.pi) * u.GHz
+    expected = amplitude*np.sqrt(2*np.pi) * u.GHz
 
-        assert quantity_allclose(result, expected, atol=0.01*u.GHz)
+    assert quantity_allclose(result, expected, atol=0.01*u.GHz)
 
 
 def test_snr(simulated_spectra):
@@ -382,30 +381,29 @@ def test_gaussian_sigma_width_regions():
     compound = g1 + g2 + g3
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=compound(frequencies))
 
-    with u.set_enabled_equivalencies(u.spectral()):
-        region1 = SpectralRegion(15*u.GHz, 5*u.GHz)
-        result1 = gaussian_sigma_width(spectrum, regions=region1)
+    region1 = SpectralRegion(15*u.GHz, 5*u.GHz)
+    result1 = gaussian_sigma_width(spectrum, regions=region1)
 
-        exp1 = g1.stddev
-        assert quantity_allclose(result1, exp1, atol=0.25*exp1)
+    exp1 = g1.stddev
+    assert quantity_allclose(result1, exp1, atol=0.25*exp1)
 
-        region2 = SpectralRegion(3*u.GHz, 1*u.GHz)
-        result2 = gaussian_sigma_width(spectrum, regions=region2)
+    region2 = SpectralRegion(3*u.GHz, 1*u.GHz)
+    result2 = gaussian_sigma_width(spectrum, regions=region2)
 
-        exp2 = g2.stddev
-        assert quantity_allclose(result2, exp2, atol=0.25*exp2)
+    exp2 = g2.stddev
+    assert quantity_allclose(result2, exp2, atol=0.25*exp2)
 
-        region3 = SpectralRegion(100*u.GHz, 40*u.GHz)
-        result3 = gaussian_sigma_width(spectrum, regions=region3)
+    region3 = SpectralRegion(100*u.GHz, 40*u.GHz)
+    result3 = gaussian_sigma_width(spectrum, regions=region3)
 
-        exp3 = g3.stddev
-        assert quantity_allclose(result3, exp3, atol=0.25*exp3)
+    exp3 = g3.stddev
+    assert quantity_allclose(result3, exp3, atol=0.25*exp3)
 
-        # Test using a list of regions
-        result_list = gaussian_sigma_width(spectrum, regions=[region1, region2, region3])
-        for model, result in zip((g1, g2, g3), result_list):
-            exp = model.stddev
-            assert quantity_allclose(result, exp, atol=0.25*exp)
+    # Test using a list of regions
+    result_list = gaussian_sigma_width(spectrum, regions=[region1, region2, region3])
+    for model, result in zip((g1, g2, g3), result_list):
+        exp = model.stddev
+        assert quantity_allclose(result, exp, atol=0.25*exp)
 
 
 def test_gaussian_sigma_width_multi_spectrum():

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -51,8 +51,7 @@ def test_equivalent_width():
 
     result = equivalent_width(spectrum)
 
-    with u.set_enabled_equivalencies(u.spectral()):
-        assert result.unit.is_equivalent(spectrum.wcs.unit)
+    assert result.unit.is_equivalent(spectrum.wcs.unit, equivalencies=u.spectral())
 
     # Since this is an emission line, we expect the equivalent width value to
     # be negative
@@ -93,8 +92,7 @@ def test_equivalent_width_continuum(continuum):
 
     result = equivalent_width(spectrum, continuum=continuum)
 
-    with u.set_enabled_equivalencies(u.spectral()):
-        assert result.unit.is_equivalent(spectrum.wcs.unit)
+    assert result.unit.is_equivalent(spectrum.wcs.unit, equivalencies=u.spectral())
 
     # Since this is an emission line, we expect the equivalent width value to
     # be negative
@@ -118,8 +116,7 @@ def test_equivalent_width_absorption():
 
     result = equivalent_width(spectrum)
 
-    with u.set_enabled_equivalencies(u.spectral()):
-        assert result.unit.is_equivalent(spectrum.wcs.unit)
+    assert result.unit.is_equivalent(spectrum.wcs.unit, equivalencies=u.spectral())
 
     expected = amplitude*np.sqrt(2*np.pi) * u.GHz
 

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -36,14 +36,15 @@ def test_region_simple(simulated_spectra):
 
 
 def test_region_ghz(simulated_spectra):
-    spectrum = Spectrum1D(flux=simulated_spectra.s1_um_mJy_e1.flux,
-                          spectral_axis=simulated_spectra.s1_um_mJy_e1.frequency)
+    with u.set_enabled_equivalencies(u.spectral()):
+        spectrum = Spectrum1D(flux=simulated_spectra.s1_um_mJy_e1.flux,
+                              spectral_axis=simulated_spectra.s1_um_mJy_e1.frequency)
 
-    region = SpectralRegion(499654.09666667*u.GHz, 374740.5725*u.GHz)
+        region = SpectralRegion(499654.09666667*u.GHz, 374740.5725*u.GHz)
 
-    sub_spectrum = extract_region(spectrum, region)
+        sub_spectrum = extract_region(spectrum, region)
 
-    sub_spectrum_flux_expected =  [
+        sub_spectrum_flux_expected =  [
              1605.71612173, 1651.41650744, 2057.65798618, 2066.73502361, 1955.75832537,
              1670.52711471, 1491.10034446, 1637.08084112, 1471.28982259, 1299.19484483,
              1423.11195734, 1226.74494917, 1572.31888312, 1311.50503403, 1474.05051673,
@@ -52,7 +53,7 @@ def test_region_ghz(simulated_spectra):
              1157.33825995, 1136.12679394,  999.92394692, 1038.61546167, 1011.60297294
              ]*u.mJy
 
-    assert quantity_allclose(sub_spectrum.flux, sub_spectrum_flux_expected)
+        assert quantity_allclose(sub_spectrum.flux, sub_spectrum_flux_expected)
 
 
 def test_region_simple_check_ends(simulated_spectra):

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -36,15 +36,14 @@ def test_region_simple(simulated_spectra):
 
 
 def test_region_ghz(simulated_spectra):
-    with u.set_enabled_equivalencies(u.spectral()):
-        spectrum = Spectrum1D(flux=simulated_spectra.s1_um_mJy_e1.flux,
-                              spectral_axis=simulated_spectra.s1_um_mJy_e1.frequency)
+    spectrum = Spectrum1D(flux=simulated_spectra.s1_um_mJy_e1.flux,
+                          spectral_axis=simulated_spectra.s1_um_mJy_e1.frequency)
 
-        region = SpectralRegion(499654.09666667*u.GHz, 374740.5725*u.GHz)
+    region = SpectralRegion(499654.09666667*u.GHz, 374740.5725*u.GHz)
 
-        sub_spectrum = extract_region(spectrum, region)
+    sub_spectrum = extract_region(spectrum, region)
 
-        sub_spectrum_flux_expected =  [
+    sub_spectrum_flux_expected =  [
              1605.71612173, 1651.41650744, 2057.65798618, 2066.73502361, 1955.75832537,
              1670.52711471, 1491.10034446, 1637.08084112, 1471.28982259, 1299.19484483,
              1423.11195734, 1226.74494917, 1572.31888312, 1311.50503403, 1474.05051673,
@@ -53,7 +52,7 @@ def test_region_ghz(simulated_spectra):
              1157.33825995, 1136.12679394,  999.92394692, 1038.61546167, 1011.60297294
              ]*u.mJy
 
-        assert quantity_allclose(sub_spectrum.flux, sub_spectrum_flux_expected)
+    assert quantity_allclose(sub_spectrum.flux, sub_spectrum_flux_expected)
 
 
 def test_region_simple_check_ends(simulated_spectra):

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -387,3 +387,12 @@ def test_str():
 """Spectrum1D (length=1)
 flux:             [ 1.0 Jy ],  mean=1.0 Jy
 spectral axis:    [ 0.0 nm ],  mean=0.0 nm"""
+
+
+def test_equivalencies():
+    """
+    Test that after import `u.spectral` equivalencies are not enabled in the global namespace.
+    """
+    assert u.micron.is_equivalent(u.cm**-1) is False
+    assert u.micron.is_equivalent(u.Hz) is False
+    assert u.Hz.is_equivalent(u.cm**-1) is False

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -135,6 +135,17 @@ def test_spectral_axis_conversions():
     new_spec = spec.with_spectral_unit(u.GHz)
 
 
+@pytest.mark.parametrize('unit', ['micron', 'GHz', 'cm**-1', 'eV'])
+def test_spectral_axis_equivalencies(unit):
+    """Test that `u.spectral` equivalencies are enabled for `spectral_axis`."""
+
+    spectral_axis=np.array([3400, 5000, 6660]) * u.AA
+    spec = Spectrum1D(flux=np.array([26.0, 30.0, 44.5]) * u.Jy, spectral_axis=spectral_axis)
+
+    new_axis = spectral_axis.to(unit, equivalencies=u.spectral())
+    assert u.allclose(spec.spectral_axis.to(unit), new_axis)
+
+
 def test_redshift():
     spec = Spectrum1D(flux=np.array([26.0, 30., 44.5]) * u.Jy,
                       spectral_axis=np.array([4000, 6000, 8000]) * u.AA,
@@ -395,4 +406,6 @@ def test_equivalencies():
     """
     assert u.micron.is_equivalent(u.cm**-1) is False
     assert u.micron.is_equivalent(u.Hz) is False
+    assert u.micron.is_equivalent(u.eV) is False
     assert u.Hz.is_equivalent(u.cm**-1) is False
+    assert u.Hz.is_equivalent(u.eV) is False


### PR DESCRIPTION
Fix for #671

Fairly pedestrian implementation; @mhvk your proposed solution to use `setup_class`/`teardown_class` environments would require creating classes for the tests in question, right?

Leaving this for consideration now; perhaps some discussion is due if the tests now still test what they are supposed to test (i.e. would a user in a normal work environment expect those equivalencies to be in effect as well)? 