### PR TITLE
Fix region extraction from Spectrum1D objects with multi-D flux

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Fix ``extract_region`` behavior and slicing for ``Spectrum1D`` objects
+  that have multi-dimensional flux arrays. Extracting a region that extends
+  beyond the limits of the data no longer drops the last data point in the
+  returned spectrum. [#724]
+
 Documentation
 ^^^^^^^^^^^^^
 

--- a/docs/manipulation.rst
+++ b/docs/manipulation.rst
@@ -267,7 +267,7 @@ the line:
     >>> noise_region = SpectralRegion([(10, 7), (3, 0)] * u.GHz)
     >>> spec_w_unc = noise_region_uncertainty(noisy_gaussian, noise_region)
     >>> spec_w_unc.uncertainty # doctest: +ELLIPSIS
-    StdDevUncertainty([0.18823157, ..., 0.18823157])
+    StdDevUncertainty([0.1886835, ..., 0.1886835])
 
 Or similarly, expressed in pixels:
 

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -51,7 +51,7 @@ def _to_edge_pixel(subregion, spectrum):
         if left_reg_in_spec_unit < spectral_axis[0]:
             left_index = 0
         elif left_reg_in_spec_unit > spectral_axis[-1]:
-            left_index = len(spectrum.spectral_axis)-1
+            left_index = len(spectrum.spectral_axis)
         else:
             try:
                 left_index = int(np.ceil(spectrum.wcs.world_to_pixel(
@@ -74,7 +74,7 @@ def _to_edge_pixel(subregion, spectrum):
                                                  u.spectral())
 
         if right_reg_in_spec_unit > spectral_axis[-1]:
-            right_index = len(spectrum.spectral_axis)-1
+            right_index = len(spectrum.spectral_axis)
         elif right_reg_in_spec_unit < spectral_axis[0]:
             right_index = 0
         else:
@@ -99,13 +99,17 @@ def extract_region(spectrum, region):
 
     Parameters
     ----------
-    spectrum: `~specutils.spectra.spectrum1d.Spectrum1D`
+    spectrum: `~specutils.Spectrum1D`
         The spectrum object from which the region will be extracted.
+
+    region: `~specutils.SpectralRegion`
+        The spectral region to extract from the original spectrum.
 
     Returns
     -------
-    spectrum: `~specutils.spectra.spectrum1d.Spectrum1D`
-        Excised spectrum.
+    spectrum: `~specutils.Spectrum1D` or list of `~specutils.Spectrum1D`
+        Excised spectrum, or list of spectra if the input region contained multiple 
+        subregions.
 
     Notes
     -----

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -108,7 +108,7 @@ def extract_region(spectrum, region):
     Returns
     -------
     spectrum: `~specutils.Spectrum1D` or list of `~specutils.Spectrum1D`
-        Excised spectrum, or list of spectra if the input region contained multiple 
+        Excised spectrum, or list of spectra if the input region contained multiple
         subregions.
 
     Notes

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -149,7 +149,18 @@ def extract_region(spectrum, region):
             if left_index > right_index:
                 left_index, right_index = right_index, left_index
 
-            extracted_spectrum.append(spectrum[left_index:right_index])
+            sub_spec = Spectrum1D(
+                        spectral_axis=spectrum.spectral_axis[left_index:right_index],
+                        flux=spectrum.flux[...,left_index:right_index],
+                        meta=spectrum.meta)
+
+            if spectrum.mask is not None:
+                sub_spec.mask=np.array(spectrum.mask)[...,left_index:right_index]
+
+            if spectrum.uncertainty is not None:
+                sub_spec.uncertainty=spectrum.uncertainty[...,left_index:right_index]
+
+            extracted_spectrum.append(sub_spec)
 
     # If there is only one subregion in the region then we will
     # just return a spectrum.

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -149,18 +149,7 @@ def extract_region(spectrum, region):
             if left_index > right_index:
                 left_index, right_index = right_index, left_index
 
-            sub_spec = Spectrum1D(
-                        spectral_axis=spectrum.spectral_axis[left_index:right_index],
-                        flux=spectrum.flux[...,left_index:right_index],
-                        meta=spectrum.meta)
-
-            if spectrum.mask is not None:
-                sub_spec.mask=np.array(spectrum.mask)[...,left_index:right_index]
-
-            if spectrum.uncertainty is not None:
-                sub_spec.uncertainty=spectrum.uncertainty[...,left_index:right_index]
-
-            extracted_spectrum.append(sub_spec)
+            extracted_spectrum.append(spectrum[..., left_index:right_index])
 
     # If there is only one subregion in the region then we will
     # just return a spectrum.

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -246,9 +246,26 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         The first case is handled by the parent class, while the second is
         handled here.
         """
-        if len(self.flux.shape) > 1:
+
+        if self.flux.ndim > 1 or (type(item) == tuple and item[0] == Ellipsis):
+            if type(item) == tuple:
+                if len(item) == len(self.flux.shape) or item[0] == Ellipsis:
+                    spec_item = item[-1]
+                    if not isinstance(spec_item, slice):
+                        spec_item = slice(spec_item, spec_item+1, None)
+                        item = item[:-1] + (spec_item,)
+                else:
+                    # Slicing on less than the full number of axes means we want
+                    # to keep the whole spectral axis
+                    spec_item = slice(None, None, None)
+            else:
+                # Slicing with a single integer or slice uses the leading axis,
+                # so we keep the whole spectral axis, which is last
+                spec_item = slice(None, None, None)
+
             return self._copy(
                 flux=self.flux[item],
+                spectral_axis=self.spectral_axis[spec_item],
                 uncertainty=self.uncertainty[item]
                 if self.uncertainty is not None else None,
                 mask=self.mask[item] if self.mask is not None else None)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -307,6 +307,17 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
 
         return self.__class__(**alt_kwargs)
 
+    @NDDataRef.mask.setter
+    def mask(self, value):
+        # Impose stricter checks than the base NDData mask setter
+        if value is not None:
+            value = np.array(value)
+            if not self.data.shape == value.shape:
+                raise ValueError(
+                    "Flux axis ({}) and mask ({}) shapes must be the "
+                    "same.".format(self.data.shape, value.shape))
+        self._mask = value
+
     @property
     def frequency(self):
         """

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -200,3 +200,14 @@ def test_extract_masked():
 
     assert np.all(extracted.mask == [False, True])
     assert np.all(extracted.flux.value == [1, 2])
+
+def test_extract_multid_flux():
+    flux = np.random.sample((10, 49)) * 100
+    spec = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm,
+                      flux=flux * u.Jy)
+
+    region = SpectralRegion(10 * u.nm, 20 * u.nm)
+    extracted = extract_region(spec, region)
+
+    assert extracted.shape == (10, 11)
+    assert extracted[0,0].flux == spec[0,9].flux

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -66,6 +66,14 @@ def test_region_simple_check_ends(simulated_spectra):
     assert sub_spectrum.spectral_axis.value[0] == 8
     assert sub_spectrum.spectral_axis.value[-1] == 15
 
+    region = SpectralRegion(0*u.um, 15*u.um)
+    sub_spectrum = extract_region(spectrum, region)
+    assert sub_spectrum.spectral_axis.value[0] == 1
+
+    region = SpectralRegion(8*u.um, 30*u.um)
+    sub_spectrum = extract_region(spectrum, region)
+    assert sub_spectrum.spectral_axis.value[-1] == 25
+
 
 def test_region_empty(simulated_spectra):
     np.random.seed(42)


### PR DESCRIPTION
I believe this fixes #690. I think I got the keywords that should be propagated through, but may have missed something.