### PR TITLE
Display list of loaders in specutils RTD

### DIFF
--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -72,6 +72,18 @@ astroquery, if the user has that package installed:
      >>> Spectrum1D.read(specs[0], format="SDSS-III/IV spec") # doctest: +SKIP
      <Spectrum1D(flux=<Quantity [30.596626,...]...>
 
+
+List of Loaders
+~~~~~~~~~~~~~~~
+
+The `~specutils.Spectrum1D` class has built-in support for various input and output formats.
+A full list of the supported formats is shown in the table below.
+
+.. automodule:: specutils.io._list_of_loaders
+
+| More information on creating custom loaders can be found in the :doc:`custom loading </custom_loading>` page.
+
+
 Including Uncertainties
 -----------------------
 

--- a/specutils/io/_list_of_loaders.py
+++ b/specutils/io/_list_of_loaders.py
@@ -1,0 +1,32 @@
+import io
+from specutils import Spectrum1D
+import specutils.io.default_loaders
+"""
+The purpose of this file is to receive a list of loaders from
+specutils.spectrum1d.read.list_formats(), format that list
+into something that can be used by `automodapi`, and then
+set it as the __doc__.
+"""
+
+def _list_of_loaders():
+    # Receive list of loaders
+    list_of_loaders = io.StringIO()
+    Spectrum1D.read.list_formats(list_of_loaders)
+
+    # Use the second line (which uses "-" to split the
+    # first row from the rest) to create the "=" signs
+    # which are used to create the table in .rst files
+    split_list = list_of_loaders.getvalue().split("\n")
+    line_of_equals = split_list[1].replace("-", "=")
+    split_list[1] = line_of_equals
+
+    # Combine elements to create formatted table
+    # which can be displayed using `automodapi`
+    formatted_table = line_of_equals + "\n"
+    for line in split_list:
+        formatted_table += line + "\n"
+    formatted_table += line_of_equals + "\n"
+    return formatted_table
+
+
+__doc__ = _list_of_loaders()


### PR DESCRIPTION
Automatically display a list of loaders in RTD as provided by spectrum1d.read.list_formats().

<img width="776" alt="Screen Shot 2020-05-07 at 12 04 34 PM" src="https://user-images.githubusercontent.com/7179333/81317395-c7b1dc00-905a-11ea-905a-32d12a95110a.png">
