### PR TITLE
Update mask handling in line flux and equivalent width functions

### DIFF
--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -117,7 +117,9 @@ def _compute_line_flux(spectrum, regions=None,
         mask = calc_spectrum.mask
         new_spec = Spectrum1D(flux=calc_spectrum.flux[~mask],
                               spectral_axis=calc_spectrum.spectral_axis[~mask])
-        return _compute_line_flux(new_spec)
+        interpolator = mask_interpolation(extrapolation_treatment='zero_fill')
+        sp = interpolator(new_spec, calc_spectrum.spectral_axis)
+        flux = sp.flux
     else:
         flux = calc_spectrum.flux
 

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -38,9 +38,11 @@ def line_flux(spectrum, regions=None,
         Region within the spectrum to calculate the gaussian sigma width. If
         regions is `None`, computation is performed over entire spectrum.
 
-    mask_interpolation : `~specutils.manipulation.LinearInterpolatedResampler`
+    mask_interpolation : ``None`` or `~specutils.manipulation.LinearInterpolatedResampler`
         Interpolator class used to fill up the gaps in the spectrum's flux
-        array, when the spectrum mask is not None.
+        array, when the spectrum mask is not None. If set to ``None``, the
+         masked spectral bins are excised from the data without interpolation
+         and the bin edges of the adjacent bins are extended to fill the gap.
 
     Returns
     -------
@@ -80,10 +82,12 @@ def equivalent_width(spectrum, continuum=1, regions=None,
         will be assumed, otherwise units are required and must be the same as
         the ``spectrum.flux``.
 
-    mask_interpolation : `~specutils.manipulation.LinearInterpolatedResampler`
+    mask_interpolation : ``None`` or `~specutils.manipulation.LinearInterpolatedResampler`
         Interpolator class used to fill up the gaps in the spectrum's flux
         array after an excise operation to ensure the mask shape can always be
-        applied when the spectrum mask is not None.
+        applied when the spectrum mask is not None. If set to ``None``, the
+        masked spectral bins are excised from the data without interpolation
+        and the bin edges of the adjacent bins are extended to fill the gap.
 
     Returns
     -------

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -143,7 +143,7 @@ def _compute_line_flux(spectrum, regions=None,
 
         if variance_q is not None:
             line_flux.uncertainty = np.sqrt(
-                np.sum(variance_q * avg_dx**2))
+                np.sum(variance_q * dx**2))
 
     # TODO: we may want to consider converting to erg / cm^2 / sec by default
     return line_flux

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -41,8 +41,8 @@ def line_flux(spectrum, regions=None,
     mask_interpolation : ``None`` or `~specutils.manipulation.LinearInterpolatedResampler`
         Interpolator class used to fill up the gaps in the spectrum's flux
         array, when the spectrum mask is not None. If set to ``None``, the
-         masked spectral bins are excised from the data without interpolation
-         and the bin edges of the adjacent bins are extended to fill the gap.
+        masked spectral bins are excised from the data without interpolation
+        and the bin edges of the adjacent bins are extended to fill the gap.
 
     Returns
     -------

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy.nddata import StdDevUncertainty, VarianceUncertainty, InverseVariance
 
 from .. import conf
+from ..spectra import Spectrum1D
 from ..manipulation import extract_region, LinearInterpolatedResampler
 from .utils import computation_wrapper
 import astropy.units as u
@@ -111,23 +112,17 @@ def _compute_line_flux(spectrum, regions=None,
     else:
         calc_spectrum = spectrum
 
-    # Average dispersion in the line region
-    avg_dx = (np.abs(np.diff(calc_spectrum.spectral_axis.bin_edges)))
-    line_flux = np.sum(calc_spectrum.flux * avg_dx)
-
-    line_flux.uncertainty = None
-
     # Account for the existence of a mask.
     if hasattr(calc_spectrum, 'mask') and calc_spectrum.mask is not None:
-        # For now, we interpolate over the masked values. A better solution
-        # would be to account for the masked values when computing the dispersion.
-        interpolator = mask_interpolation()
-        sp = interpolator(calc_spectrum, calc_spectrum.spectral_axis)
-        flux = sp.flux
+        mask = calc_spectrum.mask
+        new_spec = Spectrum1D(flux=calc_spectrum.flux[~mask],
+                              spectral_axis=calc_spectrum.spectral_axis[~mask])
+        return _compute_line_flux(new_spec)
     else:
         flux = calc_spectrum.flux
 
-    line_flux = np.sum(flux * avg_dx)
+    dx = (np.abs(np.diff(calc_spectrum.spectral_axis.bin_edges)))
+    line_flux = np.sum(flux * dx)
 
     line_flux.uncertainty = None
 

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -156,6 +156,13 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
     else:
         calc_spectrum = spectrum
 
+    # Account for the existence of a mask.
+    if hasattr(calc_spectrum, 'mask') and calc_spectrum.mask is not None:
+        mask = calc_spectrum.mask
+        new_spec = Spectrum1D(flux=calc_spectrum.flux[~mask],
+                              spectral_axis=calc_spectrum.spectral_axis[~mask])
+        return _compute_equivalent_width(new_spec, continuum=continuum)
+
     if continuum == 1:
         continuum = 1*calc_spectrum.flux.unit
 

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -117,9 +117,12 @@ def _compute_line_flux(spectrum, regions=None,
         mask = calc_spectrum.mask
         new_spec = Spectrum1D(flux=calc_spectrum.flux[~mask],
                               spectral_axis=calc_spectrum.spectral_axis[~mask])
-        interpolator = mask_interpolation(extrapolation_treatment='zero_fill')
-        sp = interpolator(new_spec, calc_spectrum.spectral_axis)
-        flux = sp.flux
+        if mask_interpolation is None:
+            return _compute_line_flux(new_spec)
+        else:
+            interpolator = mask_interpolation(extrapolation_treatment='zero_fill')
+            sp = interpolator(new_spec, calc_spectrum.spectral_axis)
+            flux = sp.flux
     else:
         flux = calc_spectrum.flux
 
@@ -161,9 +164,8 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
     # Account for the existence of a mask.
     if hasattr(calc_spectrum, 'mask') and calc_spectrum.mask is not None:
         mask = calc_spectrum.mask
-        new_spec = Spectrum1D(flux=calc_spectrum.flux[~mask],
+        calc_spectrum = Spectrum1D(flux=calc_spectrum.flux[~mask],
                               spectral_axis=calc_spectrum.spectral_axis[~mask])
-        return _compute_equivalent_width(new_spec, continuum=continuum)
 
     if continuum == 1:
         continuum = 1*calc_spectrum.flux.unit

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -149,7 +149,7 @@ def test_equivalent_width_masked ():
     # With flux conserving resampler
     result = equivalent_width(spectrum_masked,
                               mask_interpolation=FluxConservingResampler)
-    assert quantity_allclose(result.value, -719.90618, atol=0.001)
+    assert quantity_allclose(result.value, -719.987425, atol=0.001)
 
 
 def test_equivalent_width_regions():

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -77,15 +77,11 @@ def test_line_flux_masked():
 
     assert result.unit.is_equivalent(u.Jy * u.um)
 
-    # Flux from masked spectrum should be identical with the
-    # flux from same spectrum but with no mask (because we
-    # interpolate over the masked data).
-    result_unmasked = line_flux(spectrum)
-    assert quantity_allclose(result.value, result_unmasked.value, atol=0.001)
+    assert quantity_allclose(result.value, 720.52992, atol=0.001)
 
     # With flux conserving resampler
     result = line_flux(spectrum_masked, mask_interpolation=FluxConservingResampler)
-    assert quantity_allclose(result.value, result_unmasked.value, atol=0.001)
+    assert quantity_allclose(result.value, 720.61116, atol=0.001)
 
 
 def test_line_flux_uncertainty():
@@ -148,14 +144,12 @@ def test_equivalent_width_masked ():
 
     assert result.unit.is_equivalent(spectrum.wcs.unit)
 
-    # Compare with unmasked computation.
-    result_unmasked = equivalent_width(spectrum)
-    assert quantity_allclose(result.value, result_unmasked.value, atol=0.001)
+    assert quantity_allclose(result.value, -719.90618, atol=0.001)
 
     # With flux conserving resampler
     result = equivalent_width(spectrum_masked,
                               mask_interpolation=FluxConservingResampler)
-    assert quantity_allclose(result.value, result_unmasked.value, atol=0.001)
+    assert quantity_allclose(result.value, -719.90618, atol=0.001)
 
 
 def test_equivalent_width_regions():


### PR DESCRIPTION
Some further work addressing [issue 516](https://github.com/astropy/specutils/issues/516). The recent discussion between @nmearl and I provides some additional context for this PR. I believe the concern about variable-width wavelength bins with masked data removed is addressed by the fact that `Spectrum1D.bin_edges` returns appropriately spaced bin edges based on the remaining spectral_axis points if intermediate data points are removed, but it may turn out that I'm wrong and this solution isn't adequate.