### PR TITLE
Adds support for JWST c1d spectroscopic files

### DIFF
--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -241,16 +241,17 @@ def _jwst_spec1d_loader(file_obj, extname='EXTRACT1D', **kwargs):
             if "srctype" in hdu.header:
                 srctype = hdu.header.get("srctype", None)
 
+            # checking if SRCTPYE is missing or UNKNOWN
+            if not srctype or srctype == 'UNKNOWN':
+                log.warning('SRCTYPE is missing or UNKNOWN.  Defaulting to srctype="POINT".')
+                srctype = 'POINT'
+
             if srctype == "POINT":
                 flux = Quantity(data["FLUX"])
                 uncertainty = StdDevUncertainty(data["ERROR"])
             elif srctype == "EXTENDED":
                 flux = Quantity(data["SURF_BRIGHT"])
                 uncertainty = StdDevUncertainty(hdu.data["SB_ERROR"])
-            elif srctype == 'UNKNOWN':
-                flux = Quantity(data["FLUX"])
-                uncertainty = StdDevUncertainty(data["ERROR"])
-                log.warning('SRCTYPE is UNKNOWN.  Defaulting to loading FLUX and ERROR data.')
             else:
                 raise RuntimeError(f"Keyword SRCTYPE is {srctype}.  It should "
                                    "be 'POINT' or 'EXTENDED'. Can't decide between `flux` and "

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 
 def _identify_spec1d_fits(origin, extname, *args, **kwargs):
+    """ Generic spec 1d identifier function """
     is_jwst = _identify_jwst_fits(*args)
     with read_fileobj_or_hdulist(*args, memmap=False, **kwargs) as hdulist:
         return (is_jwst and extname in hdulist and (extname, 2) not in hdulist)
@@ -254,7 +255,7 @@ def _jwst_spec1d_loader(file_obj, extname='EXTRACT1D', **kwargs):
                 raise RuntimeError(f"Keyword SRCTYPE is {srctype}.  It should "
                                    "be 'POINT' or 'EXTENDED'. Can't decide between `flux` and "
                                    "`surf_bright` columns.")
-            breakpoint()
+
             # Merge primary and slit headers and dump into meta
             slit_header = hdu.header
             header = primary_header.copy()

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -234,9 +234,9 @@ def _jwst_spec1d_loader(file_obj, extname='EXTRACT1D', **kwargs):
             # per most recent pipeline definition, it should be in the
             # EXTRACT1D extension.
             #
-            # SRCTYPE should either be POINT or EXTENDED.  In some cases, it is UNKNOWN.
-            # if UNKNOWN, default to using the FLUX column.  Error out only when SRCTYPE
-            # cannot be found.
+            # SRCTYPE should either be POINT or EXTENDED.  In some cases, it is UNKNOWN
+            # or missing.  If that's the case, default to using POINT as the SRCTYPE.
+            # Error out only when SRCTYPE is a bad value.
             srctype = None
             if "srctype" in hdu.header:
                 srctype = hdu.header.get("srctype", None)

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -243,7 +243,8 @@ def _jwst_spec1d_loader(file_obj, extname='EXTRACT1D', **kwargs):
 
             # checking if SRCTPYE is missing or UNKNOWN
             if not srctype or srctype == 'UNKNOWN':
-                log.warning('SRCTYPE is missing or UNKNOWN.  Defaulting to srctype="POINT".')
+                log.warning('SRCTYPE is missing or UNKNOWN in JWST x1d loader. 
+                             Defaulting to srctype="POINT".')
                 srctype = 'POINT'
 
             if srctype == "POINT":

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -243,8 +243,8 @@ def _jwst_spec1d_loader(file_obj, extname='EXTRACT1D', **kwargs):
 
             # checking if SRCTPYE is missing or UNKNOWN
             if not srctype or srctype == 'UNKNOWN':
-                log.warning('SRCTYPE is missing or UNKNOWN in JWST x1d loader. 
-                             Defaulting to srctype="POINT".')
+                log.warning('SRCTYPE is missing or UNKNOWN in JWST x1d loader. '
+                            'Defaulting to srctype="POINT".')
                 srctype = 'POINT'
 
             if srctype == "POINT":

--- a/specutils/io/default_loaders/tests/test_jwst_reader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_reader.py
@@ -112,6 +112,21 @@ def test_jwst_1d_single_reader(tmpdir, spec_single, format):
     assert data.shape == (100,)
 
 
+@pytest.mark.parametrize("srctype", [None, "UNKNOWN"])
+def test_jwst_srctpye_defaults(tmpdir, x1d_single, srctype):
+    """ Test """
+    tmpfile = str(tmpdir.join('jwst.fits'))
+
+    # Add a spectrum with missing or UNKNOWN SRCTYPE (mutate the fixture)
+    x1d_single['EXTRACT1D'].header['SRCTYPE'] == srctype
+    x1d_single.writeto(tmpfile)
+
+    data = Spectrum1D.read(tmpfile, format='JWST x1d')
+    assert type(data) is Spectrum1D
+    assert data.shape == (100,)
+    assert x1d_single['EXTRACT1D'].header['SRCTYPE'] == "POINT"
+
+
 @pytest.mark.parametrize('spec_single', ['EXTRACT1D', 'COMBINE1D'], indirect=['spec_single'])
 def test_jwst_1d_single_reader_no_format(tmpdir, spec_single):
     """Test Spectrum1D.read for JWST c1d/x1d data without format arg"""
@@ -172,9 +187,9 @@ def test_jwst_1d_single_reader_fail_on_multi(tmpdir, spec_multi):
         Spectrum1D.read(tmpfile)
 
 
-@pytest.mark.parametrize("srctype", [None, "BADVAL"])
+@pytest.mark.parametrize("srctype", ["BADVAL"])
 def test_jwst_reader_fail(tmpdir, x1d_single, srctype):
-    """Check that the reader fails when SRCTYPE is not set or is BADVAL"""
+    """Check that the reader fails when SRCTYPE is a BADVAL"""
     tmpfile = str(tmpdir.join('jwst.fits'))
     hdulist = x1d_single
     # Add a spectrum with bad SRCTYPE (mutate the fixture)


### PR DESCRIPTION
This PR adds support for JWST combined 1d spectroscopic files (c1d).  These files are structurally the same as x1d files, so I've consolidated the identifiers and loaders.  I've also added a case when the `SRCTYPE` header keyword is present but has `value='UNKNOWN'`, where I issue a warning and default to using the `FLUX` and `ERROR` columns.  The original `SRCTYPE` error is issued when the `SRCTYPE` header value cannot be found.   

The logging syntax mirrors that of https://github.com/astropy/specutils/pull/810, but this PR is not dependent on that PR.  