### PR TITLE
Update manga cube loader, fix bugs in Spectrum1D init

### DIFF
--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -1,7 +1,7 @@
-
 import astropy.units as u
 from astropy.io import fits
 from astropy.nddata import InverseVariance
+from astropy.wcs import WCS
 
 from ...spectra import Spectrum1D
 from ..registers import data_loader
@@ -53,7 +53,7 @@ def manga_cube_loader(file_obj, **kwargs):
 
     spaxel = u.Unit('spaxel', represents=u.pixel, doc='0.5" spatial pixel', parse_strict='silent')
     with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
-        spectrum = _load_manga_spectra(hdulist, per_unit=spaxel, transpose=True)
+        spectrum = _load_manga_spectra(hdulist, per_unit=spaxel)
 
     return spectrum
 
@@ -83,13 +83,13 @@ def manga_rss_loader(file_obj, **kwargs):
     return spectrum
 
 
-def _load_manga_spectra(hdulist, per_unit=None, transpose=None):
+def _load_manga_spectra(hdulist, per_unit=None):
     """ Return a MaNGA Spectrum1D object
 
-    Returns a Spectrum1D object for a MaNGA data files.  Set
-    `transpose` kwarg to True for MaNGA cubes, as they are flipped relative
-    to what Spectrum1D expects.  Use the `per_unit` kwarg to indicate the
-    "spaxel" or "fiber" unit for cubes and rss files, respectively.
+    Returns a Spectrum1D object for a MaNGA data files. Use the `per_unit`
+    kwarg to indicate the "spaxel" or "fiber" unit for cubes and rss files,
+    respectively. Note that the spectral axis will automatically be moved to
+    be last during Spectrum1D initialization.
 
     Parameters
     ----------
@@ -97,8 +97,6 @@ def _load_manga_spectra(hdulist, per_unit=None, transpose=None):
         A MaNGA read astropy fits HDUList
     per_unit : astropy.units.Unit
         An astropy unit to divide the default flux unit by
-    transpose : bool
-        If True, transpose the data arrays
 
     Returns
     -------
@@ -110,18 +108,12 @@ def _load_manga_spectra(hdulist, per_unit=None, transpose=None):
         unit = unit / per_unit
 
     hdr = hdulist['PRIMARY'].header
-    wave = hdulist['WAVE'].data * u.angstrom
+    wcs = WCS(hdulist['FLUX'].header)
 
-    if transpose:
-        flux = hdulist['FLUX'].data.T * unit
-        ivar = InverseVariance(hdulist["IVAR"].data.T)
-        # SDSS masks are arrays of bit values storing multiple boolean conditions.
-        # Setting non-zero bit values to True to map to specutils standard
-        mask = hdulist['MASK'].data.T != 0
-    else:
-        flux = hdulist['FLUX'].data * unit
-        ivar = InverseVariance(hdulist["IVAR"].data)
-        mask = hdulist['MASK'].data != 0
+    flux = hdulist['FLUX'].data * unit
+    ivar = InverseVariance(hdulist["IVAR"].data)
+    # SDSS masks are arrays of bit values storing multiple boolean conditions.
+    mask = hdulist['MASK'].data != 0
 
-    return Spectrum1D(flux=flux, meta={'header': hdr}, spectral_axis=wave,
+    return Spectrum1D(flux=flux, meta={'header': hdr}, wcs=wcs,
                       uncertainty=ivar, mask=mask)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 import numpy as np
 from astropy import units as u
 from astropy.utils.decorators import lazyproperty
+from astropy.nddata import NDUncertainty
 
 from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
@@ -205,12 +206,22 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                     if "mask" in kwargs:
                         if kwargs["mask"] is not None:
                             kwargs["mask"] = np.moveaxis(kwargs["mask"],
-                                                len(kwargs["mask"])-temp_axes[0]-1, -1)
+                                                len(kwargs["mask"].shape)-temp_axes[0]-1, -1)
                     if "uncertainty" in kwargs:
                         if kwargs["uncertainty"] is not None:
-                            kwargs["uncertainty"] = np.moveaxis(kwargs["uncertainty"],
-                                                    len(kwargs["uncertainty"].shape) -
-                                                    temp_axes[0]-1, -1)
+                            if isinstance(kwargs["uncertainty"], NDUncertainty):
+                                # Account for Astropy uncertainty types
+                                unc_len = len(kwargs["uncertainty"].array.shape)
+                                temp_unc = np.moveaxis(kwargs["uncertainty"].array,
+                                                       unc_len-temp_axes[0]-1, -1)
+                                if kwargs["uncertainty"].unit is not None:
+                                    temp_unc = temp_unc * u.Unit(kwargs["uncertainty"].unit)
+                                kwargs["uncertainty"] = type(kwargs["uncertainty"])(temp_unc)
+                            else:
+                                kwargs["uncertainty"] = np.moveaxis(kwargs["uncertainty"],
+                                                        len(kwargs["uncertainty"].shape) -
+                                                        temp_axes[0]-1, -1)
+
 
         # Attempt to parse the spectral axis. If none is given, try instead to
         # parse a given wcs. This is put into a GWCS object to


### PR DESCRIPTION
This updates the manga cube loader to take advantage of #754 by initializing the `Spectrum1D` with the WCS rather than a spectral axis. I also had to fix a few bugs that this surfaced in the `Spectrum1D` initialization code, which now properly reshapes an input mask as well as handling reshaping `uncertainty` inputs that are `astropy.nddata.NDUncertainty` instances.