### PR TITLE
Fix radial velocity/redshift setting

### DIFF
--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -84,5 +84,5 @@ class SpectralAxis(SpectralCoord):
     def with_radial_velocity_shift(self, target_shift=None, observer_shift=None):
         if self.unit is u.pixel:
             raise u.UnitsError("Cannot transform spectral coordinates in pixel units")
-        super().with_radial_velocity_shift(target_shift=target_shift,
-                                           observer_shift=observer_shift)
+        return super().with_radial_velocity_shift(target_shift=target_shift,
+                                                  observer_shift=observer_shift)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -376,7 +376,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
 
     @redshift.setter
     def redshift(self, val):
-        new_spec_coord = self.spectral_axis.with_redshift(val)
+        new_spec_coord = self.spectral_axis.with_radial_velocity_shift(val)
         self._spectral_axis = new_spec_coord
 
     @property
@@ -397,7 +397,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             if not val.unit.is_equivalent(u.km/u.s):
                 raise u.UnitsError("Radial velocity must be a velocity.")
 
-        new_spectral_axis = self.spectral_axis.with_radial_velocity(val)
+        new_spectral_axis = self.spectral_axis.with_radial_velocity_shift(val)
         self._spectral_axis = new_spectral_axis
 
     def __add__(self, other):

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -376,7 +376,8 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
 
     @redshift.setter
     def redshift(self, val):
-        new_spec_coord = self.spectral_axis.with_radial_velocity_shift(val)
+        new_spec_coord = self.spectral_axis.with_radial_velocity_shift(
+            val - self.spectral_axis.redshift)
         self._spectral_axis = new_spec_coord
 
     @property
@@ -397,7 +398,8 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             if not val.unit.is_equivalent(u.km/u.s):
                 raise u.UnitsError("Radial velocity must be a velocity.")
 
-        new_spectral_axis = self.spectral_axis.with_radial_velocity_shift(val)
+        new_spectral_axis = self.spectral_axis.with_radial_velocity_shift(
+            val - self.spectral_axis.radial_velocity)
         self._spectral_axis = new_spectral_axis
 
     def __add__(self, other):

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -377,7 +377,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     @redshift.setter
     def redshift(self, val):
         new_spec_coord = self.spectral_axis.with_radial_velocity_shift(
-            val - self.spectral_axis.redshift)
+            -self.spectral_axis.radial_velocity).with_radial_velocity_shift(val)
         self._spectral_axis = new_spec_coord
 
     @property
@@ -399,7 +399,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
                 raise u.UnitsError("Radial velocity must be a velocity.")
 
         new_spectral_axis = self.spectral_axis.with_radial_velocity_shift(
-            val - self.spectral_axis.radial_velocity)
+            -self.spectral_axis.radial_velocity).with_radial_velocity_shift(val)
         self._spectral_axis = new_spectral_axis
 
     def __add__(self, other):

--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -10,6 +10,9 @@ from astropy.coordinates import (SkyCoord, EarthLocation, ICRS, GCRS, Galactic,
 
 from ..extern.spectralcoord import SpectralCoord
 from ..spectra.spectral_axis import SpectralAxis
+from ..spectra.spectrum1d import Spectrum1D
+
+from astropy.tests.helper import assert_quantity_allclose
 
 
 def get_greenwich_earthlocation():
@@ -121,3 +124,27 @@ def test_create_from_spectral_axis(observer, target):
     assert spec_axis1.radial_velocity == spec_axis2.radial_velocity
     assert spec_axis1.doppler_convention == spec_axis2.doppler_convention
     assert spec_axis1.doppler_rest == spec_axis2.doppler_rest
+
+
+def test_change_radial_velocity():
+    wave = np.linspace(100, 200, 100) * u.AA
+    flux = np.ones(100) * u.one
+    spec = Spectrum1D(spectral_axis=wave, flux=flux, radial_velocity=0 * u.km / u.s)
+
+    assert spec.radial_velocity == 0 * u.km/u.s
+
+    spec.radial_velocity = 1 * u.km / u.s
+
+    assert spec.radial_velocity == 1 * u.km/u.s
+
+
+def test_change_redshift():
+    wave = np.linspace(100, 200, 100) * u.AA
+    flux = np.ones(100) * u.one
+    spec = Spectrum1D(spectral_axis=wave, flux=flux, redshift=0)
+
+    assert_quantity_allclose(spec.redshift, u.Quantity(0))
+
+    spec.redshift = 0.1
+
+    assert_quantity_allclose(spec.redshift, u.Quantity(0.1))

--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -129,7 +129,8 @@ def test_create_from_spectral_axis(observer, target):
 def test_change_radial_velocity():
     wave = np.linspace(100, 200, 100) * u.AA
     flux = np.ones(100) * u.one
-    spec = Spectrum1D(spectral_axis=wave, flux=flux, radial_velocity=0 * u.km / u.s)
+    spec = Spectrum1D(spectral_axis=wave, flux=flux,
+                      radial_velocity=0 * u.km / u.s)
 
     assert spec.radial_velocity == 0 * u.km/u.s
 
@@ -137,14 +138,39 @@ def test_change_radial_velocity():
 
     assert spec.radial_velocity == 1 * u.km/u.s
 
+    spec = Spectrum1D(spectral_axis=wave, flux=flux,
+                      radial_velocity=10 * u.km / u.s)
+
+    assert spec.radial_velocity == 10 * u.km / u.s
+
+    spec.radial_velocity = 5 * u.km / u.s
+
+    assert spec.radial_velocity == 5 * u.km / u.s
+
 
 def test_change_redshift():
     wave = np.linspace(100, 200, 100) * u.AA
     flux = np.ones(100) * u.one
     spec = Spectrum1D(spectral_axis=wave, flux=flux, redshift=0)
 
+    assert spec.redshift.unit.physical_type == 'dimensionless'
     assert_quantity_allclose(spec.redshift, u.Quantity(0))
+    assert type(spec.spectral_axis) == SpectralAxis
 
     spec.redshift = 0.1
 
+    assert spec.redshift.unit.physical_type == 'dimensionless'
     assert_quantity_allclose(spec.redshift, u.Quantity(0.1))
+    assert type(spec.spectral_axis) == SpectralAxis
+
+    spec = Spectrum1D(spectral_axis=wave, flux=flux, redshift=0.2)
+
+    assert spec.redshift.unit.physical_type == 'dimensionless'
+    assert_quantity_allclose(spec.redshift, u.Quantity(0.2))
+    assert type(spec.spectral_axis) == SpectralAxis
+
+    spec.redshift = 0.4
+
+    assert spec.redshift.unit.physical_type == 'dimensionless'
+    assert_quantity_allclose(spec.redshift, u.Quantity(0.4))
+    assert type(spec.spectral_axis) == SpectralAxis


### PR DESCRIPTION
Fixes #721. This PR addresses the issue in the transition to using `SpectralAxis` which broke the property setters on the `Spectrum1D` object.