### PR TITLE
Update doc examples of sdss spectrum

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ may have downloaded from some archive, or reduced from your own observations.
 
     Now we load the dataset from it's canonical source:
 
-    >>> f = fits.open('https://dr14.sdss.org/optical/spectrum/view/data/format=fits/spec=lite?plateid=1323&mjd=52797&fiberid=12')  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> f = fits.open('https://data.sdss.org/sas/dr16/sdss/spectro/redux/26/spectra/1323/spec-1323-52797-0012.fits')  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
     >>> # The spectrum is in the second HDU of this file.
     >>> specdata = f[1].data # doctest: +REMOTE_DATA
     >>> f.close() # doctest: +REMOTE_DATA

--- a/docs/manipulation.rst
+++ b/docs/manipulation.rst
@@ -143,7 +143,7 @@ Here's a set of simple examples showing each of the three types of resampling:
     >>> from astropy.visualization import quantity_support
     >>> quantity_support()  # for getting units on the axes below  # doctest: +IGNORE_OUTPUT
 
-    >>> f = fits.open('https://dr14.sdss.org/optical/spectrum/view/data/format=fits/spec=lite?plateid=1323&mjd=52797&fiberid=12')  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> f = fits.open('https://data.sdss.org/sas/dr16/sdss/spectro/redux/26/spectra/1323/spec-1323-52797-0012.fits')  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
     >>> # The spectrum is in the second HDU of this file.
     >>> specdata = f[1].data[1020:1250] # doctest: +REMOTE_DATA
     >>> f.close() # doctest: +REMOTE_DATA

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -44,6 +44,9 @@ else:
     HAS_LZMA = True
 
 
+EBOSS_SPECTRUM_URL = 'https://data.sdss.org/sas/dr16/eboss/spectro/redux/v5_13_0/spectra/lite/4055/spec-4055-55359-0596.fits'
+
+
 def test_get_loaders_by_extension():
     loader_labels = get_loaders_by_extension('fits')
 
@@ -171,13 +174,13 @@ def test_manga_rss():
 @pytest.mark.remote_data
 def test_sdss_spec():
     sp_pattern = 'spec-4055-55359-0596.fits.'
-    with urllib.request.urlopen('https://dr14.sdss.org/optical/spectrum/view/data/format%3Dfits/spec%3Dlite?mjd=55359&fiberid=596&plateid=4055') as response:
+    with urllib.request.urlopen(EBOSS_SPECTRUM_URL) as response:
         # Read from open file object
         spec = Spectrum1D.read(response, format="SDSS-III/IV spec")
         assert isinstance(spec, Spectrum1D)
         assert spec.flux.size > 0
 
-    with urllib.request.urlopen('https://dr14.sdss.org/optical/spectrum/view/data/format%3Dfits/spec%3Dlite?mjd=55359&fiberid=596&plateid=4055') as response:
+    with urllib.request.urlopen(EBOSS_SPECTRUM_URL) as response:
         # On Windows, NamedTemporaryFile cannot be opened a second time while
         #  already being open, so we avoid using that method.
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -248,8 +251,7 @@ def test_sdss_spec_stream():
     """Test direct read and recognition of SDSS-III/IV spec from remote URL,
     i.e. do not rely on filename pattern.
     """
-    sdss_url = 'https://dr14.sdss.org/optical/spectrum/view/data/format%3Dfits/spec%3Dlite?mjd=55359&fiberid=596&plateid=4055'
-    spec = Spectrum1D.read(sdss_url)
+    spec = Spectrum1D.read(EBOSS_SPECTRUM_URL)
 
     assert isinstance(spec, Spectrum1D)
     assert spec.flux.size > 0


### PR DESCRIPTION
Closes #773 following @havok2063's suggestion of just switching to the SAS URLs.

Note, though, that while replacing this I also stumbled into a couple other SDSS spectra that might be concerning for the reasons #773 wanted to replace the 1d spectra - specifically https://github.com/astropy/specutils/blob/50752a0d58e3bd62153f21c92269e20b8a2ec637/specutils/tests/test_loaders.py#L174 and a few lines below it.  I can't seem to find plateid 4055 in the same parts of SAS, though. @havok2063, do you have any insight here?