### PR TITLE
Do not create ~/.specutils if it does not exist

### DIFF
--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -145,28 +145,25 @@ def _load_user_io():
     # Get the path relative to the user's home directory
     path = os.path.expanduser("~/.specutils")
 
-    # If the directory doesn't exist, create it
-    if not os.path.exists(path):
-        os.mkdir(path)
-
-    # Import all python files from the directory
-    for file in os.listdir(path):
-        if not file.endswith("py"):
-            continue
-
-        try:
-            import importlib.util as util
-
-            spec = util.spec_from_file_location(file[:-3],
-                                                os.path.join(path, file))
-            mod = util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
-        except ImportError:
-            from importlib import import_module
-
-            sys.path.insert(0, path)
+    # Import all python files from the directory if it exists
+    if os.path.exists(path):
+        for file in os.listdir(path):
+            if not file.endswith("py"):
+                continue
 
             try:
-                import_module(file[:-3])
-            except ModuleNotFoundError:  # noqa
-                pass
+                import importlib.util as util
+
+                spec = util.spec_from_file_location(file[:-3],
+                                                    os.path.join(path, file))
+                mod = util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
+            except ImportError:
+                from importlib import import_module
+
+                sys.path.insert(0, path)
+
+                try:
+                    import_module(file[:-3])
+                except ModuleNotFoundError:  # noqa
+                    pass


### PR DESCRIPTION
Closes #687.