### PR TITLE
Fix loader failures in remote data test

### DIFF
--- a/specutils/io/default_loaders/apogee.py
+++ b/specutils/io/default_loaders/apogee.py
@@ -146,8 +146,7 @@ def apStar_loader(file_obj, **kwargs):
     return Spectrum1D(data=data * unit,
                       uncertainty=uncertainty,
                       spectral_axis=dispersion * dispersion_unit,
-                      meta=meta,
-                      wcs=wcs)
+                      meta=meta)
 
 
 @data_loader(label="APOGEE aspcapStar", identifier=aspcapStar_identify, extensions=['fits'])

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -191,11 +191,13 @@ class Spectrum1D(OneDSpectrumMixin, NDCube):
                 temp_axes = []
                 phys_axes = wcs.world_axis_physical_types
                 for i in range(len(phys_axes)):
+                    if phys_axes[i] is None:
+                        continue
                     if phys_axes[i][0:2] == "em":
                         temp_axes.append(i)
                 if len(temp_axes) != 1:
-                    raise ValueError("Input WCS must have exactly one axis"
-                                     " with spectral units")
+                    raise ValueError("Input WCS must have exactly one axis with "
+                                     "spectral units, found {}".format(len(temp_axes)))
 
                 # Due to FITS conventions, a WCS with spectral axis first corresponds
                 # to a flux array with spectral axis last.


### PR DESCRIPTION
The `Spectrum1D.__init__` code now accounts for the possibility of `None` values in WCS physical axis types. Also, the apStar loader no longer passes the original WCS into the `Spectrum1D` it creates (that WCS was previously overwritten by the manually specified spectral axis, it doesn't make sense to keep since it doesn't match the reshaped data the loader creates for the `Spectrum1D`).