### PR TITLE
Add ability to slice Spectrum1D with spectral axis values

### DIFF
--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -185,9 +185,9 @@ common spectral axis.
     >>> from specutils import Spectrum1D
 
     >>> spec = Spectrum1D(spectral_axis=np.arange(5000, 5010)*u.AA, flux=np.random.sample((5, 10))*u.Jy)
-    >>> spec_slice = spec[0] #doctest:+SKIP
-    >>> spec_slice.spectral_axis #doctest:+SKIP
-    <Quantity [5000., 5001., 5002., 5003., 5004., 5005., 5006., 5007., 5008., 5009.] Angstrom>
+    >>> spec_slice = spec[0]
+    >>> spec_slice.spectral_axis
+    <SpectralAxis [5000., 5001., 5002., 5003., 5004., 5005., 5006., 5007., 5008., 5009.] Angstrom>
     >>> spec_slice.flux #doctest:+SKIP
     <Quantity [0.72722821, 0.32147784, 0.70256482, 0.04445197, 0.03390352,
            0.50835299, 0.87581725, 0.50270413, 0.08556376, 0.53713355] Jy>
@@ -196,6 +196,39 @@ While the above example only shows two dimensions, this concept generalizes to
 any number of dimensions for `~specutils.Spectrum1D`, as long as the spectral
 axis is always the last.
 
+
+Slicing
+-------
+
+As seen above, `~specutils.Spectrum1D` supports slicing in the same way as any 
+other array-like object. Additionally, a `~specutils.Spectrum1D` can be sliced 
+along the spectral axis using world coordinates. 
+
+.. code-block:: python
+
+    >>> from specutils import Spectrum1D
+
+    >>> spec = Spectrum1D(spectral_axis=np.arange(5000, 5010)*u.AA, flux=np.random.sample((5, 10))*u.Jy)
+    >>> spec_slice = spec[5002*u.AA:5006*u.AA]
+    >>> spec_slice.spectral_axis
+    <SpectralAxis [5002., 5003., 5004., 5005., 5006.] Angstrom>
+
+Note that this uses `~specutils.manipulation.extract_region` on the backend,
+which means that the upper bound is inclusive.
+
+Note that slicing on world coordinates for axes other than the spectral axis is
+not currently supported. It is, however, possible to slice on other axes using 
+simple array indices at the same time as slicing the spectral axis based on 
+spectral values.
+
+.. code-block:: python
+
+    >>> from specutils import Spectrum1D
+
+    >>> spec = Spectrum1D(spectral_axis=np.arange(5000, 5010)*u.AA, flux=np.random.sample((5, 10))*u.Jy)
+    >>> spec_slice = spec[2:4, 5002*u.AA:5006*u.AA]
+    >>> spec_slice.shape
+    (2, 5)
 
 
 Reference/API

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -211,10 +211,7 @@ along the spectral axis using world coordinates.
     >>> spec = Spectrum1D(spectral_axis=np.arange(5000, 5010)*u.AA, flux=np.random.sample((5, 10))*u.Jy)
     >>> spec_slice = spec[5002*u.AA:5006*u.AA]
     >>> spec_slice.spectral_axis
-    <SpectralAxis [5002., 5003., 5004., 5005., 5006.] Angstrom>
-
-Note that this uses `~specutils.manipulation.extract_region` on the backend,
-which means that the upper bound is inclusive.
+    <SpectralAxis [5002., 5003., 5004., 5005.] Angstrom>
 
 Note that slicing on world coordinates for axes other than the spectral axis is
 not currently supported. It is, however, possible to slice on other axes using 
@@ -228,7 +225,7 @@ spectral values.
     >>> spec = Spectrum1D(spectral_axis=np.arange(5000, 5010)*u.AA, flux=np.random.sample((5, 10))*u.Jy)
     >>> spec_slice = spec[2:4, 5002*u.AA:5006*u.AA]
     >>> spec_slice.shape
-    (2, 5)
+    (2, 4)
 
 
 Reference/API

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -352,7 +352,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
             stop = self.spectral_axis[-1]
         else:
             # Force the upper bound to be open, as in normal python array slicing
-            exact_match = np.where(self.spectral_axis == stop)
+            exact_match = np.where(self.spectral_axis == item.stop)
             if len(exact_match[0]) == 1:
                 stop_index = exact_match[0][0] - 1
                 stop = self.spectral_axis[stop_index]

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -298,7 +298,7 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
 
         if not isinstance(item, slice):
             if isinstance(item, u.Quantity):
-                raise ValueError("Indexing on single spectral axis values is not"
+                raise ValueError("Indexing on a single spectral axis values is not"
                                  " currently allowed, please use a slice.")
             else:
                 item = slice(item, item + 1, None)
@@ -351,7 +351,13 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         if item.stop is None:
             stop = self.spectral_axis[-1]
         else:
-            stop = item.stop
+            # Force the upper bound to be open, as in normal python array slicing
+            exact_match = np.where(self.spectral_axis == stop)
+            if len(exact_match[0]) == 1:
+                stop_index = exact_match[0][0] - 1
+                stop = self.spectral_axis[stop_index]
+            else:
+                stop = item.stop
         reg = SpectralRegion(start, stop)
         return extract_region(self, reg)
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -267,10 +267,12 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
                 # We only allow slicing with world coordinates along the spectral
                 # axis for now
                 for attr in ("start", "stop"):
+                    if getattr(item, attr) is None:
+                        continue
                     if not getattr(item, attr).unit.is_equivalent(u.AA,
                             equivalencies=u.spectral()):
-                        raise ValueError("Slicing with world coordinates is only enabled"
-                                         " for the spectral axis.")
+                        raise ValueError("Slicing with world coordinates is only"
+                                         " enabled for spectral coordinates.")
                         break
                 spec_item = item
             else:
@@ -342,8 +344,15 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         Perform a region extraction given a slice on the spectral axis.
         """
         from ..manipulation import extract_region
-        reg = SpectralRegion(item.start or self.spectral_axis[0],
-                             item.stop or self.spectral_axis[-1])
+        if item.start is None:
+            start = self.spectral_axis[0]
+        else:
+            start = item.start
+        if item.stop is None:
+            stop = self.spectral_axis[-1]
+        else:
+            stop = item.stop
+        reg = SpectralRegion(start, stop)
         return extract_region(self, reg)
 
     @NDDataRef.mask.setter

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -5,7 +5,6 @@ import numpy as np
 from astropy import units as u
 from astropy.nddata import NDDataRef
 from astropy.utils.decorators import lazyproperty
-from packaging import version
 
 from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
@@ -246,6 +245,8 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         The first case is handled by the parent class, while the second is
         handled here.
         """
+
+        print(item)
 
         if self.flux.ndim > 1 or (type(item) == tuple and item[0] == Ellipsis):
             if type(item) == tuple:

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -247,8 +247,6 @@ class Spectrum1D(OneDSpectrumMixin, NDDataRef):
         handled here.
         """
 
-        print(item)
-
         if self.flux.ndim > 1 or (type(item) == tuple and item[0] == Ellipsis):
             if type(item) == tuple:
                 if len(item) == len(self.flux.shape) or item[0] == Ellipsis:

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -134,6 +134,28 @@ def test_spectral_axis_conversions():
     new_spec = spec.with_spectral_unit(u.GHz)
 
 
+def test_spectral_slice():
+    spec = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
+                      flux=np.random.random(10) * u.Jy)
+    sliced_spec = spec[300*u.nm:600*u.nm]
+    assert np.all(sliced_spec.spectral_axis == [300, 400, 500, 600] * u.nm)
+
+    sliced_spec = spec[:300*u.nm]
+    assert np.all(sliced_spec.spectral_axis == [100, 200, 300] * u.nm)
+
+    sliced_spec = spec[800*u.nm:]
+    assert np.all(sliced_spec.spectral_axis == [800, 900, 1000] * u.nm)
+
+    # Test higher dimensional slicing
+    spec = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
+                       flux=np.random.random((10, 10)) * u.Jy)
+    sliced_spec = spec[300*u.nm:600*u.nm]
+    assert np.all(sliced_spec.spectral_axis == [300, 400, 500, 600] * u.nm)
+
+    sliced_spec = spec[4:6, 300*u.nm:600*u.nm]
+    assert sliced_spec.shape == (2, 4)
+
+
 @pytest.mark.parametrize('unit', ['micron', 'GHz', 'cm**-1', 'eV'])
 def test_spectral_axis_equivalencies(unit):
     """Test that `u.spectral` equivalencies are enabled for `spectral_axis`."""

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -138,10 +138,13 @@ def test_spectral_slice():
     spec = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
                       flux=np.random.random(10) * u.Jy)
     sliced_spec = spec[300*u.nm:600*u.nm]
+    assert np.all(sliced_spec.spectral_axis == [300, 400, 500] * u.nm)
+
+    sliced_spec = spec[300*u.nm:605*u.nm]
     assert np.all(sliced_spec.spectral_axis == [300, 400, 500, 600] * u.nm)
 
     sliced_spec = spec[:300*u.nm]
-    assert np.all(sliced_spec.spectral_axis == [100, 200, 300] * u.nm)
+    assert np.all(sliced_spec.spectral_axis == [100, 200] * u.nm)
 
     sliced_spec = spec[800*u.nm:]
     assert np.all(sliced_spec.spectral_axis == [800, 900, 1000] * u.nm)
@@ -150,10 +153,10 @@ def test_spectral_slice():
     spec = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
                        flux=np.random.random((10, 10)) * u.Jy)
     sliced_spec = spec[300*u.nm:600*u.nm]
-    assert np.all(sliced_spec.spectral_axis == [300, 400, 500, 600] * u.nm)
+    assert np.all(sliced_spec.spectral_axis == [300, 400, 500] * u.nm)
 
     sliced_spec = spec[4:6, 300*u.nm:600*u.nm]
-    assert sliced_spec.shape == (2, 4)
+    assert sliced_spec.shape == (2, 3)
 
 
 @pytest.mark.parametrize('unit', ['micron', 'GHz', 'cm**-1', 'eV'])


### PR DESCRIPTION
Currently, to slice a `Spectrum1D` based on spectral axis values a user would need to use `manipulation.extract_region` or, equivalently, `manipulation.spectral_slab`. This PR adds the ability to slice a `Spectrum1D` simply by providing spectral axis values in the slice (which then get fed to `extract_region` on the backend), for example something like `spec[300*u.nm:600*u.nm]`.

Some things to note:
1. Currently it's not possible to provide a single spectral axis value, e.g. `spec[300*u.nm]`. @eteq wanted me to save that for a future PR, since there's some discussion to be had on how to handle that case.
2. `extract_region` is inclusive on the upper bound. I noted this fact in the docs, but it's probably still confusing since this behavior contradicts general expectations for slicing an array in python. It wouldn't be hard to add a bit more parsing to make this slicing exclude upper bounds if desired.
3. I went ahead and made this work with mixed array index/spectral axis values for multi-D arrays, e.g. `spec[5:10, 300*u.nm:600*u.nm]` but I'm not sure if that's too confusing or if it's actually useful. We could potentially restrict users from mixing array index/world coordinate slicing. 

My intent is to follow this up with the ability to slice/index on spatial world coordinates as well (which might make 3 above more of a moot point), but it looks like that's going to require some more significant refactoring. My intent is to do that refactoring with an eye toward making use of NDCube 2.0 once it's released, but I'm hoping to achieve something useful without having to wait for that release. 