### PR TITLE
Update logging to use a non-root logger

### DIFF
--- a/specutils/__init__.py
+++ b/specutils/__init__.py
@@ -50,4 +50,3 @@ class Conf(_config.ConfigNamespace):
     )
 
 conf = Conf()
-

--- a/specutils/__init__.py
+++ b/specutils/__init__.py
@@ -51,8 +51,3 @@ class Conf(_config.ConfigNamespace):
 
 conf = Conf()
 
-
-import logging
-
-logging.basicConfig(format='specutils [%(levelname)-8s]: %(message)s',
-level=logging.INFO)

--- a/specutils/__init__.py
+++ b/specutils/__init__.py
@@ -35,10 +35,6 @@ if not _ASTROPY_SETUP_:
     from .io.registers import _load_user_io
     _load_user_io()
 
-    # Set up non-root logger
-    from .utils.logger import log
-    log = log
-
 __citation__ = 'https://doi.org/10.5281/zenodo.1421356'
 
 

--- a/specutils/__init__.py
+++ b/specutils/__init__.py
@@ -35,6 +35,10 @@ if not _ASTROPY_SETUP_:
     from .io.registers import _load_user_io
     _load_user_io()
 
+    # Set up non-root logger
+    from .utils.logger import log
+    log = log
+
 __citation__ = 'https://doi.org/10.5281/zenodo.1421356'
 
 

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -1,5 +1,4 @@
 import itertools
-import logging
 import operator
 
 import numpy as np
@@ -12,6 +11,7 @@ import astropy.units as u
 
 from ..spectra.spectral_region import SpectralRegion
 from ..spectra.spectrum1d import Spectrum1D
+from specutils import log
 from ..utils import QuantityModel
 from ..analysis import fwhm, gaussian_sigma_width, centroid, warn_continuum_below_threshold
 from ..manipulation import extract_region, noise_region_uncertainty
@@ -20,8 +20,6 @@ from ..manipulation.utils import excise_regions
 __all__ = ['find_lines_threshold', 'find_lines_derivative', 'fit_lines',
            'estimate_line_parameters']
 
-
-log = logging.getLogger('specutils')
 
 # Define the initial estimators. This are the default methods to use to
 # estimate astropy model parameters. This is based on only a small subset of

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -20,6 +20,9 @@ from ..manipulation.utils import excise_regions
 __all__ = ['find_lines_threshold', 'find_lines_derivative', 'fit_lines',
            'estimate_line_parameters']
 
+
+log = logging.getLogger('specutils')
+
 # Define the initial estimators. This are the default methods to use to
 # estimate astropy model parameters. This is based on only a small subset of
 # the astropy models but it was determined that this is a decent start as most
@@ -383,7 +386,7 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(),
             if uncerts is not None:
                 weights = uncerts.array ** -1
             else:
-                logging.warning("Uncertainty values are not defined, but are "
+                log.warning("Uncertainty values are not defined, but are "
                                 "trying to be used in model fitting.")
         else:
             raise ValueError("Unrecognized value `%s` in keyword argument.",

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -1,5 +1,6 @@
 import itertools
 import operator
+import logging
 
 import numpy as np
 from astropy.modeling import fitting, Model, models
@@ -11,7 +12,6 @@ import astropy.units as u
 
 from ..spectra.spectral_region import SpectralRegion
 from ..spectra.spectrum1d import Spectrum1D
-from specutils import log
 from ..utils import QuantityModel
 from ..analysis import fwhm, gaussian_sigma_width, centroid, warn_continuum_below_threshold
 from ..manipulation import extract_region, noise_region_uncertainty
@@ -19,6 +19,8 @@ from ..manipulation.utils import excise_regions
 
 __all__ = ['find_lines_threshold', 'find_lines_derivative', 'fit_lines',
            'estimate_line_parameters']
+
+log = logging.getLogger(__name__)
 
 
 # Define the initial estimators. This are the default methods to use to

--- a/specutils/io/default_loaders/generic_cube.py
+++ b/specutils/io/default_loaders/generic_cube.py
@@ -6,6 +6,7 @@
 #  21-apr-2016  Peter Teuben    hackday at "SPECTROSCOPY TOOLS IN PYTHON WORKSHOP" STSCI
 
 import os
+import logging
 
 import numpy as np
 from astropy.io import fits
@@ -15,7 +16,8 @@ from astropy.wcs import WCS
 from ...spectra import Spectrum1D
 from ..registers import data_loader
 from ..parsing_utils import read_fileobj_or_hdulist
-from ...utils.logger import log
+
+log = logging.getLogger(__name__)
 
 
 # Define an optional identifier. If made specific enough, this circumvents the

--- a/specutils/io/default_loaders/generic_cube.py
+++ b/specutils/io/default_loaders/generic_cube.py
@@ -19,6 +19,8 @@ from ..registers import data_loader
 from ..parsing_utils import read_fileobj_or_hdulist
 
 
+log = logging.getLogger('specutils')
+
 # Define an optional identifier. If made specific enough, this circumvents the
 # need to add `format="my-format"` in the `Spectrum1D.read` call.
 def identify_generic_fits(origin, *args, **kwargs):
@@ -54,7 +56,7 @@ def generic_fits(file_obj, **kwargs):
             # if len(data.shape) != 1:
             #    raise Exception,"not a true cube"
         else:
-            logging.error("Unexpected shape %s.", shape)
+            log.error("Unexpected shape %s.", shape)
 
         # store some meta data
         meta = {'header': header}

--- a/specutils/io/default_loaders/generic_cube.py
+++ b/specutils/io/default_loaders/generic_cube.py
@@ -5,8 +5,6 @@
 #
 #  21-apr-2016  Peter Teuben    hackday at "SPECTROSCOPY TOOLS IN PYTHON WORKSHOP" STSCI
 
-import logging
-#
 import os
 
 import numpy as np
@@ -17,9 +15,8 @@ from astropy.wcs import WCS
 from ...spectra import Spectrum1D
 from ..registers import data_loader
 from ..parsing_utils import read_fileobj_or_hdulist
+from ...utils.logger import log
 
-
-log = logging.getLogger('specutils')
 
 # Define an optional identifier. If made specific enough, this circumvents the
 # need to add `format="my-format"` in the `Spectrum1D.read` call.

--- a/specutils/io/default_loaders/generic_ecsv_reader.py
+++ b/specutils/io/default_loaders/generic_ecsv_reader.py
@@ -1,5 +1,4 @@
 import os
-import logging
 
 from astropy.table import Table
 

--- a/specutils/io/default_loaders/muscles_sed.py
+++ b/specutils/io/default_loaders/muscles_sed.py
@@ -1,4 +1,3 @@
-import logging
 import os
 
 from astropy.io import fits

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import _io
 

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -17,6 +17,7 @@ from ..parsing_utils import read_fileobj_or_hdulist
 
 __all__ = ['wcs1d_fits_loader', 'non_linear_wcs1d_fits', 'non_linear_multispec_fits']
 
+log = logging.getLogger('specutils')
 
 def identify_wcs1d_fits(origin, *args, **kwargs):
     """
@@ -79,7 +80,7 @@ def wcs1d_fits_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
     -----
     Loader contributed by Kelle Cruz.
     """
-    logging.info("Spectrum file looks like wcs1d-fits")
+    log.info("Spectrum file looks like wcs1d-fits")
 
     with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
         header = hdulist[hdu].header
@@ -102,7 +103,7 @@ def wcs1d_fits_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
             wcs.wcs.cunit[0] = unit
         else:  # try with unit name stripped of excess plural 's'...
             wcs.wcs.cunit[0] = unit.rstrip('s')
-        logging.info(f"Extracted spectral axis unit '{unit}' from 'WAT1_001'")
+        log.info(f"Extracted spectral axis unit '{unit}' from 'WAT1_001'")
     elif wcs.wcs.cunit[0] == '':
         wcs.wcs.cunit[0] = 'Angstrom'
 
@@ -254,14 +255,14 @@ def non_linear_wcs1d_fits(file_obj, **kwargs):
     spectral_axis, flux, meta = _read_non_linear_iraf_fits(file_obj, **kwargs)
 
     if spectral_axis.ndim > 1:
-        logging.info(f'Read spectral axis of shape {spectral_axis.shape} - '
+        log.info(f'Read spectral axis of shape {spectral_axis.shape} - '
                      'consider loading into SpectrumCollection.')
         spectral_axis = spectral_axis.flatten()
 
     # Check for ascending or descending values, as flattening might have joined overlapping orders.
     ds = (spectral_axis[1:] - spectral_axis[:-1]) / (spectral_axis[-1] - spectral_axis[0])
     if ds.min() < 0:
-        logging.warning('Non-monotonous spectral axis found, consider loading '
+        log.warning('Non-monotonous spectral axis found, consider loading '
                         'into SpectrumCollection.')
 
     if flux.shape[-1] != spectral_axis.shape[-1]:
@@ -306,7 +307,7 @@ def non_linear_multispec_fits(file_obj, **kwargs):
     spectral_axis, flux, meta = _read_non_linear_iraf_fits(file_obj, **kwargs)
 
     if spectral_axis.ndim == 1:
-        logging.info(f'Read 1D spectral axis of length {spectral_axis.shape[0]} - '
+        log.info(f'Read 1D spectral axis of length {spectral_axis.shape[0]} - '
                      'consider loading into Spectrum1D.')
         spectral_axis = spectral_axis.reshape((1, -1))
     if flux.ndim == 1:
@@ -356,18 +357,18 @@ def _read_non_linear_iraf_fits(file_obj, spectral_axis_unit=None, flux_unit=None
         Dictionary of {'header': hdulist[0].header}.
     """
 
-    logging.info('Loading 1D non-linear fits solution')
+    log.info('Loading 1D non-linear fits solution')
 
     with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
         header = hdulist[0].header
         for wcsdim in range(1, header['WCSDIM'] + 1):
             ctypen = header['CTYPE{:d}'.format(wcsdim)]
             if ctypen == 'LINEAR':
-                logging.info("linear Solution: Try using `format='wcs1d-fits'` instead")
+                log.info("linear Solution: Try using `format='wcs1d-fits'` instead")
                 wcs = WCS(header)
                 spectral_axis = _read_linear_iraf_wcs(wcs=wcs, dc_flag=header['DC-FLAG'])
             elif ctypen == 'MULTISPE':
-                logging.info("Multi spectral or non-linear solution")
+                log.info("Multi spectral or non-linear solution")
                 spectral_axis = _read_non_linear_iraf_wcs(header=header, wcsdim=wcsdim)
             else:
                 raise NotImplementedError
@@ -377,7 +378,7 @@ def _read_non_linear_iraf_fits(file_obj, spectral_axis_unit=None, flux_unit=None
         elif 'BUNIT' in header:
             data = u.Quantity(hdulist[0].data, unit=header['BUNIT'])
         else:
-            logging.info("Flux unit was not provided, nor found in the header. Assuming ADU.")
+            log.info("Flux unit was not provided, nor found in the header. Assuming ADU.")
             data = u.Quantity(hdulist[0].data, unit='adu')
 
     if spectral_axis_unit is None:
@@ -388,7 +389,7 @@ def _read_non_linear_iraf_fits(file_obj, spectral_axis_unit=None, flux_unit=None
             spectral_axis_unit = unit
         else:  # try with unit name stripped of excess plural 's'...
             spectral_axis_unit = unit.rstrip('s')
-        logging.info(f"Extracted spectral axis unit '{spectral_axis_unit}' from 'WAT1_001'")
+        log.info(f"Extracted spectral axis unit '{spectral_axis_unit}' from 'WAT1_001'")
     spectral_axis *= u.Unit(spectral_axis_unit)
 
     return spectral_axis, data, dict(header=header)
@@ -467,12 +468,12 @@ def _read_non_linear_iraf_wcs(header, wcsdim):
                   'pmin': lambda x: int(float(x)), 'pmax': lambda x: int(float(x))}
 
     ctypen = header['CTYPE{:d}'.format(wcsdim)]
-    logging.info('Attempting to read CTYPE{:d}: {:s}'.format(wcsdim, ctypen))
+    log.info('Attempting to read CTYPE{:d}: {:s}'.format(wcsdim, ctypen))
     if ctypen == 'MULTISPE':
         # This is extracting all header cards for f'WAT{wcsdim}_*' into a list
         wat_head = header['WAT{:d}*'.format(wcsdim)]
         if len(wat_head) == 1:
-            logging.debug('Get units')
+            log.debug('Get units')
             wat_array = wat_head[0].split(' ')
             for pair in wat_array:
                 split_pair = pair.split('=')
@@ -489,7 +490,7 @@ def _read_non_linear_iraf_wcs(header, wcsdim):
                     # print(wat_array[i], wat_array[i + 1])
 
     for key in wat_wcs_dict.keys():
-        logging.debug("{:d} -{:s}- {:s}".format(wcsdim, key, wat_wcs_dict[key]))
+        log.debug("{:d} -{:s}- {:s}".format(wcsdim, key, wat_wcs_dict[key]))
 
     specn = [k for k in wat_wcs_dict.keys() if k.startswith('spec')]
     spectral_axis = np.empty((len(specn), header['NAXIS1']))
@@ -498,12 +499,12 @@ def _read_non_linear_iraf_wcs(header, wcsdim):
         wcs_dict = dict((k, wcs_parser[k](spec[i])) for i, k in enumerate(wcs_parser.keys()))
         wcs_dict['fpar'] = [float(i) for i in spec[15:]]
 
-        logging.debug(f'Retrieving model for {sp}: {wcs_dict["dtype"]} {wcs_dict["ftype"]}')
+        log.debug(f'Retrieving model for {sp}: {wcs_dict["dtype"]} {wcs_dict["ftype"]}')
         math_model = _set_math_model(wcs_dict=wcs_dict)
 
         spectral_axis[n] = math_model(range(1, wcs_dict['pnum'] + 1)) / (1. + wcs_dict['z'])
 
-    logging.info(f'Constructed spectral axis of shape {spectral_axis.shape}')
+    log.info(f'Constructed spectral axis of shape {spectral_axis.shape}')
     return spectral_axis
 
 
@@ -545,16 +546,16 @@ def _set_math_model(wcs_dict):
 
     """
     if wcs_dict['dtype'] == -1:
-        logging.debug('No wavelength solution found (DTYPE={dtype:d})'.format(**wcs_dict))
+        log.debug('No wavelength solution found (DTYPE={dtype:d})'.format(**wcs_dict))
         return _none()
     elif wcs_dict['dtype'] == 0:
-        logging.debug('Setting model for DTYPE={dtype:d}'.format(**wcs_dict))
+        log.debug('Setting model for DTYPE={dtype:d}'.format(**wcs_dict))
         return _linear_solution(wcs_dict=wcs_dict)
     elif wcs_dict['dtype'] == 1:
-        logging.debug('Setting model for DTYPE={dtype:d}'.format(**wcs_dict))
+        log.debug('Setting model for DTYPE={dtype:d}'.format(**wcs_dict))
         return _log_linear(wcs_dict=wcs_dict)
     elif wcs_dict['dtype'] == 2:
-        logging.debug('Setting model for DTYPE={dtype:d} FTYPE={ftype:d}'.format(**wcs_dict))
+        log.debug('Setting model for DTYPE={dtype:d} FTYPE={ftype:d}'.format(**wcs_dict))
         if wcs_dict['ftype'] == 1:
             return _chebyshev(wcs_dict=wcs_dict)
         elif wcs_dict['ftype'] == 2:

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -1,5 +1,6 @@
 import warnings
 import _io
+import logging
 
 from astropy import units as u
 from astropy.io import fits
@@ -13,9 +14,10 @@ import shlex
 from ...spectra import Spectrum1D, SpectrumCollection
 from ..registers import data_loader, custom_writer
 from ..parsing_utils import read_fileobj_or_hdulist
-from ...utils.logger import log
 
 __all__ = ['wcs1d_fits_loader', 'non_linear_wcs1d_fits', 'non_linear_multispec_fits']
+
+log = logging.getLogger(__name__)
 
 
 def identify_wcs1d_fits(origin, *args, **kwargs):

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -1,4 +1,3 @@
-import logging
 import warnings
 import _io
 
@@ -14,10 +13,10 @@ import shlex
 from ...spectra import Spectrum1D, SpectrumCollection
 from ..registers import data_loader, custom_writer
 from ..parsing_utils import read_fileobj_or_hdulist
+from ...utils.logger import log
 
 __all__ = ['wcs1d_fits_loader', 'non_linear_wcs1d_fits', 'non_linear_multispec_fits']
 
-log = logging.getLogger('specutils')
 
 def identify_wcs1d_fits(origin, *args, **kwargs):
     """

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -16,6 +16,8 @@ import logging
 from specutils.spectra import Spectrum1D, SpectrumCollection
 
 
+log = logging.getLogger('specutils')
+
 @contextlib.contextmanager
 def read_fileobj_or_hdulist(*args, **kwargs):
     """ Context manager for reading a filename or file object
@@ -97,7 +99,7 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
             kwarg_val = u.Quantity(table[col_name], tab_unit)
 
             # Attempt to convert the table unit to the user-defined unit.
-            logging.debug("Attempting auto-convert of table unit '%s' to "
+            log.debug("Attempting auto-convert of table unit '%s' to "
                           "user-provided unit '%s'.", tab_unit, cm_unit)
 
             if not isinstance(cm_unit, u.Unit):

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -11,12 +11,10 @@ from astropy.nddata import StdDevUncertainty
 from astropy.utils.exceptions import AstropyUserWarning
 import astropy.units as u
 import warnings
-import logging
 
 from specutils.spectra import Spectrum1D, SpectrumCollection
+from ..utils.logger import log
 
-
-log = logging.getLogger('specutils')
 
 @contextlib.contextmanager
 def read_fileobj_or_hdulist(*args, **kwargs):

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -4,6 +4,7 @@ import re
 import urllib
 import io
 import contextlib
+import logging
 
 from astropy.io import fits
 from astropy.table import Table
@@ -13,7 +14,8 @@ import astropy.units as u
 import warnings
 
 from specutils.spectra import Spectrum1D, SpectrumCollection
-from ..utils.logger import log
+
+log = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -5,13 +5,15 @@ import os
 import pathlib
 import sys
 from functools import wraps
+import logging
 
 from astropy.io import registry as io_registry
 
 from ..spectra import Spectrum1D, SpectrumList, SpectrumCollection
-from ..utils.logger import log
 
 __all__ = ['data_loader', 'custom_writer', 'get_loaders_by_extension', 'identify_spectrum_format']
+
+log = logging.getLogger(__name__)
 
 
 def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -2,7 +2,6 @@
 A module containing the mechanics of the specutils io registry.
 """
 import os
-import logging
 import pathlib
 import sys
 from functools import wraps
@@ -10,12 +9,10 @@ from functools import wraps
 from astropy.io import registry as io_registry
 
 from ..spectra import Spectrum1D, SpectrumList, SpectrumCollection
-
+from ..utils.logger import log
 
 __all__ = ['data_loader', 'custom_writer', 'get_loaders_by_extension', 'identify_spectrum_format']
 
-
-log = logging.getLogger('specutils')
 
 def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
                 priority=0):

--- a/specutils/io/registers.py
+++ b/specutils/io/registers.py
@@ -15,6 +15,8 @@ from ..spectra import Spectrum1D, SpectrumList, SpectrumCollection
 __all__ = ['data_loader', 'custom_writer', 'get_loaders_by_extension', 'identify_spectrum_format']
 
 
+log = logging.getLogger('specutils')
+
 def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
                 priority=0):
     """
@@ -45,8 +47,8 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
             try:
                 return ident(*args, **kwargs)
             except Exception as e:
-                logging.debug("Tried to read this as {} file, but could not.".format(label))
-                logging.debug(e, exc_info=True)
+                log.debug("Tried to read this as {} file, but could not.".format(label))
+                log.debug(e, exc_info=True)
                 return False
         return wrapper
 
@@ -57,7 +59,7 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
             # If the identifier is not defined, but the extensions are, create
             # a simple identifier based off file extension.
             if extensions is not None:
-                logging.info("'{}' data loader provided for {} without "
+                log.info("'{}' data loader provided for {} without "
                              "explicit identifier. Creating identifier using "
                              "list of compatible extensions".format(
                                  label, dtype.__name__))
@@ -65,7 +67,7 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
                                                           for x in extensions])
             # Otherwise, create a dummy identifier
             else:
-                logging.warning("'{}' data loader provided for {} without "
+                log.warning("'{}' data loader provided for {} without "
                              "explicit identifier or list of compatible "
                              "extensions".format(label, dtype.__name__))
                 id_func = lambda *args, **kwargs: True
@@ -88,7 +90,7 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
         io_registry._readers.clear()
         io_registry._readers.update(sorted_loaders)
 
-        logging.debug("Successfully loaded reader \"{}\".".format(label))
+        log.debug("Successfully loaded reader \"{}\".".format(label))
 
         # Automatically register a SpectrumList reader for any data_loader that
         # reads Spectrum1D objects. TODO: it's possible that this
@@ -103,7 +105,7 @@ def data_loader(label, identifier=None, dtype=Spectrum1D, extensions=None,
 
             io_registry.register_reader(label, SpectrumList, load_spectrum_list)
             io_registry.register_identifier(label, SpectrumList, id_func)
-            logging.debug("Created SpectrumList reader for \"{}\".".format(label))
+            log.debug("Created SpectrumList reader for \"{}\".".format(label))
 
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/specutils/manipulation/resample.py
+++ b/specutils/manipulation/resample.py
@@ -1,4 +1,3 @@
-import logging
 from abc import ABC, abstractmethod
 
 from warnings import warn

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -1,5 +1,3 @@
-import warnings
-
 import astropy.units as u
 from astropy.utils.decorators import lazyproperty
 from astropy.coordinates import SpectralCoord

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -1,5 +1,5 @@
-import logging
 from copy import deepcopy
+import logging
 
 import numpy as np
 from astropy import units as u
@@ -14,6 +14,7 @@ from ndcube import NDCube
 
 __all__ = ['Spectrum1D']
 
+log = logging.getLogger('specutils')
 
 class Spectrum1D(OneDSpectrumMixin, NDCube):
     """
@@ -153,7 +154,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                 rest_value = None
         else:
             if not isinstance(rest_value, u.Quantity):
-                logging.info("No unit information provided with rest value. "
+                log.info("No unit information provided with rest value. "
                              "Assuming units of spectral axis ('%s').",
                              spectral_axis.unit)
                 rest_value = u.Quantity(rest_value, spectral_axis.unit)
@@ -197,8 +198,8 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                 # Due to FITS conventions, a WCS with spectral axis first corresponds
                 # to a flux array with spectral axis last.
                 if temp_axes[0] != 0:
-                    logging.warn("Input WCS indicates that the spectral axis is not"
-                                 " last. Reshaping arrays to put spectral axis last.")
+                    log.warn("Input WCS indicates that the spectral axis is not"
+                             " last. Reshaping arrays to put spectral axis last.")
                     wcs = wcs.swapaxes(0, temp_axes[0])
                     if flux is not None:
                         flux = np.moveaxis(flux, len(flux.shape)-temp_axes[0]-1, -1)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-import logging
 
 import numpy as np
 from astropy import units as u
@@ -9,12 +8,12 @@ from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
 from .spectral_region import SpectralRegion
 from ..utils.wcs_utils import gwcs_from_array
+from ..utils.logger import log
 from astropy.coordinates import SpectralCoord
 from ndcube import NDCube
 
 __all__ = ['Spectrum1D']
 
-log = logging.getLogger('specutils')
 
 class Spectrum1D(OneDSpectrumMixin, NDCube):
     """

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import logging
 
 import numpy as np
 from astropy import units as u
@@ -8,11 +9,12 @@ from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
 from .spectral_region import SpectralRegion
 from ..utils.wcs_utils import gwcs_from_array
-from ..utils.logger import log
 from astropy.coordinates import SpectralCoord
 from ndcube import NDCube
 
 __all__ = ['Spectrum1D']
+
+log = logging.getLogger(__name__)
 
 
 class Spectrum1D(OneDSpectrumMixin, NDCube):

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -1,13 +1,16 @@
+import logging
+
 import astropy.units as u
 import numpy as np
 from astropy.nddata import NDUncertainty, StdDevUncertainty
 from astropy.coordinates import SpectralCoord
 
 from .spectrum1d import Spectrum1D
-from ..utils.logger import log
 from astropy.nddata import NDIOMixin
 
 __all__ = ['SpectrumCollection']
+
+log = logging.getLogger(__name__)
 
 
 class SpectrumCollection(NDIOMixin):

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -1,16 +1,14 @@
-import logging
-
 import astropy.units as u
 import numpy as np
 from astropy.nddata import NDUncertainty, StdDevUncertainty
 from astropy.coordinates import SpectralCoord
 
 from .spectrum1d import Spectrum1D
+from ..utils.logger import log
 from astropy.nddata import NDIOMixin
 
 __all__ = ['SpectrumCollection']
 
-log = logging.getLogger('specutils')
 
 class SpectrumCollection(NDIOMixin):
     """

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -10,6 +10,7 @@ from astropy.nddata import NDIOMixin
 
 __all__ = ['SpectrumCollection']
 
+log = logging.getLogger('specutils')
 
 class SpectrumCollection(NDIOMixin):
     """
@@ -81,7 +82,7 @@ class SpectrumCollection(NDIOMixin):
             # If the uncertainties are not provided a unit, raise a warning
             # and use the flux units
             if not isinstance(uncertainty, u.Quantity):
-                logging.warning("No unit associated with uncertainty, assuming"
+                log.warning("No unit associated with uncertainty, assuming"
                                 "flux units of '{}'.".format(flux.unit))
                 uncertainty = u.Quantity(uncertainty, unit=flux.unit)
 
@@ -167,7 +168,7 @@ class SpectrumCollection(NDIOMixin):
         else:
             uncertainty = None
 
-            logging.warning("Not all spectra have associated uncertainties of "
+            log.warning("Not all spectra have associated uncertainties of "
                             "the same type, skipping uncertainties.")
 
         # Check that either all spectra have associated masks, or that
@@ -178,7 +179,7 @@ class SpectrumCollection(NDIOMixin):
         else:
             mask = None
 
-            logging.warning("Not all spectra have associated masks, "
+            log.warning("Not all spectra have associated masks, "
                             "skipping masks.")
 
         # Store the wcs and meta as lists

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import logging
 
 import numpy as np
 import astropy.units.equivalencies as eq
@@ -8,7 +9,6 @@ from astropy.utils.decorators import lazyproperty, deprecated
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 
 from specutils.utils.wcs_utils import gwcs_from_array
-from ..utils.logger import log
 
 DOPPLER_CONVENTIONS = {}
 DOPPLER_CONVENTIONS['radio'] = u.doppler_radio
@@ -16,6 +16,8 @@ DOPPLER_CONVENTIONS['optical'] = u.doppler_optical
 DOPPLER_CONVENTIONS['relativistic'] = u.doppler_relativistic
 
 __all__ = ['OneDSpectrumMixin']
+
+log = logging.getLogger(__name__)
 
 
 class OneDSpectrumMixin(NDIOMixin):

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -1,4 +1,3 @@
-import logging
 from copy import deepcopy
 
 import numpy as np
@@ -9,6 +8,7 @@ from astropy.utils.decorators import lazyproperty, deprecated
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 
 from specutils.utils.wcs_utils import gwcs_from_array
+from ..utils.logger import log
 
 DOPPLER_CONVENTIONS = {}
 DOPPLER_CONVENTIONS['radio'] = u.doppler_radio
@@ -17,7 +17,6 @@ DOPPLER_CONVENTIONS['relativistic'] = u.doppler_relativistic
 
 __all__ = ['OneDSpectrumMixin']
 
-log = logging.getLogger('specutils')
 
 class OneDSpectrumMixin(NDIOMixin):
     @property

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -17,6 +17,7 @@ DOPPLER_CONVENTIONS['relativistic'] = u.doppler_relativistic
 
 __all__ = ['OneDSpectrumMixin']
 
+log = logging.getLogger('specutils')
 
 class OneDSpectrumMixin(NDIOMixin):
     @property
@@ -287,7 +288,7 @@ class OneDSpectrumMixin(NDIOMixin):
                 self.wcs.unit[0], equivalencies=u.spectral()):
             return gwcs_from_array(self.spectral_axis), meta
 
-        logging.error("WCS units incompatible: {} and {}.".format(
+        log.error("WCS units incompatible: {} and {}.".format(
             unit, self._wcs_unit))
 
 

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import sys
 import shutil

--- a/specutils/utils/logger.py
+++ b/specutils/utils/logger.py
@@ -1,6 +1,0 @@
-import logging
-
-__all__ = ['log']
-
-# Initialize a non-root logger that other files can use
-log = logging.getLogger('specutils')

--- a/specutils/utils/logger.py
+++ b/specutils/utils/logger.py
@@ -1,0 +1,6 @@
+import logging
+
+__all__ = ['log']
+
+# Initialize a non-root logger that other files can use
+log = logging.getLogger('specutils')


### PR DESCRIPTION
Fixes #728. This also removes some code from the __init__ file that was messing with the default logging config, which I think we would rather leave in the control of the user as discussed in #728.

I'm still deciding the best way to set the logger in each file; I'll move this from draft to ready once I've finalized it. In the meantime, comments are welcome.