### PR TITLE
fix sdss loader recognition for eboss

### DIFF
--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -67,7 +67,7 @@ def spec_identify(origin, *args, **kwargs):
                 hdulist[0].header.get('FIBERID', 0) > 0 and
                 len(hdulist) > 1 and
                 (isinstance(hdulist[1], fits.BinTableHDU) and
-                 hdulist[1].header.get('TTYPE3') == 'ivar'))
+                 hdulist[1].header.get('TTYPE3').lower() == 'ivar'))
 
 
 def spSpec_identify(origin, *args, **kwargs):

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -173,7 +173,7 @@ def test_manga_rss():
 
 @pytest.mark.remote_data
 def test_sdss_spec():
-    sp_pattern = 'spec-4055-55359-0596.fits.'
+    sp_pattern = 'spec-4055-55359-0596.fits'
     with urllib.request.urlopen(EBOSS_SPECTRUM_URL) as response:
         # Read from open file object
         spec = Spectrum1D.read(response, format="SDSS-III/IV spec")
@@ -190,6 +190,7 @@ def test_sdss_spec():
                 shutil.copyfileobj(response, tmp_file)
 
                 # Read from local disk via filename
+                print(tmp_file.name)
                 spec = Spectrum1D.read(tmp_file.name)
 
                 assert isinstance(spec, Spectrum1D)
@@ -210,7 +211,7 @@ def test_sdss_spec():
 
 @pytest.mark.remote_data
 def test_sdss_spspec():
-    sp_pattern = 'spSpec-51957-0273-016.fit.'
+    sp_pattern = 'spSpec-51957-0273-016.fit'
     with urllib.request.urlopen('http://das.sdss.org/spectro/1d_26/0273/1d/spSpec-51957-0273-016.fit') as response:
         # Read from open file object
         spec = Spectrum1D.read(response, format="SDSS-I/II spSpec")


### PR DESCRIPTION
Turns out the change made in #778 revealed a subtle issue in the auto-identifier: I guess at some point between SDSS I and EBOSS, the second table in the spec files seems to at some point changed something from `IVAR` to `ivar`.  The fix is pretty trivial though.  So this gets two of the remaining CI failures working.