### PR TITLE
Add WiggleZ loader

### DIFF
--- a/specutils/io/default_loaders/wigglez.py
+++ b/specutils/io/default_loaders/wigglez.py
@@ -1,0 +1,36 @@
+import astropy.io.fits as fits
+from specutils import SpectrumList
+from specutils.io.registers import data_loader
+
+from .dc_common import FITS_FILE_EXTS, SINGLE_SPLIT_LABEL
+from ..parsing_utils import read_fileobj_or_hdulist
+
+WIGGLEZ_CONFIG = {
+    "hdus": None,
+    "wcs": None,
+    "units": None,
+    "all_standard_units": True,
+    "all_keywords": True,
+    "valid_wcs": True,
+}
+
+
+def identify_wigglez(origin, *args, **kwargs):
+    """
+    Identify if the current file is a WiggleZ file
+    """
+    with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
+        if '2018MNRAS.474.4151D' in hdulist[0].header.get("REFCODE"):
+            return True
+    return False
+
+
+@data_loader(
+    label="WiggleZ", extensions=FITS_FILE_EXTS, dtype=SpectrumList,
+    identifier=identify_wigglez,
+)
+def wigglez_loader(fname):
+    spectra = SpectrumList.read(
+        fname, format=SINGLE_SPLIT_LABEL, **WIGGLEZ_CONFIG
+    )
+    return spectra

--- a/specutils/tests/test_dc_common_loaders.py
+++ b/specutils/tests/test_dc_common_loaders.py
@@ -18,6 +18,7 @@ GAMA_GAMA_TEST_FILENAME = "G12_Y2_009_044.fit"
 GAMA_MGC_TEST_FILENAME = "MGC23320.fit"
 GAMA_WIGGLEZ_TEST_FILENAME = "Spectrum-195254.fit"
 OZDES_TEST_FILENAME = "OzDES-DR2_04720.fits"
+WIGGLEZ_TEST_FILENAME = "wig206635.fits"
 
 OZDES_CONFIG = {
     "hdus": {
@@ -130,6 +131,29 @@ GAMA_MGC_CONFIG = {
 
 
 class TestSingleSplit:
+    @remote_access([{'id': "4460981", 'filename': WIGGLEZ_TEST_FILENAME}])
+    def test_wigglez(self, remote_data_path):
+        spectra = SpectrumList.read(remote_data_path, format="WiggleZ")
+
+        assert len(spectra) == 1
+        assert spectra[0].flux.unit == u.Unit("1e-16 erg / (A cm2 s)")
+        assert spectra[0].spectral_axis.unit == u.Angstrom
+        assert isinstance(spectra[0].uncertainty, VarianceUncertainty)
+        assert spectra[0].meta.get("label") is not None
+        assert spectra[0].meta.get("header") is not None
+
+    @pytest.mark.xfail(reason="Format is ambiguous")
+    @remote_access([{'id': "4460981", 'filename': WIGGLEZ_TEST_FILENAME}])
+    def test_wigglez_guess(self, remote_data_path):
+        spectra = SpectrumList.read(remote_data_path)
+
+        assert len(spectra) == 1
+        assert spectra[0].flux.unit == u.Unit("1e-16 erg / (A cm2 s)")
+        assert spectra[0].spectral_axis.unit == u.Angstrom
+        assert isinstance(spectra[0].uncertainty, VarianceUncertainty)
+        assert spectra[0].meta.get("label") is not None
+        assert spectra[0].meta.get("header") is not None
+
     @remote_access([{'id': REMOTE_ID, 'filename': OZDES_TEST_FILENAME}])
     def test_ozdes(self, remote_data_path):
         spectra = SpectrumList.read(


### PR DESCRIPTION
Adds loader for WiggleZ. This shouldn't conflict with #765 as the identifiers should spot the difference, but a priority will need to be set such that the 1d-fits loader isn't used.