### PR TITLE
Remove unnecessary spectral axis reshaping in tabular_fits writer

### DIFF
--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -167,21 +167,10 @@ def tabular_fits_writer(spectrum, file_name, hdu=1, update_header=False, **kwarg
         columns.append(unc.astype(ftype))
         colnames.append("uncertainty")
 
-    # For 2D data transpose from row-major format
-    ndim = 1
-
+    # For > 1D data transpose from row-major format
     for c in range(1, len(columns)):
         if columns[c].ndim > 1:
-            ndim = columns[c].ndim
             columns[c] = columns[c].T
-
-    if ndim > 1:
-        spec_shape = np.ones(ndim, dtype=np.int)
-        spec_shape[0] = -1
-
-        for c in range(1, len(columns)):
-            if columns[c].ndim == 1:
-                columns[c] = columns[c].reshape(spec_shape)
 
     tab = Table(columns, names=colnames, meta=header)
 


### PR DESCRIPTION
I'm sure there was good reason for this code, but at present it seems unnecessary (perhaps due to astropy updates?). Tables are perfectly happy with columns of differing shapes, and without the removed code the 1D spectral axis properly round trips through write/read, whereas with the code the round-tripped spectrum was ending up with a 2D spectral axis.

Fixes the test failures in #718 (and the same failures elsewhere, but currently I care about that PR!) and closes #729 