### PR TITLE
Fix the JWST x1d identifier

### DIFF
--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -20,8 +20,7 @@ def identify_jwst_x1d_fits(origin, *args, **kwargs):
     """
     is_jwst = _identify_jwst_fits(args[0])
     with fits.open(args[0], memmap=False) as hdulist:
-        return (is_jwst and 'EXTRACT1D' in hdulist and ('EXTRACT1D', 2) not in hdulist
-            and "SCI" not in hdulist)
+        return (is_jwst and 'EXTRACT1D' in hdulist and ('EXTRACT1D', 2) not in hdulist)
 
 
 def identify_jwst_x1d_multi_fits(origin, *args, **kwargs):
@@ -30,7 +29,7 @@ def identify_jwst_x1d_multi_fits(origin, *args, **kwargs):
     """
     is_jwst = _identify_jwst_fits(args[0])
     with fits.open(args[0], memmap=False) as hdulist:
-        return is_jwst and ('EXTRACT1D', 2) in hdulist and "SCI" not in hdulist
+        return is_jwst and ('EXTRACT1D', 2) in hdulist
 
 
 def identify_jwst_s2d_fits(origin, *args, **kwargs):


### PR DESCRIPTION
This PR fixes #714.  This removes the `SCI` constraint on the `identify_jwst_x1d_fits` function as this was interfering with the correct identification of x1d files downloaded from MAST.  Those files have a `SCI` extension preventing them from being correctly identified.  This fix should make this identifier either backwards or forwards compatible with new JWST x1d files, depending on if the MAST files are an older or newer version than when the identifier was originally written.  The null `EXTRACT1D` constraint on the `s3d` and `s2d` identifiers is enough to uniquely separate and identify files and avoid confusion between the 3 types. 

