### PR TITLE
Raise an error if bin_edges is called for unevenly spaced centers

### DIFF
--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -48,6 +48,11 @@ class SpectralAxis(SpectralCoord):
         centers, with the two outer edges based on extrapolated centers added
         to the beginning and end of the spectral axis.
         """
+        diffs = centers[1:] - centers[:-1]
+        if not np.all(diffs == diffs[0]):
+            raise ValueError("Cannot calculate consistent bin edges from"
+                             " unevenly spaced bin centers")
+
         a = np.insert(centers, 0, 2*centers[0] - centers[1])
         b = np.append(centers, 2*centers[-1] - centers[-2])
         edges = (a + b) / 2

--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -51,6 +51,12 @@ def test_create_with_bin_edges():
     assert np.all(spectral_axis.bin_edges == wavelengths)
     assert np.all(spectral_axis == [505., 530., 555., 575.]*u.AA)
 
+def test_uneven_centers():
+
+    wavelengths = [10,15,25,28]*u.AA
+
+    with pytest.raises(ValueError):
+        spectral_axis.bin_edges
 
 # GENERAL TESTS
 


### PR DESCRIPTION
Addresses #809. I could be convinced that this should just be a warning instead of an error, but I think since the calculated bin edges don't reproduce the input centers we should error and not return them at all. See the linked issue for a little more discussion of why I didn't just implement a better edge calculation algorithm.