### PR TITLE
Subclass Spectrum1D from NDCube instead of NDDataRef

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -58,12 +58,6 @@ jobs:
             toxenv: py37-test-alldeps
             toxposargs: --durations=50
 
-          - name: Python 3.6 with astropy LTS
-            os: ubuntu-16.04
-            python: 3.6
-            toxenv: py36-test-astropylts-numpy116
-            toxposargs: --remote-data=astropy
-
           - name: Python 3.7 doc build
             os: ubuntu-latest
             python: 3.7

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -32,6 +32,12 @@ py:obj ndcube.NDCube.world_axis_physical_types
 py:obj specutils.Spectrum1D.crop
 py:obj pixel_edges
 py:obj pixel_values
+py:obj ndcube.NDCube.wcs.world_axis_physical_types
+py:obj ndcube.NDCubeSequence
+py:obj sunpy.visualization.animator.ArrayAnimatorWCS
+py:obj ndcube.mixins.plotting.NDCubePlotMixin.plot
+py:obj matplotllib.pyplot.imshow
+py:obj matplotllib.pyplot.plot
 
 # SpectralAxis inherits methods which have warnings we can't fix here.
 # FIXME: https://github.com/astropy/sphinx-automodapi/issues/101

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -18,6 +18,19 @@ py:obj SpectralCoord
 py:obj SpectralQuantity
 py:obj SkyCoord
 
+# Super class for Spectrum1D for which we don't control the API links.
+py:class ndcube.ndcube.NDCube
+py:class ndcube.ndcube.NDCubeBase
+py:class ndcube.ndcube.NDCubeABC
+py:class ndcube.mixins.plotting.NDCubePlotMixin
+py:class ndcube.mixins.ndslicing.NDCubeSlicingMixin
+py:obj ndcube.NDCube
+py:obj NDCube
+py:obj ExtraCoords
+py:obj GlobalCoords
+py:obj ndcube.NDCube.world_axis_physical_types
+py:obj specutils.Spectrum1D.crop
+
 # SpectralAxis inherits methods which have warnings we can't fix here.
 # FIXME: https://github.com/astropy/sphinx-automodapi/issues/101
 py:obj Quantity

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -30,6 +30,8 @@ py:obj ExtraCoords
 py:obj GlobalCoords
 py:obj ndcube.NDCube.world_axis_physical_types
 py:obj specutils.Spectrum1D.crop
+py:obj pixel_edges
+py:obj pixel_values
 
 # SpectralAxis inherits methods which have warnings we can't fix here.
 # FIXME: https://github.com/astropy/sphinx-automodapi/issues/101

--- a/docs/spectral_cube.rst
+++ b/docs/spectral_cube.rst
@@ -3,7 +3,13 @@ Working with Spectral Cubes
 ###########################
 
 Spectral cubes can be read directly with :class:`~specutils.Spectrum1D`.
-A specific example of this is demonstrated here.
+A specific example of this is demonstrated here. In addition to the functions
+demonstrated below, as a subclass of `NDCube <https://github.com/sunpy/ndcube>`_, 
+:class:`~specutils.Spectrum1D` also inherits useful methods for e.g. cropping 
+based on combinations of world and spectral coordinates. Most of the 
+functionality inherited from `~ndcube.NDCube` requires initializing the 
+``Spectrum1D`` object with a WCS describing the coordinates for all axes of 
+the data.
 
 Note that the workflow described here is for spectral cubes that are rectified
 such that one of the axes is entirely spectral and all the spaxels have the same

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -10,7 +10,7 @@ This section describes some of the basic features of this class.
 Basic Spectrum Creation
 -----------------------
 
-The simplest (and most powerful) way to create a `~specutils.Spectrum1D` is to
+The simplest way to create a `~specutils.Spectrum1D` is to
 create it explicitly from arrays or `~astropy.units.Quantity` objects:
 
 .. plot::

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -213,10 +213,8 @@ along the spectral axis using world coordinates.
     >>> spec_slice.spectral_axis
     <SpectralAxis [5002., 5003., 5004., 5005.] Angstrom>
 
-Note that slicing on world coordinates for axes other than the spectral axis is
-not currently supported. It is, however, possible to slice on other axes using 
-simple array indices at the same time as slicing the spectral axis based on 
-spectral values.
+It is also possible to slice on other axes using simple array indices at the 
+same time as slicing the spectral axis based on spectral values.
 
 .. code-block:: python
 
@@ -226,6 +224,23 @@ spectral values.
     >>> spec_slice = spec[2:4, 5002*u.AA:5006*u.AA]
     >>> spec_slice.shape
     (2, 4)
+
+If the `specutils.Spectrum1D` was created with a WCS that included spatial 
+information, for example in case of a spectral cube with two spatial dimensions,
+the `specutils.Spectrum1D.crop` method can be used to subset the data based on
+the world coordinates. The inputs required are two sets up `astropy.coordinates`
+objects defining the upper and lower corner of the region desired. Note that if
+one of the coordinates is decreasing along an axis, the higher world coordinate
+value will apply to the lower bound input.
+
+.. code-block:: python
+    
+    >>> from astropy.coordinates import SpectralCoord, SkyCoord
+    >>> import astropy.units as u
+
+    >>> lower = [SkyCoord(ra=201.1, dec=27.5, unit=u.deg), SpectralCoord(3000, unit=u.AA)]
+    >>> upper = [SkyCoord(ra=201.08, dec=27.52, unit=u.deg), SpectralCoord(3100, unit=u.AA)]
+    >>> cropped_spec = spec.crop(lower, upper) #doctest:+SKIP
 
 
 Reference/API

--- a/docs/types_of_spectra.rst
+++ b/docs/types_of_spectra.rst
@@ -31,7 +31,9 @@ with their corresponding ``specutils`` representations:
    ``n x m (x ...)``,  with a spectral axis strictly of length ``n`` (and a
    matched WCS). In ``specutils`` this is represented by the
    `~specutils.Spectrum1D` object where ``len(flux.shape) > 1`` . In this sense
-   the "1D" refers to the spectral axis, *not* the flux.
+   the "1D" refers to the spectral axis, *not* the flux. Note that 
+   `~specutils.Spectrum1D` subclasses `NDCube <https://github.com/sunpy/ndcube>`_,
+   which provideds utilities useful for these sorts of multidimensional fluxes.
 3. A set of fluxes  of shape ``n x m (x ...)``, and a set of spectral axes that
    are the same shape. This is distinguished from the above cases because there
    are as many spectral axes as there are spectra.  In this sense it is a

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = astropy/specutils
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     astropy>=4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     gwcs!=0.16.0
     scipy
     asdf>=2.5
-    ndcube
+    ndcube@git+https://github.com/sunpy/ndcube.git@947799ea213728d6215cb791508ef186ca53b24f
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     gwcs!=0.16.0
     scipy
     asdf>=2.5
+    ndcube
 
 [options.extras_require]
 test =

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -45,7 +45,6 @@ def _to_edge_pixel(subregion, spectrum):
     if subregion[0].unit.is_equivalent(u.pix):
         left_index = floor(subregion[0].value)
     else:
-
         # Convert lower value to spectrum spectral_axis units
         left_reg_in_spec_unit = subregion[0].to(spectral_axis.unit,
                                                 u.spectral())
@@ -56,8 +55,11 @@ def _to_edge_pixel(subregion, spectrum):
             left_index = len(spectrum.spectral_axis)
         else:
             try:
-                left_index = int(np.ceil(spectrum.wcs.world_to_pixel(
-                    left_reg_in_spec_unit)))
+                if hasattr(spectrum.wcs, "spectral"):
+                    left_index = spectrum.wcs.spectral.world_to_pixel(left_reg_in_spec_unit)
+                else:
+                    left_index = spectrum.wcs.world_to_pixel(left_reg_in_spec_unit)
+                left_index = int(np.ceil(left_index))
             except Exception as e:
                 raise ValueError(
                     "Lower value, {}, could not convert using spectrum's WCS "
@@ -70,7 +72,6 @@ def _to_edge_pixel(subregion, spectrum):
     if subregion[1].unit.is_equivalent(u.pix):
         right_index = ceil(subregion[1].value)
     else:
-
         # Convert upper value to spectrum spectral_axis units
         right_reg_in_spec_unit = subregion[1].to(spectral_axis.unit,
                                                  u.spectral())
@@ -81,8 +82,11 @@ def _to_edge_pixel(subregion, spectrum):
             right_index = 0
         else:
             try:
-                right_index = int(np.floor(spectrum.wcs.world_to_pixel(
-                    right_reg_in_spec_unit))) + 1
+                if hasattr(spectrum.wcs, "spectral"):
+                    right_index = spectrum.wcs.spectral.world_to_pixel(right_reg_in_spec_unit)
+                else:
+                    right_index = spectrum.wcs.world_to_pixel(right_reg_in_spec_unit)
+                right_index = int(np.floor(right_index)) + 1
             except Exception as e:
                 raise ValueError(
                     "Upper value, {}, could not convert using spectrum's WCS "

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -200,7 +200,6 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                                  " last. Reshaping arrays to put spectral axis last.")
                     wcs = wcs.swapaxes(0, temp_axes[0])
                     if flux is not None:
-                        print(len(flux.shape), temp_axes[0])
                         flux = np.moveaxis(flux, len(flux.shape)-temp_axes[0]-1, -1)
                     if "mask" in kwargs:
                         if kwargs["mask"] is not None:
@@ -367,7 +366,6 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                 else:
                     raise ValueError(f"Unclear how to slice with tuple {item}")
             else:
-                print(f"{type(item)}: {item}")
                 item = slice(item, item + 1, None)
         elif (isinstance(item.start, u.Quantity) or isinstance(item.stop, u.Quantity)):
             return self._spectral_slice(item)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -182,32 +182,33 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
 
         # If a WCS is provided, check that the spectral axis is last and reorder
         # the arrays if not
-        if wcs is not None:
-            temp_axes = []
-            phys_axes = wcs.world_axis_physical_types
-            for i in range(len(phys_axes)):
-                if phys_axes[i][0:2] == "em":
-                    temp_axes.append(i)
-            if len(temp_axes) != 1:
-                raise ValueError("Input WCS must have exactly one axis "
-                                 "with spectral units")
+        if wcs is not None and hasattr(wcs, "naxis"):
+            if wcs.naxis > 1:
+                temp_axes = []
+                phys_axes = wcs.world_axis_physical_types
+                for i in range(len(phys_axes)):
+                    if phys_axes[i][0:2] == "em":
+                        temp_axes.append(i)
+                if len(temp_axes) != 1:
+                    raise ValueError("Input WCS must have exactly one axis"
+                                     " with spectral units")
 
-            # Due to FITS conventions, a WCS with spectral axis first corresponds
-            # to a flux array with spectral axis last.
-            if temp_axes[0] != 0:
-                logging.warn("Input WCS indicates that the spectral axis is not"
-                             " last. Reshaping arrays to put spectral axis last.")
-                wcs = wcs.swapaxes(0, temp_axes[0])
-                if flux is not None:
-                    print(len(flux.shape), temp_axes[0])
-                    flux = np.moveaxis(flux, len(flux.shape)-temp_axes[0]-1, -1)
-                if "mask" in kwargs:
-                    kwargs["mask"] = np.moveaxis(kwargs["mask"],
-                                                 len(mask.shape)-temp_axes[0]-1, -1)
-                if "uncertainty" in kwargs:
-                    kwargs["uncertainty"] = np.moveaxis(kwargs["uncertainty"],
-                                                        len(uncertainty.shape)-temp_axes[0]-1,
-                                                        -1)
+                # Due to FITS conventions, a WCS with spectral axis first corresponds
+                # to a flux array with spectral axis last.
+                if temp_axes[0] != 0:
+                    logging.warn("Input WCS indicates that the spectral axis is not"
+                                 " last. Reshaping arrays to put spectral axis last.")
+                    wcs = wcs.swapaxes(0, temp_axes[0])
+                    if flux is not None:
+                        print(len(flux.shape), temp_axes[0])
+                        flux = np.moveaxis(flux, len(flux.shape)-temp_axes[0]-1, -1)
+                    if "mask" in kwargs:
+                        kwargs["mask"] = np.moveaxis(kwargs["mask"],
+                                            len(mask.shape)-temp_axes[0]-1, -1)
+                    if "uncertainty" in kwargs:
+                        kwargs["uncertainty"] = np.moveaxis(kwargs["uncertainty"],
+                                                    len(uncertainty.shape)-temp_axes[0]-1,
+                                                    -1)
 
         # Attempt to parse the spectral axis. If none is given, try instead to
         # parse a given wcs. This is put into a GWCS object to

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -10,13 +10,12 @@ from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
 from .spectral_region import SpectralRegion
 from ..utils.wcs_utils import gwcs_from_array
-#from ndcube import NDCube
+from ndcube import NDCube
 
 __all__ = ['Spectrum1D']
 
 
-class Spectrum1D(OneDSpectrumMixin, NDDataRef):
-#class Spectrum1D(OneDSpectrumMixin, NDCube):
+class Spectrum1D(OneDSpectrumMixin, NDCube):
     """
     Spectrum container for 1D spectral data.
 
@@ -72,7 +71,8 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
                  radial_velocity=None, bin_specification=None, **kwargs):
         # Check for pre-defined entries in the kwargs dictionary.
         unknown_kwargs = set(kwargs).difference(
-            {'data', 'unit', 'uncertainty', 'meta', 'mask', 'copy'})
+            {'data', 'unit', 'uncertainty', 'meta', 'mask', 'copy',
+             'extra_coords'})
 
         if len(unknown_kwargs) > 0:
             raise ValueError("Initializer contains unknown arguments(s): {}."

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -340,7 +340,14 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
             if isinstance(item, u.Quantity):
                 raise ValueError("Indexing on a single spectral axis values is not"
                                  " currently allowed, please use a slice.")
+            # Handle tuple slice as input by NDCube crop method
+            elif isinstance(item, tuple):
+                if len(item) == 1 and isinstance(item[0], slice):
+                    item = item[0]
+                else:
+                    raise ValueError(f"Unclear how to slice with tuple {item}")
             else:
+                print(f"{type(item)}: {item}")
                 item = slice(item, item + 1, None)
         elif (isinstance(item.start, u.Quantity) or isinstance(item.stop, u.Quantity)):
             return self._spectral_slice(item)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -10,11 +10,13 @@ from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
 from .spectral_region import SpectralRegion
 from ..utils.wcs_utils import gwcs_from_array
+#from ndcube import NDCube
 
 __all__ = ['Spectrum1D']
 
 
 class Spectrum1D(OneDSpectrumMixin, NDDataRef):
+#class Spectrum1D(OneDSpectrumMixin, NDCube):
     """
     Spectrum container for 1D spectral data.
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -34,7 +34,8 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
     Parameters
     ----------
     flux : `~astropy.units.Quantity` or `~astropy.nddata.NDData`-like
-        The flux data for this spectrum.
+        The flux data for this spectrum. This can be a simple `~astropy.units.Quantity`,
+        or an existing `~Spectrum1D` or `~ndcube.NDCube` object.
     spectral_axis : `~astropy.units.Quantity` or `~specutils.SpectralAxis`
         Dispersion information with the same shape as the last (or only)
         dimension of flux, or one greater than the last dimension of flux

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -91,7 +91,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                 raise ValueError("Input NDCube missing unit parameter")
 
             # Change the flux array from bare ndarray to a Quantity
-            q_flux = flux.data*u.Unit(flux.unit)
+            q_flux = flux.data << u.Unit(flux.unit)
 
             self.__init__(flux=q_flux, wcs=flux.wcs, mask=flux.mask,
                           uncertainty=flux.uncertainty)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -96,8 +96,6 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                     spectral_axis = c
                     break
 
-            print(spectral_axis)
-
             # Get the index of the spectral axis in case we need to reorder
             phys_axes = flux.array_axis_physical_types
             for i in range(len(phys_axes)):
@@ -110,6 +108,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
             # Change the flux array from bare ndarray to a Quantity
             q_flux = flux.data*u.Unit(flux.unit)
             # Spectrum1D expects the spectral axis to be last
+
             q_flux = np.moveaxis(q_flux, temp_axes[0], -1)
 
             self.__init__(flux=q_flux, spectral_axis=spectral_axis,

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 
 import numpy as np
 from astropy import units as u
-from astropy.nddata import NDDataRef
 from astropy.utils.decorators import lazyproperty
 
 from .spectral_axis import SpectralAxis
@@ -80,7 +79,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
 
         # If the flux (data) argument is a subclass of nddataref (as it would
         # be for internal arithmetic operations), avoid setup entirely.
-        if isinstance(flux, NDDataRef):
+        if isinstance(flux, NDCube):
             super().__init__(flux)
             return
 
@@ -363,7 +362,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
         reg = SpectralRegion(start, stop)
         return extract_region(self, reg)
 
-    @NDDataRef.mask.setter
+    @NDCube.mask.setter
     def mask(self, value):
         # Impose stricter checks than the base NDData mask setter
         if value is not None:
@@ -459,31 +458,31 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
         self._spectral_axis = new_spectral_axis
 
     def __add__(self, other):
-        if not isinstance(other, NDDataRef):
+        if not isinstance(other, NDCube):
             other = u.Quantity(other, unit=self.unit)
 
         return self.add(other)
 
     def __sub__(self, other):
-        if not isinstance(other, NDDataRef):
+        if not isinstance(other, NDCube):
             other = u.Quantity(other, unit=self.unit)
 
         return self.subtract(other)
 
     def __mul__(self, other):
-        if not isinstance(other, NDDataRef):
+        if not isinstance(other, NDCube):
             other = u.Quantity(other)
 
         return self.multiply(other)
 
     def __div__(self, other):
-        if not isinstance(other, NDDataRef):
+        if not isinstance(other, NDCube):
             other = u.Quantity(other)
 
         return self.divide(other)
 
     def __truediv__(self, other):
-        if not isinstance(other, NDDataRef):
+        if not isinstance(other, NDCube):
             other = u.Quantity(other)
 
         return self.divide(other)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -9,7 +9,7 @@ from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
 from .spectral_region import SpectralRegion
 from ..utils.wcs_utils import gwcs_from_array
-from ..extern.spectralcoord import SpectralCoord
+from astropy.coordinates import SpectralCoord
 from ndcube import NDCube
 
 __all__ = ['Spectrum1D']

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -1,9 +1,10 @@
 import logging
 from copy import deepcopy
 
-import astropy.units.equivalencies as eq
 import numpy as np
+import astropy.units.equivalencies as eq
 from astropy import units as u
+from astropy.nddata import NDIOMixin
 from astropy.utils.decorators import lazyproperty, deprecated
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 
@@ -17,7 +18,7 @@ DOPPLER_CONVENTIONS['relativistic'] = u.doppler_relativistic
 __all__ = ['OneDSpectrumMixin']
 
 
-class OneDSpectrumMixin:
+class OneDSpectrumMixin(NDIOMixin):
     @property
     def _spectral_axis_numpy_index(self):
         return self.data.ndim - 1 - self.wcs.wcs.spec

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{36,37,38,39}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38,39}-test-numpy{116,117,118}
-    py{36,37,38,39}-test-astropy{30,40,lts}
-    py{36,37,38,39}-test-external
+    py{37,38,39}-test{,-alldeps,-devdeps}{,-cov}
+    py{37,38,39}-test-numpy{116,117,118}
+    py{37,38,39}-test-astropy{30,40,lts}
+    py{37,38,39}-test-external
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
Creating this as a draft for now. I have all of the specutils tests passing, but still need to do a deeper dive to make sure that the features we were hoping to take advantage of through this change all work. Additionally, the NDCube developers are working towards a 2.0 release, so this will need to wait on that anyway (I'm working off the latest development version).