### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ asdf_schema_root = specutils/io/asdf/schemas
 asdf_schema_tests_enabled = true
 # The remote data tests will run by default. Passing --remote-data=none on the
 # command line will override this setting.
-addopts = --remote-data=any --doctest-rst
+addopts = --remote-data=any --doctest-rst --doctest-ignore-import-errors
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.