### PR TITLE
Implement moment function

### DIFF
--- a/specutils/analysis/__init__.py
+++ b/specutils/analysis/__init__.py
@@ -4,3 +4,4 @@ from .location import *  # noqa
 from .width import *  # noqa
 from .template_comparison import *  # noqa
 from .correlation import *  # noqa
+from .moment import *  # noqa

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -53,13 +53,9 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
     else:
         calc_spectrum = spectrum
 
-    if hasattr(spectrum, 'mask') and spectrum.mask is not None:
-        flux = calc_spectrum.flux[~spectrum.mask]
-    else:
-        flux = calc_spectrum.flux
-    # we don't apply the mask to the spectral axis because of
-    # dimensionality issues. This should be fully addresses when
+    # Ignore masks for now. This should be fully addressed when
     # specutils gets revamped to handle multi-dimensional masks.
+    flux = calc_spectrum.flux
     spectral_axis = calc_spectrum.spectral_axis
 
     if order is None or order < 0:

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -5,7 +5,6 @@ spectral features.
 
 import numpy as np
 from ..manipulation import extract_region
-from . import centroid
 from .utils import computation_wrapper
 
 
@@ -75,17 +74,3 @@ def _compute_moment(spectrum, regions=None, order=0):
         m1 = np.sum(flux * dispersion, axis=-1) / np.sum(flux, axis=-1)
 
         return np.sum(flux * (dispersion - m1)**order, axis=-1) / m0
-
-
-
-
-
-
-    # if flux.ndim > 1:
-    #     spectral_axis = np.broadcast_to(spectral_axis, flux.shape, subok=True)
-    #     centroid_result = centroid_result[:, np.newaxis]
-    #
-    # dx = (spectral_axis - centroid_result)
-    # sigma = np.sqrt(np.sum((dx * dx) * flux, axis=-1) / np.sum(flux, axis=-1))
-    #
-    # return sigma

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -11,7 +11,7 @@ from .utils import computation_wrapper
 __all__ = ['moment']
 
 
-def moment(spectrum, regions=None, order=0):
+def moment(spectrum, regions=None, order=0, axis=-1):
     """
     Estimate the moment of the spectrum.
 
@@ -25,8 +25,13 @@ def moment(spectrum, regions=None, order=0):
         Region within the spectrum to calculate the gaussian sigma width. If
         regions is `None`, computation is performed over entire spectrum.
 
-    order : int, default: 0
-        The order of the moment to be calculated.
+    order : int
+        The order of the moment to be calculated. Default=0
+
+    axis : int
+        Axis along which a moment is calculated. Default=-1, computes along
+        the last axis (spectral axis).
+
 
     Returns
     -------
@@ -34,10 +39,11 @@ def moment(spectrum, regions=None, order=0):
         Moment of the spectrum. Returns None if (order < 0 or None)
 
     """
-    return computation_wrapper(_compute_moment, spectrum, regions, order=order)
+    return computation_wrapper(_compute_moment, spectrum, regions,
+                               order=order, axis=axis)
 
 
-def _compute_moment(spectrum, regions=None, order=0):
+def _compute_moment(spectrum, regions=None, order=0, axis=-1):
     """
     This is a helper function for the above `moment()` method.
     """
@@ -58,19 +64,17 @@ def _compute_moment(spectrum, regions=None, order=0):
         return None
 
     if order == 0:
-        # the axis=-1 will enable this to run on single-dispersion, single-flux
-        # and single-dispersion, multiple-flux
-        return np.sum(flux, axis=-1)
+        return np.sum(flux, axis=axis)
 
     dispersion = spectral_axis
     if len(flux.shape) > 1:
         dispersion = np.tile(spectral_axis, [flux.shape[0], 1])
 
     if order == 1:
-        return np.sum(flux * dispersion, axis=-1) / np.sum(flux, axis=-1)
+        return np.sum(flux * dispersion, axis=axis) / np.sum(flux, axis=axis)
 
     if order > 1:
-        m0 = np.sum(flux, axis=-1)
-        m1 = np.sum(flux * dispersion, axis=-1) / np.sum(flux, axis=-1)
+        m0 = np.sum(flux, axis=axis)
+        m1 = np.sum(flux * dispersion, axis=axis) / np.sum(flux, axis=axis)
 
-        return np.sum(flux * (dispersion - m1)**order, axis=-1) / m0
+        return np.sum(flux * (dispersion - m1)**order, axis=axis) / m0

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -1,0 +1,70 @@
+"""
+A module for analysis tools focused on determining the moment of
+spectral features.
+"""
+
+import numpy as np
+from astropy.stats.funcs import gaussian_sigma_to_fwhm
+from astropy.modeling.models import Gaussian1D
+from ..manipulation import extract_region
+from . import centroid
+from .utils import computation_wrapper
+from scipy.signal import chirp, find_peaks, peak_widths
+
+
+__all__ = ['moment']
+
+
+def moment(spectrum, regions=None, order=0):
+    """
+    Estimate the moment of the spectrum.
+
+
+    Parameters
+    ----------
+    spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
+        The spectrum object over which the width will be calculated.
+
+    regions: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+        Region within the spectrum to calculate the gaussian sigma width. If
+        regions is `None`, computation is performed over entire spectrum.
+
+    order : int, default: 0
+        The order of the moment to be calculated.
+
+    Returns
+    -------
+    moment: `float` or list (based on region input)
+        Moment of the spectrum
+
+    """
+    return computation_wrapper(_compute_moment, spectrum, regions, order=order)
+
+
+def _compute_moment(spectrum, regions=None, order=0):
+    """
+    This is a helper function for the above `gaussian_sigma_width()` method.
+    """
+
+    if regions is not None:
+        calc_spectrum = extract_region(spectrum, regions)
+    else:
+        calc_spectrum = spectrum
+
+    if hasattr(spectrum, 'mask') and spectrum.mask is not None:
+        flux = calc_spectrum.flux[~spectrum.mask]
+        spectral_axis = calc_spectrum.spectral_axis[~spectrum.mask]
+    else:
+        flux = calc_spectrum.flux
+        spectral_axis = calc_spectrum.spectral_axis
+
+    centroid_result = centroid(spectrum, regions)
+
+    if flux.ndim > 1:
+        spectral_axis = np.broadcast_to(spectral_axis, flux.shape, subok=True)
+        centroid_result = centroid_result[:, np.newaxis]
+
+    dx = (spectral_axis - centroid_result)
+    sigma = np.sqrt(np.sum((dx * dx) * flux, axis=-1) / np.sum(flux, axis=-1))
+
+    return sigma

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -39,7 +39,7 @@ def moment(spectrum, regions=None, order=0):
 
 def _compute_moment(spectrum, regions=None, order=0):
     """
-    This is a helper function for the above `gaussian_sigma_width()` method.
+    This is a helper function for the above `moment()` method.
     """
 
     if regions is not None:

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -55,10 +55,12 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
 
     if hasattr(spectrum, 'mask') and spectrum.mask is not None:
         flux = calc_spectrum.flux[~spectrum.mask]
-        spectral_axis = calc_spectrum.spectral_axis[~spectrum.mask]
     else:
         flux = calc_spectrum.flux
-        spectral_axis = calc_spectrum.spectral_axis
+    # we don't apply the mask to the spectral axis because of
+    # dimensionality issues. This should be fully addresses when
+    # specutils gets revamped to handle multi-dimensional masks.
+    spectral_axis = calc_spectrum.spectral_axis
 
     if order is None or order < 0:
         return None

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -956,7 +956,7 @@ def test_moment_multid():
     np.random.seed(42)
 
     frequencies = np.linspace(100, 1, 10000) * u.GHz
-    g = models.Gaussian1D(amplitude=1*u.Jy, mean=10*u.GHz, stddev=1*u.GHz)
+    g = models.Gaussian1D(amplitude=100*u.Jy, mean=50*u.GHz, stddev=1000*u.GHz)
     noise = np.random.normal(0., 0.01, frequencies.shape) * u.Jy
     flux = g(frequencies) + noise
 
@@ -971,4 +971,19 @@ def test_moment_multid():
 
     assert moment_1.shape == (10,10)
     assert moment_1.unit.is_equivalent(u.GHz )
-    assert quantity_allclose(moment_1, 10.08*u.GHz, atol=0.01*u.GHz)
+    assert quantity_allclose(moment_1, 50.50*u.GHz, atol=0.01*u.GHz)
+
+    # select the last axis of the cube. Should be identical with
+    # the default call above.
+    moment_1 = moment(spectrum, order=1, axis=2)
+
+    assert moment_1.shape == (10,10)
+    assert moment_1.unit.is_equivalent(u.GHz )
+    assert quantity_allclose(moment_1, 50.50*u.GHz, atol=0.01*u.GHz)
+
+    # cross-cube - returns the dispersion
+    moment_1 = moment(spectrum, order=1, axis=1)
+
+    assert moment_1.shape == (10,10000)
+    assert moment_1.unit.is_equivalent(u.GHz )
+    assert quantity_allclose(moment_1, frequencies, atol=0.01*u.GHz)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -950,3 +950,25 @@ def test_moment():
     assert moment_3.unit.is_equivalent(u.GHz**3)
     assert quantity_allclose(moment_3, 1233.78*u.GHz**3, atol=0.01*u.GHz**3)
 
+
+def test_moment_cube():
+
+    np.random.seed(42)
+
+    frequencies = np.linspace(100, 1, 10000) * u.GHz
+    g = models.Gaussian1D(amplitude=1*u.Jy, mean=10*u.GHz, stddev=1*u.GHz)
+    noise = np.random.normal(0., 0.01, frequencies.shape) * u.Jy
+    flux = g(frequencies) + noise
+
+    # use identical arrays in each spaxel. The purpose here is not to
+    # check accuracy (already tested elsewhere), but dimensionality.
+
+    flux_cube = np.broadcast_to(flux, [10,10,flux.shape[0]]) * u.Jy
+
+    spectrum = Spectrum1D(spectral_axis=frequencies, flux=flux_cube)
+
+    moment_1 = moment(spectrum, order=1)
+
+    assert moment_1.shape == (10,10)
+    assert moment_1.unit.is_equivalent(u.GHz )
+    assert quantity_allclose(moment_1, 10.08*u.GHz, atol=0.01*u.GHz)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -934,12 +934,19 @@ def test_moment():
 
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=flux)
 
-    result = moment(spectrum, order=0)
+    moment_0 = moment(spectrum, order=0)
+    assert moment_0.unit.is_equivalent(u.Jy )
+    assert quantity_allclose(moment_0, 252.96*u.Jy, atol=0.01*u.Jy)
 
-    assert result.unit.is_equivalent(u.erg / u.cm**2 / u.s)
+    moment_1 = moment(spectrum, order=1)
+    assert moment_1.unit.is_equivalent(u.GHz)
+    assert quantity_allclose(moment_1, 10.08*u.GHz, atol=0.01*u.GHz)
 
-    # Account for the fact that Astropy uses a different normalization of the
-    # Gaussian where the integral is not 1
-    expected = np.sqrt(2*np.pi) * u.GHz * u.Jy
+    moment_2 = moment(spectrum, order=2)
+    assert moment_2.unit.is_equivalent(u.GHz**2)
+    assert quantity_allclose(moment_2, 13.40*u.GHz**2, atol=0.01*u.GHz**2)
 
-    assert quantity_allclose(result, expected, atol=0.01*u.GHz*u.Jy)
+    moment_3 = moment(spectrum, order=3)
+    assert moment_3.unit.is_equivalent(u.GHz**3)
+    assert quantity_allclose(moment_3, 1233.78*u.GHz**3, atol=0.01*u.GHz**3)
+

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -951,7 +951,7 @@ def test_moment():
     assert quantity_allclose(moment_3, 1233.78*u.GHz**3, atol=0.01*u.GHz**3)
 
 
-def test_moment_cube():
+def test_moment_multid():
 
     np.random.seed(42)
 
@@ -963,9 +963,9 @@ def test_moment_cube():
     # use identical arrays in each spaxel. The purpose here is not to
     # check accuracy (already tested elsewhere), but dimensionality.
 
-    flux_cube = np.broadcast_to(flux, [10,10,flux.shape[0]]) * u.Jy
+    flux_multid = np.broadcast_to(flux, [10,10,flux.shape[0]]) * u.Jy
 
-    spectrum = Spectrum1D(spectral_axis=frequencies, flux=flux_cube)
+    spectrum = Spectrum1D(spectral_axis=frequencies, flux=flux_multid)
 
     moment_1 = moment(spectrum, order=1)
 


### PR DESCRIPTION
As per #745 

This is for now being implemented as a function, not as a method in the `Spectrum1D` class. The rationale is that, in `specutils`, measurement and processing operations are implemented as functions in top-level packages such as `analysis`, `fitting`, and `manipulation`, and not as methods in `Spectrum1D` or `OneDSpectrumMixin`. I am not sure we should break this pattern now.

The `moment` method in `spectral_cube` accepts a parameter (how: cube | slice | ray | auto) that is meant to select specialized cube addressing patterns that optimize the calculation for certain cube and memory configurations. We leave this out of this PR for now (it's using the "cube" mode).

