### PR TITLE
Use np.swapaxes to match wcs operation correctly

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -206,23 +206,23 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                              " last. Reshaping arrays to put spectral axis last.")
                     wcs = wcs.swapaxes(0, temp_axes[0])
                     if flux is not None:
-                        flux = np.moveaxis(flux, len(flux.shape)-temp_axes[0]-1, -1)
+                        flux = np.swapaxes(flux, len(flux.shape)-temp_axes[0]-1, -1)
                     if "mask" in kwargs:
                         if kwargs["mask"] is not None:
-                            kwargs["mask"] = np.moveaxis(kwargs["mask"],
+                            kwargs["mask"] = np.swapaxes(kwargs["mask"],
                                                 len(kwargs["mask"].shape)-temp_axes[0]-1, -1)
                     if "uncertainty" in kwargs:
                         if kwargs["uncertainty"] is not None:
                             if isinstance(kwargs["uncertainty"], NDUncertainty):
                                 # Account for Astropy uncertainty types
                                 unc_len = len(kwargs["uncertainty"].array.shape)
-                                temp_unc = np.moveaxis(kwargs["uncertainty"].array,
+                                temp_unc = np.swapaxes(kwargs["uncertainty"].array,
                                                        unc_len-temp_axes[0]-1, -1)
                                 if kwargs["uncertainty"].unit is not None:
                                     temp_unc = temp_unc * u.Unit(kwargs["uncertainty"].unit)
                                 kwargs["uncertainty"] = type(kwargs["uncertainty"])(temp_unc)
                             else:
-                                kwargs["uncertainty"] = np.moveaxis(kwargs["uncertainty"],
+                                kwargs["uncertainty"] = np.swapaxes(kwargs["uncertainty"],
                                                         len(kwargs["uncertainty"].shape) -
                                                         temp_axes[0]-1, -1)
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -193,7 +193,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                 for i in range(len(phys_axes)):
                     if phys_axes[i] is None:
                         continue
-                    if phys_axes[i][0:2] == "em":
+                    if phys_axes[i][0:2] == "em" or phys_axes[i][0:5] == "spect":
                         temp_axes.append(i)
                 if len(temp_axes) != 1:
                     raise ValueError("Input WCS must have exactly one axis with "

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from astropy.nddata import StdDevUncertainty
 from astropy.coordinates import SpectralCoord
+from astropy.wcs import WCS
 
 from .conftest import remote_access
 from ..spectra import Spectrum1D
@@ -106,6 +107,20 @@ def test_create_with_spectral_coord():
     assert isinstance(spec.spectral_axis, SpectralCoord)
     assert spec.spectral_axis.size == 50
 
+
+def test_create_from_cube():
+
+    flux = np.arange(24).reshape([2,3,4])*u.Jy
+    wcs_dict = {"CTYPE1": "RA---TAN", "CTYPE2": "DEC--TAN", "CTYPE3": "WAVE-LOG",
+                "CRVAL1": 205, "CRVAL2": 27, "CRVAL3": 3.622e-7,
+                "CRDELT1": -0.0001, "CRDELT2": 0.0001, "CRDELT3": 8e-11,
+                "CRPIX1": 0, "CRPIX2": 0, "CRPIX3": 0}
+    w = WCS(wcs_dict)
+
+    spec = Spectrum1D(flux=flux, wcs=w)
+
+    assert spec.flux.shape == (4,3,2)
+    assert spec.flux[3,2,1] == 23*u.Jy
 
 def test_spectral_axis_conversions():
     # By default the spectral axis units should be set to angstroms

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -121,6 +121,7 @@ def test_create_from_cube():
 
     assert spec.flux.shape == (4,3,2)
     assert spec.flux[3,2,1] == 23*u.Jy
+    assert np.all(spec.spectral_axis.value == np.exp(np.array([1,2])*w.wcs.cdelt[-1]/w.wcs.crval[-1])*w.wcs.crval[-1])
 
 def test_spectral_axis_conversions():
     # By default the spectral axis units should be set to angstroms

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -113,7 +113,7 @@ def test_create_from_cube():
     flux = np.arange(24).reshape([2,3,4])*u.Jy
     wcs_dict = {"CTYPE1": "RA---TAN", "CTYPE2": "DEC--TAN", "CTYPE3": "WAVE-LOG",
                 "CRVAL1": 205, "CRVAL2": 27, "CRVAL3": 3.622e-7,
-                "CRDELT1": -0.0001, "CRDELT2": 0.0001, "CRDELT3": 8e-11,
+                "CDELT1": -0.0001, "CDELT2": 0.0001, "CDELT3": 8e-11,
                 "CRPIX1": 0, "CRPIX2": 0, "CRPIX3": 0}
     w = WCS(wcs_dict)
 


### PR DESCRIPTION
After a vacation break, I came back and looked at this code with fresh eyes and immediately said "how the heck did I convince myself I needed to use `np.moveaxis` instead of `np.swapaxes`?" 

@eteq @nmearl can I get a sanity check here - I believe the way I have it coded now the RA/Dec axes in a 3D flux cube end up switched compared to the WCS, which this PR should fix. I think I had somehow erroneously gotten into my head at some point that the WCS operation was a move, not a swap. 