### PR TITLE
Handle new `PhysicalType` class in `spectrum_from_column_mapping`

### DIFF
--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -134,10 +134,12 @@ def tabular_fits_writer(spectrum, file_name, hdu=1, update_header=False, **kwarg
     wunit = u.Unit(kwargs.pop('wunit', spectrum.spectral_axis.unit))
     disp = spectrum.spectral_axis.to(wunit, equivalencies=u.spectral())
 
-    # Mapping of spectral_axis types to header TTYPE1
-    dispname = wunit.physical_type
+    # Mapping of spectral_axis types to header TTYPE1 (no "torque/work" types!)
+    dispname = str(wunit.physical_type)
     if dispname == "length":
         dispname = "wavelength"
+    elif "energy" in dispname:
+        dispname = "energy"
 
     # Add flux array and unit
     ftype = kwargs.pop('ftype', spectrum.flux.dtype)

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -104,8 +104,8 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
 
             if not isinstance(cm_unit, u.Unit):
                 cm_unit = u.Unit(cm_unit)
-            cm_type =  str(cm_unit.physical_type)
-            if 'length in cm_type' or 'frequency' in cm_type or 'energy' in cm_type:
+            cm_type = str(cm_unit.physical_type)
+            if 'length' in cm_type or 'frequency' in cm_type or 'energy' in cm_type:
                 # Spectral axis column information
                 kwarg_val = kwarg_val.to(cm_unit, equivalencies=u.spectral())
             elif 'spectral flux' in cm_type:

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -104,11 +104,10 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
 
             if not isinstance(cm_unit, u.Unit):
                 cm_unit = u.Unit(cm_unit)
-            cm_type = str(cm_unit.physical_type)
-            if 'length' in cm_type or 'frequency' in cm_type or 'energy' in cm_type:
+            if cm_unit.physical_type in ('length', 'frequency', 'energy'):
                 # Spectral axis column information
                 kwarg_val = kwarg_val.to(cm_unit, equivalencies=u.spectral())
-            elif 'spectral flux' in cm_type:
+            elif 'spectral flux' in str(cm_unit.physical_type):
                 # Flux/error column information
                 kwarg_val = kwarg_val.to(cm_unit, equivalencies=u.spectral_density(1 * u.AA))
         elif tab_unit:

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -99,8 +99,8 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
             kwarg_val = u.Quantity(table[col_name], tab_unit)
 
             # Attempt to convert the table unit to the user-defined unit.
-            log.debug(f"Attempting auto-convert of table unit {tab_unit} to "
-                      f"user-provided unit {cm_unit}.")
+            log.debug("Attempting auto-convert of table unit '%s' to "
+                      "user-provided unit '%s'.", tab_unit, cm_unit)
 
             if not isinstance(cm_unit, u.Unit):
                 cm_unit = u.Unit(cm_unit)

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -99,18 +99,18 @@ def spectrum_from_column_mapping(table, column_mapping, wcs=None):
             kwarg_val = u.Quantity(table[col_name], tab_unit)
 
             # Attempt to convert the table unit to the user-defined unit.
-            log.debug("Attempting auto-convert of table unit '%s' to "
-                          "user-provided unit '%s'.", tab_unit, cm_unit)
+            log.debug(f"Attempting auto-convert of table unit {tab_unit} to "
+                      f"user-provided unit {cm_unit}.")
 
             if not isinstance(cm_unit, u.Unit):
                 cm_unit = u.Unit(cm_unit)
-            if cm_unit.physical_type in ('length', 'frequency'):
+            cm_type =  str(cm_unit.physical_type)
+            if 'length in cm_type' or 'frequency' in cm_type or 'energy' in cm_type:
                 # Spectral axis column information
                 kwarg_val = kwarg_val.to(cm_unit, equivalencies=u.spectral())
-            elif 'spectral flux' in cm_unit.physical_type:
+            elif 'spectral flux' in cm_type:
                 # Flux/error column information
-                kwarg_val = kwarg_val.to(
-                    cm_unit, equivalencies=u.spectral_density(1 * u.AA))
+                kwarg_val = kwarg_val.to(cm_unit, equivalencies=u.spectral_density(1 * u.AA))
         elif tab_unit:
             # The user has provided no unit in the column mapping, so we
             # use the unit as defined in the table object.

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -522,14 +522,14 @@ def test_tabular_fits_writer(tmpdir, spectral_axis):
         spectrum.write(tmpfile, format='tabular-fits')
     spectrum.write(tmpfile, format='tabular-fits', overwrite=True)
 
-    cmap = {spectral_axis: ('spectral_axis', wlu[spectral_axis]),
+    cmap = {spectral_axis: ('spectral_axis', 'micron'),
             'flux': ('flux', 'erg / (s cm**2 AA)'),
             'uncertainty': ('uncertainty', None)}
 
     # Read it back again and check against the original
     spec = Spectrum1D.read(tmpfile, format='tabular-fits', column_mapping=cmap)
     assert spec.flux.unit == u.Unit('erg / (s cm**2 AA)')
-    assert spec.spectral_axis.unit == spectrum.spectral_axis.unit
+    assert spec.spectral_axis.unit == u.um
     assert quantity_allclose(spec.spectral_axis, spectrum.spectral_axis)
     assert quantity_allclose(spec.flux, spectrum.flux)
     assert quantity_allclose(spec.uncertainty.quantity,
@@ -566,13 +566,13 @@ def test_tabular_fits_multid(tmpdir, ndim, spectral_axis):
                              spectrum.uncertainty.quantity)
 
     # Test again, using `column_mapping` to convert to different flux unit
-    cmap = {spectral_axis: ('spectral_axis', wlu[spectral_axis]),
+    cmap = {spectral_axis: ('spectral_axis', 'THz'),
             'flux': ('flux', 'erg / (s cm**2 AA)'),
             'uncertainty': ('uncertainty', None)}
 
     spec = Spectrum1D.read(tmpfile, format='tabular-fits', column_mapping=cmap)
     assert spec.flux.unit == u.Unit('erg / (s cm**2 AA)')
-    assert spec.spectral_axis.unit == spectrum.spectral_axis.unit
+    assert spec.spectral_axis.unit == u.THz
     assert quantity_allclose(spec.spectral_axis, spectrum.spectral_axis)
     assert quantity_allclose(spec.flux, spectrum.flux)
     assert quantity_allclose(spec.uncertainty.quantity,

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -522,6 +522,7 @@ def test_tabular_fits_writer(tmpdir, spectral_axis):
         spectrum.write(tmpfile, format='tabular-fits')
     spectrum.write(tmpfile, format='tabular-fits', overwrite=True)
 
+    # Map to alternative set of units
     cmap = {spectral_axis: ('spectral_axis', 'micron'),
             'flux': ('flux', 'erg / (s cm**2 AA)'),
             'uncertainty': ('uncertainty', None)}
@@ -565,7 +566,7 @@ def test_tabular_fits_multid(tmpdir, ndim, spectral_axis):
     assert quantity_allclose(spec.uncertainty.quantity,
                              spectrum.uncertainty.quantity)
 
-    # Test again, using `column_mapping` to convert to different flux unit
+    # Test again, using `column_mapping` to convert to different spectral axis and flux units
     cmap = {spectral_axis: ('spectral_axis', 'THz'),
             'flux': ('flux', 'erg / (s cm**2 AA)'),
             'uncertainty': ('uncertainty', None)}


### PR DESCRIPTION
To fix #831 and #824.

This converts the new ~astropy.units.physical.PhysicalType class from 4.3 (https://github.com/astropy/astropy/pull/11204) to string, if necessary, and also uses the appropriate type only from types like `PhysicalType({'energy', 'torque', 'work'})`. Updated tests to test setting of custom `spectral_axis` units and types as well.