### PR TITLE
fix doctests failures triggered by fix in #669

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -90,10 +90,20 @@ of a spectrum.  Both are demonstrated below:
 .. code-block:: python
 
     >>> from specutils.analysis import line_flux
-    >>> line_flux(noisy_gaussian).to(u.erg * u.cm**-2 * u.s**-1)  # doctest:+FLOAT_CMP
-    <Quantity 4.97826284e-14 erg / (cm2 s)>
     >>> line_flux(noisy_gaussian, SpectralRegion(7*u.GHz, 3*u.GHz))  # doctest:+FLOAT_CMP
     <Quantity 4.93784874 GHz Jy>
+    >>> line_flux(noisy_gaussian).to(u.erg * u.cm**-2 * u.s**-1)  # doctest:+FLOAT_CMP
+    <Quantity 4.97826284e-14 erg / (cm2 s)>
+
+These line_flux measurements also include uncertainties if the spectrum itself
+has uncertainties::
+
+.. code-block:: python
+
+    >>> flux = line_flux(noisy_gaussian)
+    >>> flux.uncertainty.to(u.erg * u.cm**-2 * u.s**-1) # doctest:+FLOAT_CMP
+    <Quantity 1.42132016e-15 erg / (cm2 s)>
+
 
 For the equivalent width, note the need to add a continuum level:
 

--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -93,7 +93,7 @@ of a spectrum.  Both are demonstrated below:
     >>> line_flux(noisy_gaussian).to(u.erg * u.cm**-2 * u.s**-1)  # doctest:+FLOAT_CMP
     <Quantity 4.97826284e-14 erg / (cm2 s)>
     >>> line_flux(noisy_gaussian, SpectralRegion(7*u.GHz, 3*u.GHz))  # doctest:+FLOAT_CMP
-    <Quantity 4.93254052 GHz Jy>
+    <Quantity 4.93784874 GHz Jy>
 
 For the equivalent width, note the need to add a continuum level:
 
@@ -102,9 +102,9 @@ For the equivalent width, note the need to add a continuum level:
     >>> from specutils.analysis import equivalent_width
     >>> noisy_gaussian_with_continuum = noisy_gaussian + 1*u.Jy
     >>> equivalent_width(noisy_gaussian_with_continuum)  # doctest:+FLOAT_CMP
-    <Quantity -4.97826284 GHz>
+    <Quantity -5.02976212 GHz>
     >>> equivalent_width(noisy_gaussian_with_continuum, regions=SpectralRegion(7*u.GHz, 3*u.GHz))  # doctest:+FLOAT_CMP
-    <Quantity -4.93254052 GHz>
+    <Quantity -4.9881 GHz>
 
 
 Centroid

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,7 +95,7 @@ containing the line:
     >>> from specutils import SpectralRegion
     >>> from specutils.analysis import equivalent_width
     >>> equivalent_width(cont_norm_spec, regions=SpectralRegion(6562*u.AA, 6575*u.AA)) # doctest: +REMOTE_DATA
-    <Quantity -14.78092438 Angstrom>
+    <Quantity -16.25232188 Angstrom>
 
 
 While there are other tools and spectral representations detailed more below,


### PR DESCRIPTION
Just after #669 got merged I realized it created some doctest failures.

The origin of this seems to be that #669 has a subtle behavior change that it now (correctly, I think!) doesn't ignore the first pixel of the region being considered. So that changed the values of the output.

For good measure I also added a mention of the uncertainty machinery, which I guess should have gone in #669 but I forgot we had that section in the docs already!

cc @nmearl 