### PR TITLE
Use read_fileobj_or_hdulist in all loaders and keep `gzip`, `bz2` file objects open in contextmanager

### DIFF
--- a/specutils/io/default_loaders/generic_cube.py
+++ b/specutils/io/default_loaders/generic_cube.py
@@ -14,23 +14,24 @@ from astropy.io import fits
 from astropy.units import Unit
 from astropy.wcs import WCS
 
-from ..registers import data_loader
 from ...spectra import Spectrum1D
+from ..registers import data_loader
+from ..parsing_utils import read_fileobj_or_hdulist
 
 
 # Define an optional identifier. If made specific enough, this circumvents the
 # need to add `format="my-format"` in the `Spectrum1D.read` call.
 def identify_generic_fits(origin, *args, **kwargs):
-    with fits.open(args[0]) as hdulist:
+    with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
         return (hdulist[0].header['NAXIS'] == 3)
 
 
 # not yet ready because it's not generic enough and does not use column_mapping
 # @data_loader("Cube", identifier=identify_generic_fits, extensions=['fits'])
-def generic_fits(file_name, **kwargs):
+def generic_fits(file_obj, **kwargs):
     name = os.path.basename(file_name.rstrip(os.sep)).rsplit('.', 1)[0]
 
-    with fits.open(file_name, **kwargs) as hdulist:
+    with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
         header = hdulist[0].header
         data3  = hdulist[0].data
         wcs    = WCS(header)

--- a/specutils/io/default_loaders/hst_cos.py
+++ b/specutils/io/default_loaders/hst_cos.py
@@ -4,19 +4,17 @@ from astropy.io import fits
 from astropy.units import Unit
 from astropy.nddata import StdDevUncertainty
 
-from specutils.io.registers import data_loader
-from specutils import Spectrum1D
+from ...spectra import Spectrum1D
+from ..registers import data_loader
+from ..parsing_utils import read_fileobj_or_hdulist
 
 __all__ = ['cos_identify', 'cos_spectrum_loader']
 
 
 def cos_identify(origin, *args, **kwargs):
     """Check whether given file contains HST/COS spectral data."""
-    with fits.open(args[0]) as hdulist:
-        if hdulist[0].header['TELESCOP'] == 'HST' and hdulist[0].header['INSTRUME'] == 'COS':
-            return True
-
-    return False
+    with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
+        return (hdulist[0].header['TELESCOP'] == 'HST' and hdulist[0].header['INSTRUME'] == 'COS')
 
 
 @data_loader(label="HST/COS", identifier=cos_identify, extensions=['FITS', 'FIT', 'fits', 'fit'])
@@ -35,28 +33,22 @@ def cos_spectrum_loader(file_obj, **kwargs):
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
     """
-    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist = file_obj
-    else:
-        hdulist = fits.open(file_obj, **kwargs)
 
-    header = hdulist[0].header
-    name = header.get('FILENAME')
-    meta = {'header': header}
+    with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
+        header = hdulist[0].header
+        name = header.get('FILENAME')
+        meta = {'header': header}
 
-    unit = Unit("erg/cm**2 Angstrom s")
-    disp_unit = Unit('Angstrom')
-    data = hdulist[1].data['FLUX'].flatten() * unit
-    dispersion = hdulist[1].data['wavelength'].flatten() * disp_unit
-    uncertainty = StdDevUncertainty(hdulist[1].data["ERROR"].flatten() * unit)
+        unit = Unit("erg/cm**2 Angstrom s")
+        disp_unit = Unit('Angstrom')
+        data = hdulist[1].data['FLUX'].flatten() * unit
+        dispersion = hdulist[1].data['wavelength'].flatten() * disp_unit
+        uncertainty = StdDevUncertainty(hdulist[1].data["ERROR"].flatten() * unit)
 
     sort_idx = dispersion.argsort()
     dispersion = dispersion[sort_idx]
     data = data[sort_idx]
     uncertainty = uncertainty[sort_idx]
-
-    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist.close()
 
     return Spectrum1D(flux=data,
                       spectral_axis=dispersion,

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -173,7 +173,7 @@ def _jwst_x1d_loader(file_obj, **kwargs):
             slit_header = hdu.header
             header = primary_header.copy()
             header.extend(slit_header, strip=True, update=True)
-            meta = {k: v for k, v in header.items()}
+            meta = dict(header)
 
             spec = Spectrum1D(flux=flux, spectral_axis=wavelength,
                               uncertainty=uncertainty, meta=meta)
@@ -312,7 +312,7 @@ def _jwst_s2d_loader(filename, **kwargs):
             slit_header = hdu.header
             header = primary_header.copy()
             header.extend(slit_header, strip=True, update=True)
-            meta = {k: v for k, v in header.items()}
+            meta = dict(header)
 
             spec = Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)
             spectra.append(spec)
@@ -396,7 +396,7 @@ def _jwst_s3d_loader(filename, **kwargs):
             slit_header = hdu.header
             header = primary_header.copy()
             header.extend(slit_header, strip=True, update=True)
-            meta = {k: v for k, v in header.items()}
+            meta = dict(header)
 
             spec = Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)
             spectra.append(spec)

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -9,6 +9,7 @@ from gwcs.wcstools import grid_from_bounding_box
 
 from ...spectra import Spectrum1D, SpectrumList
 from ..registers import data_loader
+from ..parsing_utils import read_fileobj_or_hdulist
 
 
 __all__ = ["jwst_x1d_single_loader", "jwst_x1d_multi_loader"]
@@ -18,8 +19,8 @@ def identify_jwst_x1d_fits(origin, *args, **kwargs):
     """
     Check whether the given file is a JWST x1d spectral data product.
     """
-    is_jwst = _identify_jwst_fits(args[0])
-    with fits.open(args[0], memmap=False) as hdulist:
+    is_jwst = _identify_jwst_fits(*args)
+    with read_fileobj_or_hdulist(*args, memmap=False, **kwargs) as hdulist:
         return (is_jwst and 'EXTRACT1D' in hdulist and ('EXTRACT1D', 2) not in hdulist)
 
 
@@ -27,8 +28,8 @@ def identify_jwst_x1d_multi_fits(origin, *args, **kwargs):
     """
     Check whether the given file is a JWST x1d spectral data product with many slits.
     """
-    is_jwst = _identify_jwst_fits(args[0])
-    with fits.open(args[0], memmap=False) as hdulist:
+    is_jwst = _identify_jwst_fits(*args)
+    with read_fileobj_or_hdulist(*args, memmap=False, **kwargs) as hdulist:
         return is_jwst and ('EXTRACT1D', 2) in hdulist
 
 
@@ -36,47 +37,47 @@ def identify_jwst_s2d_fits(origin, *args, **kwargs):
     """
     Check whether the given file is a JWST s2d spectral data product.
     """
-    is_jwst = _identify_jwst_fits(args[0])
-    with fits.open(args[0], memmap=False) as hdulist:
+    is_jwst = _identify_jwst_fits(*args)
+    with read_fileobj_or_hdulist(*args, memmap=False, **kwargs) as hdulist:
         return (is_jwst and "SCI" in hdulist and ("SCI", 2) not in hdulist
-            and "EXTRACT1D" not in hdulist and len(hdulist["SCI"].data.shape) == 2)
+                and "EXTRACT1D" not in hdulist and len(hdulist["SCI"].data.shape) == 2)
 
 
 def identify_jwst_s2d_multi_fits(origin, *args, **kwargs):
     """
     Check whether the given file is a JWST s2d spectral data product with many slits.
     """
-    is_jwst = _identify_jwst_fits(args[0])
-    with fits.open(args[0], memmap=False) as hdulist:
+    is_jwst = _identify_jwst_fits(*args)
+    with read_fileobj_or_hdulist(*args, memmap=False, **kwargs) as hdulist:
         return (is_jwst and ("SCI", 2) in hdulist and "EXTRACT1D" not in hdulist
-            and len(hdulist["SCI"].data.shape) == 2)
+                and len(hdulist["SCI"].data.shape) == 2)
 
 
 def identify_jwst_s3d_fits(origin, *args, **kwargs):
     """
     Check whether the given file is a JWST s3d spectral data product.
     """
-    is_jwst = _identify_jwst_fits(args[0])
-    with fits.open(args[0], memmap=False) as hdulist:
+    is_jwst = _identify_jwst_fits(*args)
+    with read_fileobj_or_hdulist(*args, memmap=False, **kwargs) as hdulist:
         return (is_jwst and "SCI" in hdulist and "EXTRACT1D" not in hdulist
-            and len(hdulist["SCI"].data.shape) == 3)
+                and len(hdulist["SCI"].data.shape) == 3)
 
 
-def _identify_jwst_fits(filename):
+def _identify_jwst_fits(*args):
     """
     Check whether the given file is a JWST data product.
     """
     try:
-        with fits.open(filename, memmap=False) as hdulist:
-            return "ASDF" in hdulist and hdulist[0].header["TELESCOP"] == "JWST"
+        with read_fileobj_or_hdulist(*args, memmap=False) as hdulist:
+            return "ASDF" in hdulist and hdulist[0].header.get("TELESCOP") == "JWST"
     # This probably means we didn't have a FITS file
     except Exception:
         return False
 
 
 @data_loader("JWST x1d", identifier=identify_jwst_x1d_fits, dtype=Spectrum1D,
-            extensions=['fits'])
-def jwst_x1d_single_loader(filename, **kwargs):
+             extensions=['fits'])
+def jwst_x1d_single_loader(file_obj, **kwargs):
     """
     Loader for JWST x1d 1-D spectral data in FITS format
 
@@ -90,40 +91,42 @@ def jwst_x1d_single_loader(filename, **kwargs):
     Spectrum1D
         The spectrum contained in the file.
     """
-    spectrum_list = _jwst_x1d_loader(filename, **kwargs)
+    spectrum_list = _jwst_x1d_loader(file_obj, **kwargs)
     if len(spectrum_list) == 1:
         return spectrum_list[0]
     else:
         raise RuntimeError(f"Input data has {len(spectrum_list)} spectra. "
-            "Use SpectrumList.read() instead.")
+                           "Use SpectrumList.read() instead.")
 
 
 @data_loader("JWST x1d multi", identifier=identify_jwst_x1d_multi_fits,
-            dtype=SpectrumList, extensions=['fits'])
-def jwst_x1d_multi_loader(filename, **kwargs):
+             dtype=SpectrumList, extensions=['fits'])
+def jwst_x1d_multi_loader(file_obj, **kwargs):
     """
     Loader for JWST x1d 1-D spectral data in FITS format
 
     Parameters
     ----------
-    filename : str
-        The path to the FITS file
+    file_obj: str, file-like, or HDUList
+          FITS file name, object (provided from name by Astropy I/O Registry),
+          or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------
     SpectrumList
         A list of the spectra that are contained in the file.
     """
-    return _jwst_x1d_loader(filename, **kwargs)
+    return _jwst_x1d_loader(file_obj, **kwargs)
 
 
-def _jwst_x1d_loader(filename, **kwargs):
+def _jwst_x1d_loader(file_obj, **kwargs):
     """Implementation of loader for JWST x1d 1-D spectral data in FITS format
 
     Parameters
     ----------
-    filename : str
-        The path to the FITS file
+    file_obj: str, file-like, or HDUList
+          FITS file name, object (provided from name by Astropy I/O Registry),
+          or HDUList (as resulting from astropy.io.fits.open()).
 
     Returns
     -------
@@ -133,7 +136,7 @@ def _jwst_x1d_loader(filename, **kwargs):
 
     spectra = []
 
-    with fits.open(filename, memmap=False) as hdulist:
+    with read_fileobj_or_hdulist(file_obj, memmap=False, **kwargs) as hdulist:
 
         primary_header = hdulist["PRIMARY"].header
 
@@ -163,24 +166,24 @@ def _jwst_x1d_loader(filename, **kwargs):
 
             else:
                 raise RuntimeError(f"Keyword SRCTYPE is {srctype}.  It should "
-                    "be 'POINT' or 'EXTENDED'. Can't decide between `flux` and "
-                    "`surf_bright` columns.")
+                                   "be 'POINT' or 'EXTENDED'. Can't decide between `flux` and "
+                                   "`surf_bright` columns.")
 
             # Merge primary and slit headers and dump into meta
             slit_header = hdu.header
             header = primary_header.copy()
             header.extend(slit_header, strip=True, update=True)
-            meta = {k: v for k,v in header.items()}
+            meta = {k: v for k, v in header.items()}
 
             spec = Spectrum1D(flux=flux, spectral_axis=wavelength,
-                uncertainty=uncertainty, meta=meta)
+                              uncertainty=uncertainty, meta=meta)
             spectra.append(spec)
 
     return SpectrumList(spectra)
 
 
 @data_loader("JWST s2d", identifier=identify_jwst_s2d_fits, dtype=Spectrum1D,
-            extensions=['fits'])
+             extensions=['fits'])
 def jwst_s2d_single_loader(filename, **kwargs):
     """
     Loader for JWST s2d 2D rectified spectral data in FITS format.
@@ -200,13 +203,13 @@ def jwst_s2d_single_loader(filename, **kwargs):
         return spectrum_list[0]
     elif len(spectrum_list) > 1:
         raise RuntimeError(f"Input data has {len(spectrum_list)} spectra. "
-            "Use SpectrumList.read() instead.")
+                           "Use SpectrumList.read() instead.")
     else:
         raise RuntimeError(f"Input data has {len(spectrum_list)} spectra.")
 
 
 @data_loader("JWST s2d multi", identifier=identify_jwst_s2d_multi_fits, dtype=SpectrumList,
-            extensions=['fits'])
+             extensions=['fits'])
 def jwst_s2d_multi_loader(filename, **kwargs):
     """
     Loader for JWST s2d 2D rectified spectral data in FITS format.
@@ -290,17 +293,17 @@ def _jwst_s2d_loader(filename, **kwargs):
                 # Make sure all rows are the same
                 if not (lam == wavelength_array).all():
                     raise RuntimeError("This 2D or 3D spectrum is not rectified "
-                        "and cannot be loaded into a Spectrum1D object.")
+                                       "and cannot be loaded into a Spectrum1D object.")
             elif dispaxis == 2:
                 flux_array = hdu.data.T
                 wavelength_array = lam[:, 0]
                 # Make sure all columns are the same
                 if not (lam.T == lam[None, :, 0]).all():
                     raise RuntimeError("This 2D or 3D spectrum is not rectified "
-                        "and cannot be loaded into a Spectrum1D object.")
+                                       "and cannot be loaded into a Spectrum1D object.")
             else:
                 raise RuntimeError("This 2D spectrum has an unknown dispaxis "
-                    "and cannot be loaded into a Spectrum1D object.")
+                                   "and cannot be loaded into a Spectrum1D object.")
 
             flux = Quantity(flux_array, unit=flux_unit)
             wavelength = Quantity(wavelength_array, unit=lam_unit)
@@ -309,7 +312,7 @@ def _jwst_s2d_loader(filename, **kwargs):
             slit_header = hdu.header
             header = primary_header.copy()
             header.extend(slit_header, strip=True, update=True)
-            meta = {k: v for k,v in header.items()}
+            meta = {k: v for k, v in header.items()}
 
             spec = Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)
             spectra.append(spec)
@@ -318,7 +321,7 @@ def _jwst_s2d_loader(filename, **kwargs):
 
 
 @data_loader("JWST s3d", identifier=identify_jwst_s3d_fits, dtype=Spectrum1D,
-            extensions=['fits'])
+             extensions=['fits'])
 def jwst_s3d_single_loader(filename, **kwargs):
     """
     Loader for JWST s3d 3D rectified spectral data in FITS format.
@@ -338,7 +341,7 @@ def jwst_s3d_single_loader(filename, **kwargs):
         return spectrum_list[0]
     elif len(spectrum_list) > 1:
         raise RuntimeError(f"Input data has {len(spectrum_list)} spectra. "
-            "Use SpectrumList.read() instead.")
+                           "Use SpectrumList.read() instead.")
     else:
         raise RuntimeError(f"Input data has {len(spectrum_list)} spectra.")
 
@@ -393,7 +396,7 @@ def _jwst_s3d_loader(filename, **kwargs):
             slit_header = hdu.header
             header = primary_header.copy()
             header.extend(slit_header, strip=True, update=True)
-            meta = {k: v for k,v in header.items()}
+            meta = {k: v for k, v in header.items()}
 
             spec = Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)
             spectra.append(spec)

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -173,7 +173,7 @@ def _jwst_x1d_loader(file_obj, **kwargs):
             slit_header = hdu.header
             header = primary_header.copy()
             header.extend(slit_header, strip=True, update=True)
-            meta = dict(header)
+            meta = {'header': header}
 
             spec = Spectrum1D(flux=flux, spectral_axis=wavelength,
                               uncertainty=uncertainty, meta=meta)
@@ -312,7 +312,7 @@ def _jwst_s2d_loader(filename, **kwargs):
             slit_header = hdu.header
             header = primary_header.copy()
             header.extend(slit_header, strip=True, update=True)
-            meta = dict(header)
+            meta = {'header': header}
 
             spec = Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)
             spectra.append(spec)
@@ -396,7 +396,7 @@ def _jwst_s3d_loader(filename, **kwargs):
             slit_header = hdu.header
             header = primary_header.copy()
             header.extend(slit_header, strip=True, update=True)
-            meta = dict(header)
+            meta = {'header': header}
 
             spec = Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)
             spectra.append(spec)

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -51,16 +51,9 @@ def manga_cube_loader(file_obj, **kwargs):
         The spectrum contained in the file.
     """
 
-    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist = file_obj
-    else:
-        hdulist = fits.open(file_obj, **kwargs)
-
     spaxel = u.Unit('spaxel', represents=u.pixel, doc='0.5" spatial pixel', parse_strict='silent')
-    spectrum = _load_manga_spectra(hdulist, per_unit=spaxel, transpose=True)
-
-    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist.close()
+    with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
+        spectrum = _load_manga_spectra(hdulist, per_unit=spaxel, transpose=True)
 
     return spectrum
 
@@ -83,16 +76,9 @@ def manga_rss_loader(file_obj, **kwargs):
         The spectrum contained in the file.
     """
 
-    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist = file_obj
-    else:
-        hdulist = fits.open(file_obj, **kwargs)
-
     fiber = u.Unit('fiber', represents=u.pixel, doc='spectroscopic fiber', parse_strict='silent')
-    spectrum = _load_manga_spectra(hdulist, per_unit=fiber)
-
-    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist.close()
+    with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
+        spectrum = _load_manga_spectra(hdulist, per_unit=fiber)
 
     return spectrum
 

--- a/specutils/io/default_loaders/subaru_pfs_spec.py
+++ b/specutils/io/default_loaders/subaru_pfs_spec.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from ...spectra import Spectrum1D
 from ..registers import data_loader
-from ..parsing_utils import _fits_identify_by_name
+from ..parsing_utils import _fits_identify_by_name, read_fileobj_or_hdulist
 
 __all__ = ['spec_identify', 'spec_loader']
 
@@ -51,6 +51,9 @@ def pfs_spec_loader(file_obj, **kwargs):
     data : Spectrum1D
         The spectrum that is represented by the data in this table.
     """
+
+    # This will fail for file-like objects without 'name' property like `bz2.BZ2File`,
+    # workarund needed (or better yet, a scheme to parse the `meta` items from the header).
     if isinstance(file_obj, str):
         file_name = file_obj
     else:
@@ -58,7 +61,7 @@ def pfs_spec_loader(file_obj, **kwargs):
 
     m = _spec_pattern.match(os.path.basename(file_name))
 
-    with fits.open(file_obj, **kwargs) as hdulist:
+    with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
         header = hdulist[0].header
         meta = {'header': header,
                 'tract': m['tract'],

--- a/specutils/io/default_loaders/tests/test_jwst_reader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_reader.py
@@ -132,8 +132,8 @@ def test_jwst_x1d_reader_meta(tmpdir, x1d_single):
     x1d_single.writeto(tmpfile)
 
     data = Spectrum1D.read(tmpfile)
-    assert ('TELESCOP', 'JWST') in data.meta.items()
-    assert ('SRCTYPE', 'POINT') in data.meta.items()
+    assert ('TELESCOP', 'JWST') in data.meta['header'].items()
+    assert ('SRCTYPE', 'POINT') in data.meta['header'].items()
 
 
 def test_jwst_x1d_single_reader_fail_on_multi(tmpdir, x1d_multi):

--- a/specutils/io/default_loaders/twoslaq_lrg.py
+++ b/specutils/io/default_loaders/twoslaq_lrg.py
@@ -1,36 +1,26 @@
-import astropy.io.fits as fits
 from astropy.units import Unit
 from astropy.wcs import WCS
-from specutils.io.registers import data_loader
-from specutils import Spectrum1D, SpectrumList
+
+from ...spectra import Spectrum1D, SpectrumList
+from ..registers import data_loader
+from ..parsing_utils import read_fileobj_or_hdulist
 
 
 def identify_2slaq_lrg(origin, *args, **kwargs):
     """
     Identify if the current file is a 2SLAQ-LRG file
     """
-    file_obj = args[0]
-    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist = file_obj
-    else:
-        hdulist = fits.open(file_obj, **kwargs)
-
-    if hdulist[0].header["MSTITLE"].startswith("2dF-SDSS LRG/QSO survey"):
-        # apparently the QSO part doesn't have MSTITLE, so we should be safe
-        # with just the above condition, but just in case, we know they have
-        # a different structure (LRG has one ext, QSO has more; LRG is 3d,
-        # QSO is 1d
-        if len(hdulist) == 1 and hdulist[0].data.ndim == 3:
-            if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
-                hdulist.close()
-            return True
-
-    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist.close()
-    return False
+    with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
+        if hdulist[0].header["MSTITLE"].startswith("2dF-SDSS LRG/QSO survey"):
+            # apparently the QSO part doesn't have MSTITLE, so we should be safe
+            # with just the above condition, but just in case, we know they have
+            # a different structure (LRG has one ext, QSO has more; LRG is 3d,
+            # QSO is 1d
+            if len(hdulist) == 1 and hdulist[0].data.ndim == 3:
+                return True
 
 
-@data_loader("2SLAQ-LRG", identifier=identify_2slaq_lrg,dtype=SpectrumList,
+@data_loader("2SLAQ-LRG", identifier=identify_2slaq_lrg, dtype=SpectrumList,
              extensions=["fit", "fits"])
 def twoslaq_lrg_fits_loader(file_obj, **kwargs):
     """
@@ -57,14 +47,11 @@ def twoslaq_lrg_fits_loader(file_obj, **kwargs):
     data: SpectrumList
         The 2SLAQ-LRG spectrum that is represented by the data in this file.
     """
-    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist = file_obj
-    else:
-        hdulist = fits.open(file_obj, **kwargs)
 
-    header = hdulist[0].header
-    spectrum = hdulist[0].data[0,0] * Unit("count/s")
-    sky = hdulist[0].data[1,0] * Unit("count/s")
+    with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
+        header = hdulist[0].header
+        spectrum = hdulist[0].data[0, 0] * Unit("count/s")
+        sky = hdulist[0].data[1, 0] * Unit("count/s")
 
     # Due to the odd structure of the file, the WCS needs to be read in
     # manually
@@ -75,9 +62,6 @@ def twoslaq_lrg_fits_loader(file_obj, **kwargs):
     wcs.wcs.cunit[0] = Unit("Angstrom")
 
     meta = {"header": header}
-
-    if not isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        hdulist.close()
 
     return SpectrumList([
         Spectrum1D(flux=spectrum, wcs=wcs, meta=meta),

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -24,6 +24,7 @@ def read_fileobj_or_hdulist(*args, **kwargs):
     -------
     hdulist : `astropy.io.fits.HDUList`
         Provides a generator-iterator representing the open file object handle.
+    """
     # Access the fileobj or filename arg
     # Do this so identify functions are useable outside of Spectrum1d.read context
     try:

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -20,9 +20,10 @@ from specutils.spectra import Spectrum1D, SpectrumCollection
 def read_fileobj_or_hdulist(*args, **kwargs):
     """ Context manager for reading a filename or file object
 
-    Returns:
-        an Astropy HDUList
-    """
+    Returns
+    -------
+    hdulist : `astropy.io.fits.HDUList`
+        Provides a generator-iterator representing the open file object handle.
     # Access the fileobj or filename arg
     # Do this so identify functions are useable outside of Spectrum1d.read context
     try:

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -72,7 +72,7 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
         unit for the file column (or ``None`` to take unit from the table)::
 
             column_mapping = {'FLUX': ('flux', 'Jy'),
-                              'WAVE': ('spectral_axis', 'um')}
+                              'WAVE': ('spectral_axis'spectral_axisu', 'um')}
 
     wcs : :class:`~astropy.wcs.WCS` or :class:`gwcs.WCS`
         WCS object passed to the Spectrum1D initializer.
@@ -80,7 +80,8 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
     Returns
     -------
     :class:`~specutils.Spectrum1D`
-        The spectrum that is represented by the data in this table.
+        The spectrum with 'spectral_axis', 'flux' and optionally 'uncertainty'
+        as identified by `column_mapping`.
     """
     spec_kwargs = {}
 
@@ -121,6 +122,10 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
             # This may be desired e.g. for the mask or bit flag arrays.
             kwarg_val = table[col_name]
 
+        # Transpose > 1D data to row-major format
+        if kwarg_val.ndim > 1:
+            kwarg_val = kwarg_val.T
+
         spec_kwargs.setdefault(kwarg_name, kwarg_val)
 
     # Ensure that the uncertainties are a subclass of NDUncertainty
@@ -156,7 +161,8 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
     Returns
     -------
     :class:`~specutils.Spectrum1D`
-        The spectrum that is represented by the data in this table.
+        The spectrum that is represented by the data from the columns
+        as automatically identified above.
 
     Raises
     ------

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -22,7 +22,7 @@ def read_fileobj_or_hdulist(*args, **kwargs):
 
     Returns
     -------
-    hdulist : `astropy.io.fits.HDUList`
+    hdulist : :class:`~astropy.io.fits.HDUList`
         Provides a generator-iterator representing the open file object handle.
     """
     # Access the fileobj or filename arg
@@ -76,6 +76,11 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
 
     wcs : :class:`~astropy.wcs.WCS` or :class:`gwcs.WCS`
         WCS object passed to the Spectrum1D initializer.
+
+    Returns
+    -------
+    :class:`~specutils.Spectrum1D`
+        The spectrum that is represented by the data in this table.
     """
     spec_kwargs = {}
 
@@ -123,7 +128,7 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
         spec_kwargs['uncertainty'] = StdDevUncertainty(
             spec_kwargs.get('uncertainty'))
 
-    return Spectrum1D(**spec_kwargs, wcs=wcs, meta=table.meta)
+    return Spectrum1D(**spec_kwargs, wcs=wcs, meta={'header': table.meta})
 
 
 def generic_spectrum_from_table(table, wcs=None, **kwargs):
@@ -150,7 +155,7 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
 
     Returns
     -------
-    data: Spectrum1D
+    :class:`~specutils.Spectrum1D`
         The spectrum that is represented by the data in this table.
 
     Raises
@@ -273,7 +278,7 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
     if wcs is not None or spectral_axis_column is not None and flux_column is not None:
         # For > 1D spectral axis transpose to row-major format and return SpectrumCollection
         spectrum = Spectrum1D(flux=flux, spectral_axis=spectral_axis,
-                              uncertainty=err, meta=table.meta, wcs=wcs)
+                              uncertainty=err, meta={'header': table.meta}, wcs=wcs)
 
     return spectrum
 


### PR DESCRIPTION
This PR should fix the remaining `Cannot read from/write to a closed file-like object`  (`<bz2.BZ2 >`, `<gzip >`) failures  on loading an auto-detected FITS format after #702 including the `xfails` left after #717, i.e. resolve #711.

`read_fileobj_or_hdulist` was modified along the _second_ suggestion in https://github.com/astropy/specutils/issues/711#issuecomment-694931263, keeping any generic file-type objects open and rewinding them to beginning of file as required/supported. This will allow the loaders to continue using the open file handles rather then starting again with file names, which has the advantage of keeping the automatic decompression support provided by I/O Registry.
It is put into a `finally:` because some identifier functions simply raise an exception on a non-matching format.

I have also switched all the `fits.open` operations in `default_loaders` to use this context manager added by @havok2063, which cleans up code quite a bit and should allow us to maintain file handling issues in one central place.
I only partly converted `jwst_reader` (only the pure FITS operations) in a separate commit, as I'd rather wait for advice from @jdavies-st before touching any ASDF-related code.

One note on the `xz` support from `~astropy.io.registry` on systems built with `lzma`: since this is only provided through the registry, while `io.fits` does not support this format natively, this currently puts us in the strange situation that it is _only_ supported when using automatic format detection, not when directly calling the loader with a given format. If anyone has advice how to always use the registry, I'd be happy to change that.