### PR TITLE
Stop fast-failing for now

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -11,7 +11,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
 


### PR DESCRIPTION
It appears that the docs having issues with links causes all the tests to be skipped. Hopefully removing fast-failing fixes this.

#751 is where I'm trying to fix the link errors.