### PR TITLE
Stop infinitely recursing in some model fitting cases

### DIFF
--- a/specutils/tests/test_utils.py
+++ b/specutils/tests/test_utils.py
@@ -24,7 +24,7 @@ def test_quantity_model():
 
     assert uc(10*u.nm).to(u.m) == 0*u.m
 
-def test_pickle_quantity_model():
+def test_pickle_quantity_model(tmp_path):
     """
     Check that a QuantityModel can roundtrip through pickling, as it
     would if fit in a multiprocessing pool.
@@ -33,10 +33,12 @@ def test_pickle_quantity_model():
     c = modeling.models.Chebyshev1D(3)
     uc = QuantityModel(c, u.AA, u.km)
 
-    with open("qmodel.pkl", "wb") as f:
+    pkl_file = tmp_path / "qmodel.pkl"
+
+    with open(pkl_file, "wb") as f:
         pickle.dump(uc, f)
 
-    with open("qmodel.pkl", "rb") as f:
+    with open(pkl_file, "rb") as f:
         new_model = pickle.load(f)
 
     assert new_model.input_units == uc.input_units

--- a/specutils/utils/quantity_model.py
+++ b/specutils/utils/quantity_model.py
@@ -41,7 +41,7 @@ class QuantityModel:
         return False
 
     def __getattr__(self, nm):
-        if hasattr(self.unitless_model, nm):
+        if nm != 'unitless_model' and hasattr(self.unitless_model, nm):
             return getattr(self.unitless_model, nm)
         else:
             raise AttributeError("'{}' object has no attribute '{}'"


### PR DESCRIPTION
I was running into a nasty infinite recursion while trying to fit `Polynomial1D` or `Linear1D` models, possibly due to some quirk of the way `fit_lines` was getting called in a wrapper class in a multiprocessing pool. Regardless of the exact details, this change prevents the infinite recursion. However, I'm somewhat surprised that it didn't break anything else and I'm not 100% clear about the initial motivation for overriding the attribute getters and setters, so I'm very open to suggestions on better ways to fix this.