### PR TITLE
Fixes bug in moment calculation

### DIFF
--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -74,6 +74,7 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
     if order > 1:
         m0 = np.sum(flux, axis=axis)
         m1 = np.sum(flux * dispersion, axis=axis) / np.sum(flux, axis=axis)
+
         if len(flux.shape) > 1 and (axis == len(flux.shape)-1 or axis == -1):
             _shape = flux.shape[-1:] + tuple(np.ones(flux.ndim - 1, dtype='i'))
             m1 = np.tile(m1, _shape).T

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -47,7 +47,6 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
     """
     This is a helper function for the above `moment()` method.
     """
-
     if regions is not None:
         calc_spectrum = extract_region(spectrum, regions)
     else:
@@ -66,8 +65,8 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
 
     dispersion = spectral_axis
     if len(flux.shape) > len(spectral_axis.shape):
-        shape_ = flux.shape[:-1] + (1,)
-        dispersion = np.tile(spectral_axis, shape_)
+        _shape = flux.shape[:-1] + (1,)
+        dispersion = np.tile(spectral_axis, _shape)
 
     if order == 1:
         return np.sum(flux * dispersion, axis=axis) / np.sum(flux, axis=axis)
@@ -75,7 +74,8 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
     if order > 1:
         m0 = np.sum(flux, axis=axis)
         m1 = np.sum(flux * dispersion, axis=axis) / np.sum(flux, axis=axis)
-        if len(flux.shape) > 1:
-            m1 = np.tile(m1.T, flux.shape[-1:] + tuple(np.ones(flux.ndim - 1, dtype='i'))).T
+        if len(flux.shape) > 1 and (axis == len(flux.shape)-1 or axis == -1):
+            _shape = flux.shape[-1:] + tuple(np.ones(flux.ndim - 1, dtype='i'))
+            m1 = np.tile(m1, _shape).T
 
-        return np.sum(flux * (dispersion - m1)**order, axis=axis) / m0
+        return np.sum(flux * (dispersion - m1) ** order, axis=axis) / m0

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -65,8 +65,9 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
         return np.sum(flux, axis=axis)
 
     dispersion = spectral_axis
-    if len(flux.shape) > 1:
-        dispersion = np.tile(spectral_axis, [flux.shape[0], 1])
+    if len(flux.shape) > len(spectral_axis.shape):
+        shape_ = flux.shape[:-1] + (1,)
+        dispersion = np.tile(spectral_axis, shape_)
 
     if order == 1:
         return np.sum(flux * dispersion, axis=axis) / np.sum(flux, axis=axis)
@@ -74,5 +75,7 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
     if order > 1:
         m0 = np.sum(flux, axis=axis)
         m1 = np.sum(flux * dispersion, axis=axis) / np.sum(flux, axis=axis)
+        if len(flux.shape) > 1:
+            m1 = np.tile(m1.T, flux.shape[-1:] + tuple(np.ones(flux.ndim - 1, dtype='i'))).T
 
         return np.sum(flux * (dispersion - m1)**order, axis=axis) / m0

--- a/specutils/fitting/continuum.py
+++ b/specutils/fitting/continuum.py
@@ -25,7 +25,7 @@ def fit_generic_continuum(spectrum, median_window=3, model=Chebyshev1D(3),
         The list of models that contain the initial guess.
     median_window : float
         The width of the median smoothing kernel used to filter the data before
-        fitting the continuum. See the ``kernel_size`` parameter of 
+        fitting the continuum. See the ``kernel_size`` parameter of
         `~scipy.signal.medfilt` for more information.
     fitter : `~astropy.fitting._FitterMeta`
         The astropy fitter to use for fitting the model.

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -128,7 +128,7 @@ def find_lines_threshold(spectrum, noise_factor=1):
 
     # Threshold based on noise estimate and factor.
     uncertainty = spectrum.uncertainty
-    uncert_val = 0 if uncertainty is None else uncertainty.array 
+    uncert_val = 0 if uncertainty is None else uncertainty.array
 
     inds = np.where(np.abs(spectrum.flux) > (noise_factor * uncert_val) *
                     spectrum.flux.unit)[0]

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -953,7 +953,7 @@ def test_moment():
     assert quantity_allclose(moment_3, 1233.78*u.GHz**3, atol=0.01*u.GHz**3)
 
 
-def test_moment_multid():
+def test_moment_cube():
 
     np.random.seed(42)
 
@@ -972,36 +972,36 @@ def test_moment_multid():
     moment_1 = moment(spectrum, order=1)
 
     assert moment_1.shape == (10,10)
-    assert moment_1.unit.is_equivalent(u.GHz )
+    assert moment_1.unit.is_equivalent(u.GHz)
     assert quantity_allclose(moment_1, 50.50*u.GHz, atol=0.01*u.GHz)
 
     # select the last axis of the cube. Should be identical with
     # the default call above.
-    moment_1 = moment(spectrum, order=1, axis=2)
+    moment_1_last = moment(spectrum, order=1, axis=2)
 
-    assert moment_1.shape == (10,10)
-    assert moment_1.unit.is_equivalent(u.GHz )
-    assert quantity_allclose(moment_1, 50.50*u.GHz, atol=0.01*u.GHz)
+    assert moment_1_last.shape == moment_1.shape
+    assert moment_1_last.unit.is_equivalent(moment_1.unit)
+    assert quantity_allclose(moment_1, moment_1_last, rtol=1.E-5)
 
-    # cross-cube - returns the dispersion
+    # spatial 1st order - returns the dispersion
     moment_1 = moment(spectrum, order=1, axis=1)
 
     assert moment_1.shape == (10,10000)
-    assert moment_1.unit.is_equivalent(u.GHz )
-    assert quantity_allclose(moment_1, frequencies, atol=0.01*u.GHz)
+    assert moment_1.unit.is_equivalent(u.GHz)
+    assert quantity_allclose(moment_1, frequencies, rtol=1.E-5)
 
     # higher order
     moment_2 = moment(spectrum, order=2)
 
     assert moment_2.shape == (10,10)
-    assert moment_2.unit.is_equivalent(u.GHz**2 )
+    assert moment_2.unit.is_equivalent(u.GHz**2)
     assert quantity_allclose(moment_2, 816.648*u.GHz**2, atol=0.01*u.GHz**2)
 
-    # higher order, cross-cube (what is the meaning of this?)
+    # spatial higher order (what's the meaning of this?)
     moment_2 = moment(spectrum, order=2, axis=1)
 
     assert moment_2.shape == (10,10000)
-    assert moment_2.unit.is_equivalent(u.GHz**2 )
+    assert moment_2.unit.is_equivalent(u.GHz**2)
     # check assorted values.
     assert quantity_allclose(moment_2[0][0], 2.019e-28*u.GHz**2, rtol=0.01)
     assert quantity_allclose(moment_2[1][0], 2.019e-28*u.GHz**2, rtol=0.01)
@@ -1027,7 +1027,7 @@ def test_moment_collection():
     collection = SpectrumCollection.from_spectra([s1, s2])
 
     # Compare moments derived from collection, with moments
-    # derrived of individual members.
+    # derived from individual members.
     moment_0 = moment(collection, order=0)
     moment_0_s1 = moment(s1, order=0)
     moment_0_s2 = moment(s2, order=0)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -988,8 +988,19 @@ def test_moment_multid():
     assert moment_1.unit.is_equivalent(u.GHz )
     assert quantity_allclose(moment_1, frequencies, atol=0.01*u.GHz)
 
-    moment_2 = moment(spectrum, order=2, axis=1)
+    # higher order
+    moment_2 = moment(spectrum, order=2)
 
     assert moment_2.shape == (10,10)
     assert moment_2.unit.is_equivalent(u.GHz**2 )
-    assert quantity_allclose(moment_2, 816.64782527*u.GHz**2, atol=0.01*u.GHz**2)
+    assert quantity_allclose(moment_2, 816.648*u.GHz**2, atol=0.01*u.GHz**2)
+
+    # higher order, cross-cube (what is the meaning of this?)
+    moment_2 = moment(spectrum, order=2, axis=1)
+
+    assert moment_2.shape == (10,10000)
+    assert moment_2.unit.is_equivalent(u.GHz**2 )
+    # check assorted values.
+    assert quantity_allclose(moment_2[0][0], 2.019e-28*u.GHz**2, rtol=0.01)
+    assert quantity_allclose(moment_2[1][0], 2.019e-28*u.GHz**2, rtol=0.01)
+    assert quantity_allclose(moment_2[0][3], 8.078e-28*u.GHz**2, rtol=0.01)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -1035,3 +1035,8 @@ def test_moment_collection():
     assert moment_1.unit.is_equivalent(u.GHz)
     assert quantity_allclose(moment_1[0], 10.08*u.GHz, atol=0.01*u.GHz)
     assert quantity_allclose(moment_1[1], 20.20*u.GHz, atol=0.01*u.GHz)
+
+    moment_2 = moment(collection, order=2)
+    assert moment_2.unit.is_equivalent(u.GHz**2 )
+    assert quantity_allclose(moment_2[0], 13.40*u.GHz**2, atol=0.01*u.GHz**2)
+    assert quantity_allclose(moment_2[1], 3.99*u.GHz**2, atol=0.01*u.GHz**2)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -987,3 +987,9 @@ def test_moment_multid():
     assert moment_1.shape == (10,10000)
     assert moment_1.unit.is_equivalent(u.GHz )
     assert quantity_allclose(moment_1, frequencies, atol=0.01*u.GHz)
+
+    moment_2 = moment(spectrum, order=2, axis=1)
+
+    assert moment_2.shape == (10,10)
+    assert moment_2.unit.is_equivalent(u.GHz**2 )
+    assert quantity_allclose(moment_2, 816.64782527*u.GHz**2, atol=0.01*u.GHz**2)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -1026,17 +1026,22 @@ def test_moment_collection():
 
     collection = SpectrumCollection.from_spectra([s1, s2])
 
+    # Compare moments derived from collection, with moments
+    # derrived of individual members.
     moment_0 = moment(collection, order=0)
-    assert moment_0.unit.is_equivalent(u.Jy )
-    assert quantity_allclose(moment_0[0], 252.96*u.Jy, atol=0.01*u.Jy)
-    assert quantity_allclose(moment_0[1], 509.05*u.Jy, atol=0.01*u.Jy)
+    moment_0_s1 = moment(s1, order=0)
+    moment_0_s2 = moment(s2, order=0)
+    assert quantity_allclose(moment_0[0], moment_0_s1, rtol=1.E-5)
+    assert quantity_allclose(moment_0[1], moment_0_s2, rtol=1.E-5)
 
     moment_1 = moment(collection, order=1)
-    assert moment_1.unit.is_equivalent(u.GHz)
-    assert quantity_allclose(moment_1[0], 10.08*u.GHz, atol=0.01*u.GHz)
-    assert quantity_allclose(moment_1[1], 20.20*u.GHz, atol=0.01*u.GHz)
+    moment_1_s1 = moment(s1, order=1)
+    moment_1_s2 = moment(s2, order=1)
+    assert quantity_allclose(moment_1[0], moment_1_s1, rtol=1.E-5)
+    assert quantity_allclose(moment_1[1], moment_1_s2, rtol=1.E-5)
 
     moment_2 = moment(collection, order=2)
-    assert moment_2.unit.is_equivalent(u.GHz**2 )
-    assert quantity_allclose(moment_2[0], 13.40*u.GHz**2, atol=0.01*u.GHz**2)
-    assert quantity_allclose(moment_2[1], 3.99*u.GHz**2, atol=0.01*u.GHz**2)
+    moment_2_s1 = moment(s1, order=2)
+    moment_2_s2 = moment(s2, order=2)
+    assert quantity_allclose(moment_2[0], moment_2_s1, rtol=1.E-5)
+    assert quantity_allclose(moment_2[1], moment_2_s2, rtol=1.E-5)


### PR DESCRIPTION
as per bug report #772 

The first implementation didn't handle well `SpectrumCollection`. It also had problems with higher order moments (n > 1) with cubes in the spatial direction (axis=0 or 1). This PR fixes that. 

A few additional unit test cases exercise these (previously failing) modes. 