### PR TITLE
Fix factor of two error in SpectralRegion.from_center

### DIFF
--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -42,16 +42,16 @@ class SpectralRegion:
            The center of the spectral region.
 
         width : Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
-           The width of the spectral region.
+           The full width of the spectral region (upper bound - lower bound).
         """
 
         if width.value <= 0:
             raise ValueError('SpectralRegion width must be positive.')
 
         if center.unit.physical_type != 'length':
-            return cls(center + width, center - width)
+            return cls(center + width/2, center - width/2)
 
-        return cls(center - width, center + width)
+        return cls(center - width/2, center + width/2)
 
     def __init__(self, *args):
         """

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -36,8 +36,8 @@ def test_from_center():
 
     # Spectral region from center with width
     sr = SpectralRegion.from_center(center=6563*u.AA, width=10*u.AA)
-    assert sr.lower == 6553.0*u.AA
-    assert sr.upper == 6573.0*u.AA
+    assert sr.lower == 6558.0*u.AA
+    assert sr.upper == 6568.0*u.AA
 
     # Check the exception if the width is negative.
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
The `SpectralRegion.from_center` method previously returned a region twice the size expected given the docs, which implied that the input was the full width of the region. I halved the input width in the calculations of the region upper and lower bounds so that the resulting width matches the input width, and made the language in the docs more explicit.