### PR TITLE
Fix 2SLAQ_QSO loader error

### DIFF
--- a/specutils/io/default_loaders/gama.py
+++ b/specutils/io/default_loaders/gama.py
@@ -21,11 +21,16 @@ GAMA_2QZ_CONFIG = {
 }
 GAMA_2SLAQ_QSO_CONFIG = {
     "hdus": None,
-    "wcs": None,
+    "wcs": {
+        "pixel_reference_point_keyword": "CRPIX1",
+        "pixel_reference_point_value_keyword": "CRVAL1",
+        "pixel_width_keyword": "CDELT1",
+        "wavelength_unit": "Angstrom",
+    },
     "units": {"flux_unit": "count"},
     "all_standard_units": False,
     "all_keywords": True,
-    "valid_wcs": True,
+    "valid_wcs": False,
 }
 GAMA_CONFIG = {
     "hdu": {


### PR DESCRIPTION
This should fix the last remaining build failure.  I confess I don't really understand these Data Central loaders (@aragilar might?), but if I'm understanding right it looks like this is a case where the `GAMA_2SLAQ_QSO_CONFIG` was updated in the tests but not the loader itself (specifically, the details of how to interpret the wcs).  So this just copy-and-pastes `GAMA_2SLAQ_QSO_CONFIG` from the tests to the loaderm which seems to do the job.