### PR TITLE
Add warning about Astropy 4.1 and SpectralCoord

### DIFF
--- a/specutils/extern/spectralcoord/__init__.py
+++ b/specutils/extern/spectralcoord/__init__.py
@@ -44,6 +44,14 @@ from astropy import __version__ as astropy_version
 if LooseVersion(astropy_version) >= '4.1':
     from astropy.coordinates import SpectralCoord
 else:
+    from warnings import warn
+    from astropy.utils.exceptions import AstropyDeprecationWarning
+    warn('You are using SpectralCoord with a version of astropy earlier than '
+         '4.1. This uses a version of SpectralCoord supplied with specutils '
+         'that may not be fully compatible with the astropy SpectralCoord. '
+         'It is recommended that you upgrade to a version of Astropy >=4.1 if '
+         'you can.', AstropyDeprecationWarning)
+
     from .spectral_coordinate import SpectralCoord
 
 __all__ = ['SpectralCoord']


### PR DESCRIPTION
This is a proposed follow-on for #674 based on this thread: https://github.com/astropy/specutils/pull/674#discussion_r423335793

The gist is: I'm concerned about people using a "frozen" SpectralCoord and not realizing they're writing code that isn't compatible with a newer Astropy when they make an update (if they're using Astropy 4.0.x, for example). So this adds a warning suggesting they update.

That said: this is a pretty annoying warning to see *anytime* you import specutils, so I'm not sold on it myself (despite making the PR). Hence why I'm calling it a draft.

The alternative solution to this problem is to commit to making sure extern's copy of SpectralCoord stays up-to-date in some manner.  The most straightforward way to do that is probably to add a step to `specutils`'s release process to update the extern with whatever the most recent Astropy released version is (if it differs). So if we want to commit to that we can, but we probably should write that down in a release procedure document or something, otherwise we will inevitably forget.

cc @nmearl @astrofrog