### PR TITLE
Fixes problem with non-loadable x1d files

### DIFF
--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -150,23 +150,12 @@ def _jwst_x1d_loader(file_obj, **kwargs):
             wavelength = Quantity(data["WAVELENGTH"])
 
             # Determine if FLUX or SURF_BRIGHT column should be returned
-            # based on whether it is point or extended source
+            # based on whether it is point or extended source.
+            #
+            # SRCTYPE used to be in primary header, but was moved around. As
+            # per most recent pipeline definition, it will be either in the
+            # EXTRACT1D or the SCI extension.
             srctype = hdu.header.get("srctype")
-
-            # SRCTYPE is in primary header because there is only one spectrum
-            if srctype is None:
-                # srctype = hdulist["PRIMARY"].header.get("srctype")
-                # srctype = hdulist["SCI"].header.get("srctype")
-
-
-                print("@@@@  jwst_reader.py-164: ", hdulist['PRIMARY'].header)
-                print("@@@@  jwst_reader.py-164: ", hdulist['EXTRACT1D'].header)
-
-
-                # srctype = hdulist["EXTRACT1D"].header.get("srctype")
-
-
-
 
             if srctype == "POINT":
                 flux = Quantity(data["FLUX"])

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -159,10 +159,11 @@ def _jwst_x1d_loader(file_obj, **kwargs):
                 # srctype = hdulist["SCI"].header.get("srctype")
 
 
+                print("@@@@  jwst_reader.py-164: ", hdulist['PRIMARY'].header)
                 print("@@@@  jwst_reader.py-164: ", hdulist['EXTRACT1D'].header)
 
 
-                srctype = hdulist["EXTRACT1D"].header.get("srctype")
+                # srctype = hdulist["EXTRACT1D"].header.get("srctype")
 
 
 

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -152,9 +152,20 @@ def _jwst_x1d_loader(file_obj, **kwargs):
             # Determine if FLUX or SURF_BRIGHT column should be returned
             # based on whether it is point or extended source
             srctype = hdu.header.get("srctype")
+
             # SRCTYPE is in primary header because there is only one spectrum
             if srctype is None:
-                srctype = hdulist["PRIMARY"].header.get("srctype")
+                # srctype = hdulist["PRIMARY"].header.get("srctype")
+                # srctype = hdulist["SCI"].header.get("srctype")
+
+
+                print("@@@@  jwst_reader.py-164: ", hdulist['EXTRACT1D'].header)
+
+
+                srctype = hdulist["EXTRACT1D"].header.get("srctype")
+
+
+
 
             if srctype == "POINT":
                 flux = Quantity(data["FLUX"])

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -141,7 +141,7 @@ def _jwst_x1d_loader(file_obj, **kwargs):
         primary_header = hdulist["PRIMARY"].header
 
         for hdu in hdulist:
-            # Read only the BinaryTableHDUs named EXTRACT1D
+            # Read only the BinaryTableHDUs named EXTRACT1D and SCI
             if hdu.name != 'EXTRACT1D':
                 continue
 
@@ -153,9 +153,11 @@ def _jwst_x1d_loader(file_obj, **kwargs):
             # based on whether it is point or extended source.
             #
             # SRCTYPE used to be in primary header, but was moved around. As
-            # per most recent pipeline definition, it will be either in the
-            # EXTRACT1D or the SCI extension.
-            srctype = hdu.header.get("srctype")
+            # per most recent pipeline definition, it should be in the
+            # EXTRACT1D extension.
+            srctype = None
+            if "srctype" in hdu.header:
+                srctype = hdu.header.get("srctype")
 
             if srctype == "POINT":
                 flux = Quantity(data["FLUX"])


### PR DESCRIPTION
Fixes the bug reported in jdaviz's issue #390. 

The bug was caused by the SRCTYPE keyword being moved around different extensions by different pipeline versions. Or, just not being there. 

Data created by pipeline 0.17.1 mostly works with the fix in here. That is, as long as the keyword is somewhere in the file, it works. Other pipeline versions do not create this keyword (they should, and they will from release B7.7.1, around beginning of March.

Link for 0.17.1 files https://stsci.box.com/s/5rxc5b41p04k8pux91iyn7aij5zhmm1l