### PR TITLE
Adds new specutils data loader for SDSS MaNGA cube/rss data

### DIFF
--- a/docs/identify.rst
+++ b/docs/identify.rst
@@ -8,8 +8,11 @@ Identifying Spectrum1D Formats
 essentially acts as a wrapper on `~astropy.io.registry.identify_format`.
 
 This function is useful for identifying a spectrum file format without the need to
-read it in with Spectrum1d's `~specutils.Spectrum1D.read` method.  It returns the best guess as to a
-valid format from the list of ``Formats`` as given by `~astropy.io.registry.get_formats`.
+read it in with Spectrum1d's `~specutils.Spectrum1D.read` method.  It uses the
+same identification method as `read` however, so it simply provides a convenience
+of access outside of calling `read` without any change in underlying functionality.
+It returns the best guess as to a valid format from the list of ``Formats``
+as given by `~astropy.io.registry.get_formats`.
 
 General usage is as follows, passing in an absolute filename path:
 

--- a/docs/identify.rst
+++ b/docs/identify.rst
@@ -9,8 +9,8 @@ essentially acts as a wrapper on `~astropy.io.registry.identify_format`.
 
 This function is useful for identifying a spectrum file format without the need to
 read it in with Spectrum1d's `~specutils.Spectrum1D.read` method.  It uses the
-same identification method as `read` however, so it simply provides a convenience
-of access outside of calling `read` without any change in underlying functionality.
+same identification method as ``read`` however, so it simply provides a convenience
+of access outside of calling ``read`` without any change in underlying functionality.
 It returns the best guess as to a valid format from the list of ``Formats``
 as given by `~astropy.io.registry.get_formats`.
 

--- a/docs/identify.rst
+++ b/docs/identify.rst
@@ -7,21 +7,14 @@ Identifying Spectrum1D Formats
 `~specutils.Spectrum1D` file format from the list of registered formats, and
 essentially acts as a wrapper on `~astropy.io.registry.identify_format`.
 
-This function is useful for identifying a spectrum file format without the need to
-read it in with Spectrum1d's `~specutils.Spectrum1D.read` method.  It uses the
-same identification method as ``read`` however, so it simply provides a convenience
+This function is useful for identifying a spectrum file format without reading the
+whole file with the  `~specutils.Spectrum1D.read` method.  It uses the
+same identification method as ``read`` however, so it provides a convenience
 of access outside of calling ``read`` without any change in underlying functionality.
 It returns the best guess as to a valid format from the list of ``Formats``
 as given by `~astropy.io.registry.get_formats`.
 
-General usage is as follows, passing in an absolute filename path:
-
-.. code-block:: python
-
-    >>> from specutils.io.registers import identify_spectrum_format
-    >>> identify_spectrum_format("/path/to/file.fits")  # doctest: +SKIP
-
-An example is given to identify a SDSS MaNGA data cube file:
+For eample, to identify a SDSS MaNGA data cube file:
 
 .. code-block:: python
 

--- a/docs/identify.rst
+++ b/docs/identify.rst
@@ -1,0 +1,40 @@
+==============================
+Identifying Spectrum1D Formats
+==============================
+
+``specutils`` provides a convenience function,
+`~specutils.io.registers.identify_spectrum_format`, which attempts to guess the
+`~specutils.Spectrum1D` file format from the list of registered formats, and
+essentially acts as a wrapper on `~astropy.io.registry.identify_format`.
+
+This function is useful for identifying a spectrum file format without the need to
+read it in with Spectrum1d's `~specutils.Spectrum1D.read` method.  It returns the best guess as to a
+valid format from the list of ``Formats`` as given by `~astropy.io.registry.get_formats`.
+
+General usage is as follows, passing in an absolute filename path:
+
+.. code-block:: python
+
+    >>> from specutils.io.registers import identify_spectrum_format
+    >>> identify_spectrum_format("/path/to/file.fits")  # doctest: +SKIP
+
+An example is given to identify a SDSS MaNGA data cube file:
+
+.. code-block:: python
+
+    >>> from astropy.utils.data import download_file
+    >>> from specutils.io.registers import identify_spectrum_format
+    >>>
+    >>> url='https://dr15.sdss.org/sas/dr15/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
+    >>> dd = download_file(url)
+    >>> identify_spectrum_format(dd)
+    'MaNGA cube'
+
+or a JWST extracted 1d spectral file:
+
+.. code-block:: python
+
+    >>> from specutils.io.registers import identify_spectrum_format
+    >>> path = '/data/jwst/jw00626-o030_s00000_nirspec_f170lp-g235m_x1d.fits'
+    >>> identify_spectrum_format(path)  # doctest: +SKIP
+    'JWST x1d'

--- a/docs/identify.rst
+++ b/docs/identify.rst
@@ -26,7 +26,7 @@ An example is given to identify a SDSS MaNGA data cube file:
     >>> from specutils.io.registers import identify_spectrum_format
     >>>
     >>> url='https://dr15.sdss.org/sas/dr15/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
-    >>> dd = download_file(url)
+    >>> dd = download_file(url)  # doctest: +SKIP
     >>> identify_spectrum_format(dd)
     'MaNGA cube'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,6 +120,7 @@ For more details on usage of specutils, see the sections listed below.
     manipulation
     arithmetic
     custom_loading
+    identify
 
 Get Involved - Developer Docs
 -----------------------------

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -1,14 +1,3 @@
-# !/usr/bin/env python
-# -*- coding: utf-8 -*-
-#
-# Filename: manga.py
-# Project: default_loaders
-# Author: Brian Cherinka
-# Created: Tuesday, 21st July 2020 2:40:56 pm
-# License: BSD 3-clause "New" or "Revised" License
-# Copyright (c) 2020 Brian Cherinka
-# Last Modified: Tuesday, 21st July 2020 2:40:56 pm
-# Modified By: Brian Cherinka
 
 
 from __future__ import print_function, division, absolute_import
@@ -114,4 +103,3 @@ def _load_manga_spectra(hdulist, per_unit=None, transpose=None):
 
     return Spectrum1D(flux=flux, meta={'header': hdr}, spectral_axis=wave,
                       uncertainty=ivar)
-

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -79,8 +79,9 @@ def manga_cube_loader(file_obj, **kwargs):
 
     Parameters
     ----------
-    filename : str
-        The path to the FITS file
+    file_obj: str, file-like, or HDUList
+          FITS file name, object (provided from name by Astropy I/O Registry),
+          or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------
@@ -110,8 +111,9 @@ def manga_rss_loader(file_obj, **kwargs):
 
     Parameters
     ----------
-    filename : str
-        The path to the FITS file
+    file_obj: str, file-like, or HDUList
+          FITS file name, object (provided from name by Astropy I/O Registry),
+          or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -114,9 +114,11 @@ def _load_manga_spectra(hdulist, per_unit=None, transpose=None):
     if transpose:
         flux = hdulist['FLUX'].data.T * unit
         ivar = InverseVariance(hdulist["IVAR"].data.T)
+        mask = hdulist['MASK'].data.T
     else:
         flux = hdulist['FLUX'].data * unit
         ivar = InverseVariance(hdulist["IVAR"].data)
+        mask = hdulist['MASK'].data
 
     return Spectrum1D(flux=flux, meta={'header': hdr}, spectral_axis=wave,
-                      uncertainty=ivar)
+                      uncertainty=ivar, mask=mask)

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -1,0 +1,117 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Filename: manga.py
+# Project: default_loaders
+# Author: Brian Cherinka
+# Created: Tuesday, 21st July 2020 2:40:56 pm
+# License: BSD 3-clause "New" or "Revised" License
+# Copyright (c) 2020 Brian Cherinka
+# Last Modified: Tuesday, 21st July 2020 2:40:56 pm
+# Modified By: Brian Cherinka
+
+
+from __future__ import print_function, division, absolute_import
+from astropy.io import fits
+import astropy.units as u
+from ...spectra import Spectrum1D
+from ..registers import data_loader
+from astropy.nddata import InverseVariance
+
+
+__all__ = ["identify_manga_cube", "identify_manga_rss", "manga_cube_loader", "manga_rss_loader"]
+
+
+def _identify_sdss_fits(filename):
+    """
+    Check whether the given file is a SDSS data product.
+    """
+    try:
+        with fits.open(filename, memmap=True) as hdulist:
+            return hdulist[0].header["TELESCOP"] == "SDSS 2.5-M"
+    except Exception:
+        return False
+
+
+def identify_manga_cube(origin, *args, **kwargs):
+    """
+    Check whether the given file is a MaNGA CUBE.
+    """
+    is_sdss = _identify_sdss_fits(args[0])
+    with fits.open(args[0], memmap=True) as hdulist:
+        return (is_sdss and "FLUX" in hdulist and hdulist[1].header['INSTRUME'] == 'MaNGA'
+                and hdulist[1].header["NAXIS"] == 3)
+
+
+def identify_manga_rss(origin, *args, **kwargs):
+    """
+    Check whether the given file is a MaNGA RSS.
+    """
+    is_sdss = _identify_sdss_fits(args[0])
+    with fits.open(args[0], memmap=True) as hdulist:
+        return (is_sdss and "FLUX" in hdulist and hdulist[1].header['INSTRUME'] == 'MaNGA'
+                and hdulist[1].header["NAXIS"] == 2)
+
+
+@data_loader("MaNGA cube", identifier=identify_manga_cube, dtype=Spectrum1D,
+             extensions=['fits'])
+def manga_cube_loader(filename, **kwargs):
+    """
+    Loader for MaNGA 3D rectified spectral data in FITS format.
+
+    Parameters
+    ----------
+    filename : str
+        The path to the FITS file
+
+    Returns
+    -------
+    Spectrum1D
+        The spectrum contained in the file.
+    """
+
+    with fits.open(filename, memmap=False) as hdulist:
+        spaxel = u.Unit('spaxel', represents=u.pixel, doc='0.5" spatial pixel', parse_strict='silent')
+        return _load_manga_spectra(hdulist, per_unit=spaxel, transpose=True)
+
+
+@data_loader("MaNGA rss", identifier=identify_manga_rss, dtype=Spectrum1D,
+             extensions=['fits'])
+def manga_rss_loader(filename, **kwargs):
+    """
+    Loader for MaNGA 2D row-stacked spectral data in FITS format.
+
+    Parameters
+    ----------
+    filename : str
+        The path to the FITS file
+
+    Returns
+    -------
+    Spectrum1D
+        The spectrum contained in the file.
+    """
+
+    with fits.open(filename, memmap=False) as hdulist:
+        fiber = u.Unit('fiber', represents=u.pixel, doc='spectroscopic fiber', parse_strict='silent')
+        return _load_manga_spectra(hdulist, per_unit=fiber)
+
+
+def _load_manga_spectra(hdulist, per_unit=None, transpose=None):
+    unit = u.Unit('1e-17 erg / (Angstrom cm2 s)')
+    if per_unit:
+        unit = unit / per_unit
+
+    hdr = hdulist['PRIMARY'].header
+    wave = hdulist['WAVE'].data * u.angstrom
+
+    if transpose:
+        flux = hdulist['FLUX'].data.T * unit
+        ivar = InverseVariance(hdulist["IVAR"].data.T)
+    else:
+        flux = hdulist['FLUX'].data * unit
+        ivar = InverseVariance(hdulist["IVAR"].data)
+
+    return Spectrum1D(flux=flux, meta={'header': hdr}, spectral_axis=wave,
+                      uncertainty=ivar)
+

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -104,6 +104,27 @@ def manga_rss_loader(file_obj, **kwargs):
 
 
 def _load_manga_spectra(hdulist, per_unit=None, transpose=None):
+    """ Return a MaNGA Spectrum1D object
+
+    Returns a Spectrum1D object for a MaNGA data files.  Set
+    `transpose` kwarg to True for MaNGA cubes, as they are flipped relative
+    to what Spectrum1D expects.  Use the `per_unit` kwarg to indicate the
+    "spaxel" or "fiber" unit for cubes and rss files, respectively.
+
+    Parameters
+    ----------
+    hdulist : fits.HDUList
+        A MaNGA read astropy fits HDUList
+    per_unit : astropy.units.Unit
+        An astropy unit to divide the default flux unit by
+    transpose : bool
+        If True, transpose the data arrays
+
+    Returns
+    -------
+    Spectrum1D
+        The spectrum contained in the file.
+    """
     unit = u.Unit('1e-17 erg / (Angstrom cm2 s)')
     if per_unit:
         unit = unit / per_unit

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -135,11 +135,13 @@ def _load_manga_spectra(hdulist, per_unit=None, transpose=None):
     if transpose:
         flux = hdulist['FLUX'].data.T * unit
         ivar = InverseVariance(hdulist["IVAR"].data.T)
-        mask = hdulist['MASK'].data.T
+        # SDSS masks are arrays of bit values storing multiple boolean conditions.
+        # Setting non-zero bit values to True to map to specutils standard
+        mask = hdulist['MASK'].data.T != 0
     else:
         flux = hdulist['FLUX'].data * unit
         ivar = InverseVariance(hdulist["IVAR"].data)
-        mask = hdulist['MASK'].data
+        mask = hdulist['MASK'].data != 0
 
     return Spectrum1D(flux=flux, meta={'header': hdr}, spectral_axis=wave,
                       uncertainty=ivar, mask=mask)

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -38,36 +38,25 @@ def _read_fileobj(*args, **kwargs):
         hdulist.close()
 
 
-def _identify_sdss_fits(*args, **kwargs):
-    """
-    Check whether the given file is a SDSS data product.
-    """
-
-    try:
-        with _read_fileobj(*args, **kwargs) as hdulist:
-            return hdulist[0].header["TELESCOP"] == "SDSS 2.5-M"
-    except Exception:
-        return False
-
-
 def identify_manga_cube(origin, *args, **kwargs):
     """
     Check whether the given file is a MaNGA CUBE.
     """
 
-    is_sdss = _identify_sdss_fits(*args, **kwargs)
     with _read_fileobj(*args, **kwargs) as hdulist:
-        return (is_sdss and "FLUX" in hdulist and hdulist[1].header['INSTRUME'] == 'MaNGA'
+        return (hdulist[0].header["TELESCOP"] == "SDSS 2.5-M" and "FLUX" in hdulist
+                and hdulist[1].header['INSTRUME'] == 'MaNGA'
                 and hdulist[1].header["NAXIS"] == 3)
 
 
-def identify_manga_rss(origin, *args, **kwargs):
+def identify_manga_rss(origin, path, fileobj, *args, **kwargs):
     """
     Check whether the given file is a MaNGA RSS.
     """
-    is_sdss = _identify_sdss_fits(*args, **kwargs)
+
     with _read_fileobj(*args, **kwargs) as hdulist:
-        return (is_sdss and "FLUX" in hdulist and hdulist[1].header['INSTRUME'] == 'MaNGA'
+        return (hdulist[0].header["TELESCOP"] == "SDSS 2.5-M" and "FLUX" in hdulist
+                and hdulist[1].header['INSTRUME'] == 'MaNGA'
                 and hdulist[1].header["NAXIS"] == 2)
 
 

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -1,6 +1,5 @@
 
 
-from __future__ import print_function, division, absolute_import
 from astropy.io import fits
 import astropy.units as u
 from ...spectra import Spectrum1D

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -43,7 +43,7 @@ def identify_manga_rss(origin, *args, **kwargs):
 
 @data_loader("MaNGA cube", identifier=identify_manga_cube, dtype=Spectrum1D,
              extensions=['fits'])
-def manga_cube_loader(filename, **kwargs):
+def manga_cube_loader(file_obj, **kwargs):
     """
     Loader for MaNGA 3D rectified spectral data in FITS format.
 
@@ -58,14 +58,23 @@ def manga_cube_loader(filename, **kwargs):
         The spectrum contained in the file.
     """
 
-    with fits.open(filename, memmap=False) as hdulist:
-        spaxel = u.Unit('spaxel', represents=u.pixel, doc='0.5" spatial pixel', parse_strict='silent')
-        return _load_manga_spectra(hdulist, per_unit=spaxel, transpose=True)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist = file_obj
+    else:
+        hdulist = fits.open(file_obj, **kwargs)
+
+    spaxel = u.Unit('spaxel', represents=u.pixel, doc='0.5" spatial pixel', parse_strict='silent')
+    spectrum = _load_manga_spectra(hdulist, per_unit=spaxel, transpose=True)
+
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist.close()
+
+    return spectrum
 
 
 @data_loader("MaNGA rss", identifier=identify_manga_rss, dtype=Spectrum1D,
              extensions=['fits'])
-def manga_rss_loader(filename, **kwargs):
+def manga_rss_loader(file_obj, **kwargs):
     """
     Loader for MaNGA 2D row-stacked spectral data in FITS format.
 
@@ -80,9 +89,18 @@ def manga_rss_loader(filename, **kwargs):
         The spectrum contained in the file.
     """
 
-    with fits.open(filename, memmap=False) as hdulist:
-        fiber = u.Unit('fiber', represents=u.pixel, doc='spectroscopic fiber', parse_strict='silent')
-        return _load_manga_spectra(hdulist, per_unit=fiber)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist = file_obj
+    else:
+        hdulist = fits.open(file_obj, **kwargs)
+
+    fiber = u.Unit('fiber', represents=u.pixel, doc='spectroscopic fiber', parse_strict='silent')
+    spectrum = _load_manga_spectra(hdulist, per_unit=fiber)
+
+    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        hdulist.close()
+
+    return spectrum
 
 
 def _load_manga_spectra(hdulist, per_unit=None, transpose=None):

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -176,8 +176,8 @@ def identify_spectrum_format(filename):
 
     Given a filename, attempts to identify a valid file format
     from the list of registered specutils loaders.  Essentially a wrapper for
-    `~astropy.io.registry.identify_format` setting origin to ``read`` and
-    data_class to `~specutils.Spectrum1D`.
+    `~astropy.io.registry.identify_format` setting **origin** to ``read`` and
+    **data_class_required** to `~specutils.Spectrum1D`.
 
     Parameters
     ----------

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -8,12 +8,11 @@ import sys
 from functools import wraps
 
 from astropy.io import registry as io_registry
-from astropy.utils.data import get_readable_fileobj
 
 from ..spectra import Spectrum1D, SpectrumList
 
 
-__all__ = ['data_loader', 'custom_writer', 'get_loaders_by_extension']
+__all__ = ['data_loader', 'custom_writer', 'get_loaders_by_extension', 'identify_spectrum_format']
 
 
 def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
@@ -172,7 +171,7 @@ def _load_user_io():
                     pass
 
 
-def identify_spectrum_format(filename, cache=False):
+def identify_spectrum_format(filename):
     """ Attempt to identify a spectrum file format
 
     Given a filename, attempts to identify a valid file format
@@ -184,8 +183,6 @@ def identify_spectrum_format(filename, cache=False):
     ----------
     filename : str
         The absolute filename to the object
-    cache : bool
-        If True, caches the readable file object
 
     Returns
     -------
@@ -198,20 +195,9 @@ def identify_spectrum_format(filename, cache=False):
     if not isinstance(filename, (str, pathlib.Path)) or not os.path.isfile(filename):
         raise ValueError(f'{filename} is not a valid string path to a file')
 
-    # open the file
-    ctx = None
-    try:
-        ctx = get_readable_fileobj(str(filename), encoding='binary', cache=cache)
-        stream = ctx.__enter__()
-    except OSError:
-        raise
-    finally:
-        if ctx:
-            ctx.__exit__(*sys.exc_info())
-
     # identify the file format
     valid_format = io_registry.identify_format(
-        'read', Spectrum1D, filename, stream, {}, {})
+        'read', Spectrum1D, filename, None, {}, {})
 
     if valid_format and len(valid_format) == 1:
         return valid_format[0]

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -182,7 +182,7 @@ def identify_spectrum_format(filename, dtype=Spectrum1D):
     Parameters
     ----------
     filename : str
-        The absolute filename to the object
+        A path to a file to be identified
     dtype: object
         class type of Spectrum1D, SpectrumList, or SpectrumCollection. Default is
         Spectrum1D.

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -5,7 +5,7 @@ import os
 import logging
 from functools import wraps
 
-from astropy.io import registry as io_registry
+from astropy.io import registry as io_registry, fits
 
 from ..spectra import Spectrum1D, SpectrumList
 
@@ -167,3 +167,33 @@ def _load_user_io():
                     import_module(file[:-3])
                 except ModuleNotFoundError:  # noqa
                     pass
+
+
+def identify_spectrum_format(filename):
+    """ Attempt to identify a spectrum file format
+
+    Given a filename, attempts to identify a valid file format
+    from the list of registered specutils loaders.  Essentially a wrapper for
+    `~astropy.io.registry.identify_format` setting origin to `read` and
+    data_class to `Spectrum1D`.
+
+    Parameters
+    ----------
+    filename : str
+        The absolute filename to the object
+
+    Returns
+    -------
+    valid_format : list | str
+        A list of valid file formats.  If only one valid format found, returns
+        just that element.
+
+    """
+    stream = fits.open(filename)
+    valid_format = io_registry.identify_format(
+        'read', Spectrum1D, filename, stream, {}, {})
+
+    if valid_format and len(valid_format) == 1:
+        return valid_format[0]
+
+    return valid_format

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -9,7 +9,7 @@ from functools import wraps
 
 from astropy.io import registry as io_registry
 
-from ..spectra import Spectrum1D, SpectrumList
+from ..spectra import Spectrum1D, SpectrumList, SpectrumCollection
 
 
 __all__ = ['data_loader', 'custom_writer', 'get_loaders_by_extension', 'identify_spectrum_format']
@@ -171,7 +171,7 @@ def _load_user_io():
                     pass
 
 
-def identify_spectrum_format(filename):
+def identify_spectrum_format(filename, dtype=Spectrum1D):
     """ Attempt to identify a spectrum file format
 
     Given a filename, attempts to identify a valid file format
@@ -183,6 +183,9 @@ def identify_spectrum_format(filename):
     ----------
     filename : str
         The absolute filename to the object
+    dtype: object
+        class type of Spectrum1D, SpectrumList, or SpectrumCollection. Default is
+        Spectrum1D.
 
     Returns
     -------
@@ -195,9 +198,14 @@ def identify_spectrum_format(filename):
     if not isinstance(filename, (str, pathlib.Path)) or not os.path.isfile(filename):
         raise ValueError(f'{filename} is not a valid string path to a file')
 
+    # check for proper class type
+    assert dtype in \
+        [Spectrum1D, SpectrumList, SpectrumCollection], \
+        'dtype class must be either Spectrum1D, SpectrumList, or SpectrumCollection'
+
     # identify the file format
     valid_format = io_registry.identify_format(
-        'read', Spectrum1D, filename, None, {}, {})
+        'read', dtype, filename, None, {}, {})
 
     if valid_format and len(valid_format) == 1:
         return valid_format[0]

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -176,8 +176,8 @@ def identify_spectrum_format(filename):
 
     Given a filename, attempts to identify a valid file format
     from the list of registered specutils loaders.  Essentially a wrapper for
-    `~astropy.io.registry.identify_format` setting origin to `read` and
-    data_class to `Spectrum1D`.
+    `~astropy.io.registry.identify_format` setting origin to ``read`` and
+    data_class to `~specutils.Spectrum1D`.
 
     Parameters
     ----------
@@ -186,7 +186,7 @@ def identify_spectrum_format(filename):
 
     Returns
     -------
-    valid_format : list | str
+    valid_format : list, str
         A list of valid file formats.  If only one valid format found, returns
         just that element.
 

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -131,6 +131,28 @@ def test_hst_stis(remote_data_path):
 
 
 @pytest.mark.remote_data
+def test_manga_cube():
+    url = 'https://dr15.sdss.org/sas/dr15/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
+    spec = Spectrum1D.read(url, format='MaNGA cube')
+
+    assert isinstance(spec, Spectrum1D)
+    assert spec.flux.size > 0
+    assert spec.meta['header']['INSTRUME'] == 'MaNGA'
+    assert spec.shape == (34, 34, 4563)
+
+
+@pytest.mark.remote_data
+def test_manga_rss():
+    url = 'https://dr15.sdss.org/sas/dr15/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGRSS.fits.gz'
+    spec = Spectrum1D.read(url, format='MaNGA rss')
+
+    assert isinstance(spec, Spectrum1D)
+    assert spec.flux.size > 0
+    assert spec.meta['header']['INSTRUME'] == 'MaNGA'
+    assert spec.shape == (171, 4563)
+
+
+@pytest.mark.remote_data
 def test_sdss_spec():
     sp_pattern = 'spec-4055-55359-0596.fits.'
     with urllib.request.urlopen('https://dr14.sdss.org/optical/spectrum/view/data/format%3Dfits/spec%3Dlite?mjd=55359&fiberid=596&plateid=4055') as response:


### PR DESCRIPTION
This PR adds a new data loader for SDSS MaNGA cube and rss spectral data.  It also adds a convenience function, `io.registers.identify_spectrum_format` to identify a valid registered `specutils` file format given an input filename.  This function is essentially a wrapper for `astropy.io.registry.identify_format` setting origin to `read` and data_class to `Spectrum1D`.