### PR TITLE
Fit continuum over multiple windows.

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -103,7 +103,8 @@ has uncertainties::
     >>> flux = line_flux(noisy_gaussian)
     >>> flux.uncertainty.to(u.erg * u.cm**-2 * u.s**-1) # doctest:+FLOAT_CMP
     <Quantity 1.42132016e-15 erg / (cm2 s)>
-
+    >>> line_flux(noisy_gaussian, SpectralRegion(7*u.GHz, 3*u.GHz))  # doctest:+FLOAT_CMP
+    <Quantity 4.93784874 GHz Jy>
 
 For the equivalent width, note the need to add a continuum level:
 

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -679,13 +679,9 @@ fitted continuum, which returns a new object:
 
 
 When fitting over a specific wavelength region of a spectrum, one
-should use the `window` parameter to specify the region. This
-parameter accepts one single instance of a region. It is usually
-specified as a tuple of two wavelength values, but in cases where
-one wants to fit over multiple, disjoint regions, it is possible
-to pass to the parameter a single instance of a SpectralRegion.
-In this case, a Spectral Region can have multiple subregions, defined
-as a tuple of tuples in the constructor call:
+should use the `window` parameter to specify the region. Windows
+can be comprisewd of more than one wavelength interval; each interval
+is specified by a sequence:
 
 .. plot::
     :include-source:
@@ -697,7 +693,6 @@ as a tuple of tuples in the constructor call:
     import astropy.units as u
 
     from specutils.spectra.spectrum1d import Spectrum1D
-    from specutils.spectra import SpectralRegion
     from specutils.fitting.continuum import fit_continuum
 
     np.random.seed(0)
@@ -708,7 +703,7 @@ as a tuple of tuples in the constructor call:
 
     spectrum = Spectrum1D(flux=y * u.Jy, spectral_axis=x * u.um)
 
-    region = SpectralRegion(((4.*u.um, 5.*u.um), (8.*u.um, 10.*u.um)))
+    region = [(4.*u.um, 5.*u.um), (8.*u.um, 10.*u.um)]
 
     fitted_continuum = fit_continuum(spectrum, window=region)
 

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -689,7 +689,7 @@ is specified by a sequence:
     :context: close-figs
 
     import numpy as np
-
+import matplotlib.pyplot as plt
     import astropy.units as u
 
     from specutils.spectra.spectrum1d import Spectrum1D
@@ -707,7 +707,12 @@ is specified by a sequence:
 
     fitted_continuum = fit_continuum(spectrum, window=region)
 
+y_fit = fitted_continuum(x*u.um)
 
+plt.plot(x,y)
+plt.plot(x,y_fit)
+plt.title('Continuum Fitting')
+plt.grid(True)
 Reference/API
 -------------
 

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -679,7 +679,7 @@ fitted continuum, which returns a new object:
 
 
 When fitting over a specific wavelength region of a spectrum, one
-should use the `window` parameter to specify the region. Windows
+should use the ``window`` parameter to specify the region. Windows
 can be comprisewd of more than one wavelength interval; each interval
 is specified by a sequence:
 

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -692,11 +692,25 @@ as a tuple of tuples in the constructor call:
     :align: center
     :context: close-figs
 
-    from specutils.fitting import fit_continuum
+    import numpy as np
+
+    import astropy.units as u
+
+    from specutils.spectra.spectrum1d import Spectrum1D
+    from specutils.spectra import SpectralRegion
+    from specutils.fitting.continuum import fit_continuum
+
+    np.random.seed(0)
+    x = np.linspace(0., 10., 200)
+    y = 3 * np.exp(-0.5 * (x - 6.3)**2 / 0.1**2)
+    y += np.random.normal(0., 0.2, x.shape)
+    y += 3.2 * np.exp(-0.5 * (x - 5.6)**2 / 4.8**2)
+
+    spectrum = Spectrum1D(flux=y * u.Jy, spectral_axis=x * u.um)
 
     region = SpectralRegion(((4.*u.um, 5.*u.um), (8.*u.um, 10.*u.um)))
 
-    fitted_continuum = fit_continuum(spectrum, model=Chebyshev1D(5), window=region)
+    fitted_continuum = fit_continuum(spectrum, window=region)
 
 
 Reference/API

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -692,6 +692,8 @@ as a tuple of tuples in the constructor call:
     :align: center
     :context: close-figs
 
+    from specutils.fitting import fit_continuum
+
     region = SpectralRegion(((4.*u.um, 5.*u.um), (8.*u.um, 10.*u.um)))
 
     fitted_continuum = fit_continuum(spectrum, model=Chebyshev1D(5), window=region)

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -689,7 +689,7 @@ is specified by a sequence:
     :context: close-figs
 
     import numpy as np
-import matplotlib.pyplot as plt
+    import matplotlib.pyplot as plt
     import astropy.units as u
 
     from specutils.spectra.spectrum1d import Spectrum1D
@@ -707,12 +707,14 @@ import matplotlib.pyplot as plt
 
     fitted_continuum = fit_continuum(spectrum, window=region)
 
-y_fit = fitted_continuum(x*u.um)
+    y_fit = fitted_continuum(x*u.um)
 
-plt.plot(x,y)
-plt.plot(x,y_fit)
-plt.title('Continuum Fitting')
-plt.grid(True)
+    plt.plot(x, y)
+    plt.plot(x, y_fit)
+    plt.title("Continuum Fitting")
+    plt.grid(True)
+
+
 Reference/API
 -------------
 

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -680,7 +680,7 @@ fitted continuum, which returns a new object:
 
 When fitting over a specific wavelength region of a spectrum, one
 should use the ``window`` parameter to specify the region. Windows
-can be comprisewd of more than one wavelength interval; each interval
+can be comprised of more than one wavelength interval; each interval
 is specified by a sequence:
 
 .. plot::

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -678,6 +678,25 @@ fitted continuum, which returns a new object:
     plt.grid('on')
 
 
+When fitting over a specific wavelength region of a spectrum, one
+should use the `window` parameter to specify the region. This
+parameter accepts one single instance of a region. It is usually
+specified as a tuple of two wavelength values, but in cases where
+one wants to fit over multiple, disjoint regions, it is possible
+to pass to the parameter a single instance of a SpectralRegion.
+In this case, a Spectral Region can have multiple subregions, defined
+as a tuple of tuples in the constructor call:
+
+.. plot::
+    :include-source:
+    :align: center
+    :context: close-figs
+
+    region = SpectralRegion(((4.*u.um, 5.*u.um), (8.*u.um, 10.*u.um)))
+
+    fitted_continuum = fit_continuum(spectrum, model=Chebyshev1D(5), window=region)
+
+
 Reference/API
 -------------
 

--- a/specutils/fitting/continuum.py
+++ b/specutils/fitting/continuum.py
@@ -115,3 +115,4 @@ def _is_valid_sequence(value):
                isinstance(value[1], u.Quantity)
     else:
         return False
+

--- a/specutils/fitting/continuum.py
+++ b/specutils/fitting/continuum.py
@@ -7,7 +7,6 @@ from ..manipulation.smoothing import median_smooth
 from ..spectra import SpectralRegion
 
 
-
 __all__ = ['fit_continuum', 'fit_generic_continuum']
 
 
@@ -115,4 +114,3 @@ def _is_valid_sequence(value):
                isinstance(value[1], u.Quantity)
     else:
         return False
-

--- a/specutils/fitting/continuum.py
+++ b/specutils/fitting/continuum.py
@@ -80,7 +80,7 @@ def fit_continuum(spectrum, model=Chebyshev1D(3), fitter=LevMarLSQFitter(),
         Start and end wavelengths used for fitting.
 
     weights : list  (NOT IMPLEMENTED YET)
-        List of weights to define importance of fitting regions. and
+        List of weights to define importance of fitting regions.
 
     Returns
     -------

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -413,7 +413,6 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
     flux = spectrum.flux
     flux_unit = spectrum.flux.unit
 
-
     #
     # Determine the window if it is not None.  There
     # are several options here:
@@ -437,7 +436,7 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
     # should fit
     elif window is not None and isinstance(window, tuple):
         window_indices = np.nonzero((dispersion >= window[0]) &
-                             (dispersion <= window[1]))
+                                    (dispersion <= window[1]))
 
     # in this case the window is spectral regions that determine where
     # to fit.

--- a/specutils/tests/test_continuum.py
+++ b/specutils/tests/test_continuum.py
@@ -154,7 +154,7 @@ def test_continuum_window_no_noise():
 
 def test_constant_continuum_window():
     """
-    Fit to no-noise spectrum comprised of a constant continuum plus an emission Gaussian
+    Fit to no-noise spectrum comprised of a exponential continuum plus an emission Gaussian
     """
     x_single_continuum, y_single_continuum = single_peak_continuum(noise=0.,constant_continuum=False)
     spectrum = Spectrum1D(flux=y_single_continuum*u.Jy, spectral_axis=x_single_continuum*u.um)

--- a/specutils/tests/test_continuum.py
+++ b/specutils/tests/test_continuum.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import astropy.units as u
+from astropy.modeling.polynomial import Chebyshev1D
 
 from ..spectra.spectrum1d import Spectrum1D
 from ..spectra import SpectralRegion
@@ -155,21 +156,27 @@ def test_constant_continuum_window():
     """
     Fit to no-noise spectrum comprised of a constant continuum plus an emission Gaussian
     """
-    x_single_continuum, y_single_continuum = single_peak_continuum(noise=0.,constant_continuum=True)
+    x_single_continuum, y_single_continuum = single_peak_continuum(noise=0.,constant_continuum=False)
     spectrum = Spectrum1D(flux=y_single_continuum*u.Jy, spectral_axis=x_single_continuum*u.um)
 
     # Smooth in the same way fit_generic_continuum does.
     spectrum_smoothed = median_smooth(spectrum, 3)
 
-    # Window selects the first half of the spectrum.
-    g1_fit = fit_continuum(spectrum_smoothed, window=[(0.*u.um, 5.*u.um),(8.*u.um, 10.*u.um)])
+    # Test spectrum is comprised of an exponential continuum that increases sharply at the
+    # long wavelength end, plus a large-amplitude narrow Gaussian. We define the fitting
+    # window as a SpectralRegion with sub-regions at the blue and red halves of the spectrum,
+    # avoiding the Gaussian in between. The polynomial degree is high to accomodate the large
+    # amplitude range of the expoinential continuum.
+    region = SpectralRegion(((0.*u.um, 5.*u.um), (8.* u.um, 10.* u.um)))
+    g1_fit = fit_continuum(spectrum_smoothed, model=Chebyshev1D(7), window=region)
 
     spectrum_normalized = spectrum / g1_fit(spectrum.spectral_axis)
 
     y_continuum_fitted_expected = np.ones(shape=(spectrum_normalized.spectral_axis.shape))
 
-    # Check fit over the windowed regions.
-    assert np.allclose(spectrum_normalized.flux.value[0:100], y_continuum_fitted_expected[0:100],
-                       atol=1.e-5)
-    assert np.allclose(spectrum_normalized.flux.value[160:], y_continuum_fitted_expected[160:],
-                       atol=1.e-5)
+    # Check fit over the windowed regions. Note that we fit a noiseless spectrum so we can
+    # actually measure the degree of mismatch between model and data (polynomial X exponential).
+    assert np.allclose(spectrum_normalized.flux.value[0:90], y_continuum_fitted_expected[0:90],
+                       atol=1.e-4)
+    assert np.allclose(spectrum_normalized.flux.value[170:], y_continuum_fitted_expected[170:],
+                       atol=1.e-4)


### PR DESCRIPTION
This PR is in lieu of PR #681 , which got busted when my fork got busted. Discussions associated to this work can be found in #681 .

The implementation was actually simpler than it seemed at first. The code to fit a single model (the continuum) over multiple regions is already in place. To use it, it is just a matter of passing a single window to `fit_continuum`, using a single instance of `SpectralRegion`, but initialized with a tuple of regions. It is not enough to pass a sequence of tuples to the `window` parameter. An explicit instance of `SpectralRegion` does the trick.