### PR TITLE
Fix linkcheck error and include py39

### DIFF
--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -33,7 +33,7 @@ def centroid(spectrum, region):
     -----
     The spectrum will need to be continuum subtracted before calling
     this method. See the
-    `analysis documentation <https://specutils.readthedocs.io/en/latest/basic_analysis.html>`_ for more information.
+    `analysis documentation <https://specutils.readthedocs.io/en/latest/analysis.html>`_ for more information.
 
     """
 

--- a/specutils/manipulation/smoothing.py
+++ b/specutils/manipulation/smoothing.py
@@ -23,7 +23,7 @@ def convolution_smooth(spectrum, kernel):
     below.
 
     If the spectrum uncertainty exists and is ``StdDevUncertainty``,
-    ``VarianceUncertainty`` or ``InverseVariance``then the errors will be
+    ``VarianceUncertainty`` or ``InverseVariance`` then the errors will be
     propagated through the convolution using a standard propagation of errors.
     The covariance is not considered, currently.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38}-test-numpy{116,117,118}
-    py{36,37,38}-test-astropy{30,40,lts}
-    py{36,37,38}-test-external
+    py{36,37,38,39}-test{,-alldeps,-devdeps}{,-cov}
+    py{36,37,38,39}-test-numpy{116,117,118}
+    py{36,37,38,39}-test-astropy{30,40,lts}
+    py{36,37,38,39}-test-external
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
This fixes one of the linkcheck errors and adds py39 to tox. Depending on the openssl settings that the CI runs under, links to SDSS may not work as they need to update their webserver settings (see https://ssl-config.mozilla.org/)