### PR TITLE
Fix test_spectral_axis by passing frame instances

### DIFF
--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -67,8 +67,8 @@ LSRD = Galactic(u=0 * u.km, v=0 * u.km, w=0 * u.km,
 LSRD_EQUIV = [
               LSRD,
               SkyCoord(LSRD),  # as a SkyCoord
-              LSRD.transform_to(ICRS),  # different frame
-              LSRD.transform_to(ICRS).transform_to(Galactic)  # different representation
+              LSRD.transform_to(ICRS()),  # different frame
+              LSRD.transform_to(ICRS()).transform_to(Galactic())  # different representation
               ]
 
 


### PR DESCRIPTION
Fixes deprecation warning #779 in setup of `test_spectral_axis.py`.
Tested against astropy 4.1-4.3rc1.