### PR TITLE
Propagate nans in flux to mask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ New Features
 
 - Allow continuum fitting over multiple windows. [#698]
 
+- Have NaN-masked inputs automatically update the ``mask`` appropriately. [#699]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -85,7 +87,7 @@ Other Changes and Additions
 New Features
 ^^^^^^^^^^^^
 
-- Implement ``SpectralCoord`` object. [#524] 
+- Implement ``SpectralCoord`` object. [#524]
 
 - Implement cross-correlation for finding redshift/radial velocity. [#544]
 
@@ -95,7 +97,7 @@ New Features
 
 - Improved 1D JWST loader and allow parsing into an ``SpectrumCollection`` object. [#579]
 
-- Implemented 2D and 3D data loaders for JWST products. [#595] 
+- Implemented 2D and 3D data loaders for JWST products. [#595]
 
 - Include documentation on how to use dust_extinction in specutils. [#594]
 
@@ -112,7 +114,7 @@ Bug Fixes
 
 - Fix spectral axis unit retrieval. [#581]
 
-- Fix bug in subspectrum fitting. [#586] 
+- Fix bug in subspectrum fitting. [#586]
 
 - Fix uncertainty to weight conversion to match astropy assumptions. [#594]
 

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -30,7 +30,7 @@ create it explicitly from arrays or `~astropy.units.Quantity` objects:
     >>> ax.set_ylabel("Flux")  # doctest: +SKIP
 
 .. note::
-    Note that the ``spectral_axis`` can also be provided as a :class:`~specutils.SpectralAxis` object, 
+    Note that the ``spectral_axis`` can also be provided as a :class:`~specutils.SpectralAxis` object,
     and in fact will internally convert the spectral_axis to :class:`~specutils.SpectralAxis` if it
     is provided as an array or `~astropy.units.Quantity`.
 
@@ -47,15 +47,15 @@ encouraged to :doc:`create their own loader </custom_loading>`.
     >>> from specutils import Spectrum1D
     >>> spec1d = Spectrum1D.read("/path/to/file.fits")  # doctest: +SKIP
 
-Most of the built-in specutils default loaders can also read an existing 
-`astropy.io.fits.HDUList` object or an open file object (as resulting 
-from e.g. streaming a file from the internet). Note that in these cases, a 
-format string corresponding to an existing loader must be supplied because 
+Most of the built-in specutils default loaders can also read an existing
+`astropy.io.fits.HDUList` object or an open file object (as resulting
+from e.g. streaming a file from the internet). Note that in these cases, a
+format string corresponding to an existing loader must be supplied because
 these objects lack enough contextual information to automatically identify
 a loader.
 
 .. code-block:: python
-    
+
     >>> from specutils import Spectrum1D
     >>> import urllib
     >>> specs = urllib.request.urlopen('https://data.sdss.org/sas/dr14/sdss/spectro/redux/26/spectra/0751/spec-0751-52251-0160.fits') # doctest: +REMOTE_DATA
@@ -106,6 +106,27 @@ specify the uncertainty type at creation time
              :class:`~astropy.nddata.UnknownUncertainty` object which will not
              propagate uncertainties in arithmetic operations.
 
+
+Including Masks
+---------------
+
+Masks are also available for :class:`~specutils.Spectrum1D`, following the
+same mechanisms as :class:`~astropy.nddata.NDData`.  That is, the mask should
+have the property that it is ``False``/``0`` wherever the data is *good*, and
+``True``/anything else where it should be masked.  This allows "data quality"
+arrays to function as masks by default.
+
+Note that this is distinct from "missing data" implementations, which generally
+use ``NaN`` as a masking technique.  This method has the problem that ``NaN``
+values are frequently "infectious", in that arithmetic operations sometimes
+propagate to yield results as just ``NaN`` where the intent is instead to skip
+that particular pixel. It also makes it impossible to store data that in the
+spectrum that may have meaning but should *sometimes* be masked.  The separate
+``mask`` attribute in :class:`~specutils.Spectrum1D` addresses that in that the
+spectrum may still have a value underneath the mask, but it is not used in most
+calculations. To allow for compatibility with ``NaN``-masking representations,
+however, specutils will recognize ``flux`` values input as ``NaN`` and set the
+mask to ``True`` for those values unless explicitly overridden.
 
 
 Defining WCS

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -57,8 +57,10 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         Contains uncertainty information along with propagation rules for
         spectrum arithmetic. Can take a unit, but if none is given, will use
         the unit defined in the flux.
-    mask : `~numpy.ndarray`-like and bool
-        Boolean array where values in the flux to be masked are set to `True`.
+    mask : `~numpy.ndarray`-like
+        Array where values in the flux to be masked are those that
+        ``astype(bool)`` converts to True. (For example, integer arrays are not
+        masked where they are 0, and masked for any other value.)
     meta : dict
         Arbitrary container for any user-specific information to be carried
         around with the spectrum container object.

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -18,9 +18,9 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     """
     Spectrum container for 1D spectral data.
 
-    Note that "1d" in this case refers to the fact that there is only one
-    spectral axis.  `Spectrum1D` can contain "vector 1d spectra" by having the
-    ``flux`` have a shape with dimension great than 1 - the requirement then
+    Note that "1D" in this case refers to the fact that there is only one
+    spectral axis.  `Spectrum1D` can contain "vector 1D spectra" by having the
+    ``flux`` have a shape with dimension greater than 1.  The requirement
     is that the last dimension of ``flux`` match the length of the
     ``spectral_axis``.
 
@@ -32,13 +32,13 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
 
     Parameters
     ----------
-    flux : `astropy.units.Quantity` or astropy.nddata.NDData`-like
+    flux : `~astropy.units.Quantity` or `~astropy.nddata.NDData`-like
         The flux data for this spectrum.
-    spectral_axis : `astropy.units.Quantity` or `specutils.SpectralAxis`
+    spectral_axis : `~astropy.units.Quantity` or `~specutils.SpectralAxis`
         Dispersion information with the same shape as the last (or only)
         dimension of flux, or one greater than the last dimension of flux
         if specifying bin edges.
-    wcs : `astropy.wcs.WCS` or `gwcs.wcs.WCS`
+    wcs : `~astropy.wcs.WCS` or `~gwcs.wcs.WCS`
         WCS information object.
     velocity_convention : {"doppler_relativistic", "doppler_optical", "doppler_radio"}
         Convention used for velocity conversions.
@@ -50,10 +50,15 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         See `redshift` for more information.
     radial_velocity
         See `radial_velocity` for more information.
+    bin_specification : str
+        Either "edges" or "centers" to indicate whether the `spectral_axis`
+        values represent edges of the wavelength bin, or centers of the bin.
     uncertainty : `~astropy.nddata.NDUncertainty`
         Contains uncertainty information along with propagation rules for
         spectrum arithmetic. Can take a unit, but if none is given, will use
         the unit defined in the flux.
+    mask : `~numpy.ndarray`-like and bool
+        Boolean array where values in the flux to be masked are set to `True`.
     meta : dict
         Arbitrary container for any user-specific information to be carried
         around with the spectrum container object.
@@ -72,8 +77,19 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         # If the flux (data) argument is a subclass of nddataref (as it would
         # be for internal arithmetic operations), avoid setup entirely.
         if isinstance(flux, NDDataRef):
-            super(Spectrum1D, self).__init__(flux)
+            super().__init__(flux)
             return
+
+        # If the mask kwarg is not passed to the constructor, but the flux array
+        # contains NaNs, add the NaN locations to the mask.
+        if "mask" not in kwargs and flux is not None:
+            nan_mask = np.isnan(flux)
+            if nan_mask.any():
+                if hasattr(self, "mask"):
+                    kwargs["mask"] = np.logical_or(nan_mask, self.mask)
+                else:
+                    kwargs["mask"] = nan_mask.copy()
+            del nan_mask
 
         # Ensure that the flux argument is an astropy quantity
         if flux is not None:
@@ -186,9 +202,10 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             size = len(flux) if not flux.isscalar else 1
             wcs = gwcs_from_array(np.arange(size) * u.Unit(""))
 
-        super(Spectrum1D, self).__init__(
+        super().__init__(
             data=flux.value if isinstance(flux, u.Quantity) else flux,
-            wcs=wcs, **kwargs)
+            wcs=wcs, **kwargs
+            )
 
         # If no spectral_axis was provided, create a SpectralCoord based on
         # the WCS
@@ -274,14 +291,14 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     @property
     def frequency(self):
         """
-        The frequency as a `~astropy.units.Quantity` in units of GHz
+        The `spectral_axis` as a `~astropy.units.Quantity` in units of GHz
         """
         return self.spectral_axis.to(u.GHz, u.spectral())
 
     @property
     def wavelength(self):
         """
-        The wavelength as a `~astropy.units.Quantity` in units of Angstroms
+        The `spectral_axis` as a `~astropy.units.Quantity` in units of Angstroms
         """
         return self.spectral_axis.to(u.AA, u.spectral())
 

--- a/specutils/tests/test_arithmetic.py
+++ b/specutils/tests/test_arithmetic.py
@@ -104,3 +104,16 @@ def test_masks(simulated_spectra):
     masked_diff = masked_sum - masked_spec
     assert u.allclose(masked_diff.flux, masked_spec.flux)
     assert np.all(masked_diff.mask == masked_sum.mask | masked_spec.mask)
+
+
+def test_mask_nans():
+    flux1 = np.random.random(10)
+    flux2 = np.random.random(10)
+    nan_idx = [1, 3, 5]
+    flux2[nan_idx] = np.nan
+    spec1 = Spectrum1D(spectral_axis=np.arange(10) * u.nm, flux=flux1 * u.Jy)
+    spec2 = Spectrum1D(spectral_axis=np.arange(10) * u.nm, flux=flux2 * u.Jy)
+
+    spec3 = spec1 + spec2
+
+    assert spec3.mask[nan_idx].all() == True

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -335,6 +335,16 @@ def test_energy_photon_flux():
     assert spec.photon_flux.unit == u.photon * u.cm**-2 * u.s**-1 * u.nm**-1
 
 
+def test_flux_nans_propagate_to_mask():
+    """Check that indices in input flux with NaNs get propagated to the mask"""
+    flux = np.random.randn(10)
+    nan_idx = [0, 3, 5]
+    flux[nan_idx] = np.nan
+    spec = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
+                      flux=flux * u.Jy)
+    assert spec.mask[nan_idx].all() == True
+
+
 def test_repr():
     spec_with_wcs = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
                                flux=np.random.random(10) * u.Jy)


### PR DESCRIPTION
If the flux array in a `Spectrum1D` instance has NaN values, mask them in the `mask` attribute.

Tests are the most simple case, and I'm sure I'm missing something here.  Anyone point to me to other use cases so I can expand the tests?  @eteq 

~Resolves X #518?~