### PR TITLE
Update Spectral Region docstrings and initializer

### DIFF
--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -7,12 +7,12 @@ import astropy.units as u
 
 class SpectralRegion:
     """
-    A `SpectralRegion` is a container class that enables some simplicty
-    in defining and passing a region (interval) for a spectrum.
+    A `SpectralRegion` is a container class for regions (intervals) along a
+    spectral coordinate.
 
-    In the future, there might be more functionality added in here, and there
-    is some discussion that this might/could move to
-    `Astropy Regions <http://astropy-regions.readthedocs.io/en/latest/>`_.
+    This class can either represent a single contiguous region or a set of
+    regions related to each other in some way (For example, a pair of 
+    continuum windows around a line or a doublet of lines).
 
     Parameters
     ----------

--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -28,6 +28,34 @@ class SpectralRegion:
     The subregions will be ordered based on the lower bound of each subregion.
 
     """
+    def __init__(self, *args):
+        # Create instance variables
+        self._subregions = None
+
+        # Set the values (using the setters for doing the proper checking)
+        if len(args) == 1:
+            if all([self._is_2_element(x) for x in args[0]]):
+                self._subregions = [tuple(x) for x in args[0]]
+            else:
+                raise ValueError("SpectralRegion 1-argument input must be "
+                                 "a list of length-two Quantity objects.")
+        elif len(args) == 2:
+            if self._is_2_element(args):
+                self._subregions = [tuple(args)]
+            else:
+                raise ValueError("SpectralRegion 2-argument inputs must be "
+                                 "Quantity objects.")
+        else:
+            raise TypeError(f'SpectralRegion initializer takes 1 or 2'
+                            f'positional arguments but {len(args)} were given')
+
+        #  Check validity of the input sub regions.
+        if not self._valid():
+            raise ValueError("SpectralRegion 2-tuple lower extent must be "
+                             "less than upper extent.")
+
+        # The sub-regions are to always be ordered based on the lower bound.
+        self._reorder()
 
     @classmethod
     def from_center(cls, center=None, width=None):
@@ -77,36 +105,6 @@ class SpectralRegion:
 
         return cls([(x - width * 0.5, x + width * 0.5)
                     for x in table['line_center']])
-
-    def __init__(self, *args):
-        """
-        Lower and upper values for the interval.
-        """
-
-        # Create instance variables
-        self._subregions = None
-
-        # Set the values (using the setters for doing the proper checking)
-        if self._is_2_element(args):
-            self._subregions = [tuple(args)]
-        elif isinstance(args, (list, tuple)):
-            if all([self._is_2_element(x) for x in args[0]]):
-                self._subregions = [tuple(x) for x in args[0]]
-            else:
-                raise ValueError("Region bounds must be given as a tuple of "
-                                 "`Quantity` objects, or as a length 2 "
-                                 "`Quantity` object.")
-        else:
-            raise ValueError("`SpectralRegion` input must be a 2-tuple or a "
-                             "list of 2-tuples.")
-
-        #  Check validity of the input sub regions.
-        if not self._valid():
-            raise ValueError("SpectralRegion 2-tuple lower extent must be "
-                             "less than upper extent.")
-
-        # The sub-regions are to always be ordered based on the lower bound.
-        self._reorder()
 
     def _info(self):
         """
@@ -194,10 +192,11 @@ class SpectralRegion:
 
         return True
 
-    def _is_2_element(self, value):
+    @staticmethod
+    def _is_2_element(value):
         """
         Helper function to check a variable to see if it
-        is a 2-tuple.
+        is a 2-tuple of Quantity objects.
         """
         return len(value) == 2 and \
                isinstance(value[0], u.Quantity) and \

--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -11,17 +11,20 @@ class SpectralRegion:
     spectral coordinate.
 
     This class can either represent a single contiguous region or a set of
-    regions related to each other in some way (For example, a pair of 
+    regions related to each other in some way (For example, a pair of
     continuum windows around a line or a doublet of lines).
 
     Parameters
     ----------
+    *args : variable
+        Either a single parameter or two parameters can be given:
 
-    lower : Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
-       The lower bound of the region.
-
-    upper : Scalar `~astropy.units.Quantity` with pixel or any valid ``spectral_axis`` unit
-       The upper bound of the region.
+        * 1 argument ``regioniter``: An iterable of length-2
+          `~astropy.units.Quantity` objects (or a single n x 2
+          `~astropy.units.Quantity` object), where the length-2 dimension is
+          ``lower``, ``upper``.
+        * ``lower``, ``upper``: Each should be an `~astropy.units.Quantity`
+          object.
 
     Notes
     -----
@@ -210,6 +213,10 @@ class SpectralRegion:
 
     @property
     def subregions(self):
+        """
+        An iterable over ``(lower, upper)`` tuples that are each of the
+        sub-regions.
+        """
         return self._subregions
 
     @property


### PR DESCRIPTION
This PR follows from #759 (and is currently based on @nmearl's) branch so I'm issuing it as a draft until that's merged and I can rebase it on master.

To see the diffs for just *this* PR and not #759, see https://github.com/eteq/specutils/compare/8b85d0ed783b2af726d1aff16fcf12143402741a..18c8c6958dad2893aa2338cc11c9b9fbfe1218c5

Mainly it cleans up the documentation and error messages to be (IMHO) much less confusing. #759 fixes the proximate issues #750 raises, but I think the underying issue of #750 is that the initializer is written in such a way that it was hard to generate case-relevant error messages, and the docstring was rather misleading (if not outright wrong).  This PR attempts to address that. (And in that direction, if @janerigby has some bandwidth to review this or at least say if this would also help with the ambiguity that #750 points out, even better!)