### PR TITLE
Use spectral_axis.bin_edges to integrate continuum flux in equivalent_width

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -113,9 +113,9 @@ For the equivalent width, note the need to add a continuum level:
     >>> from specutils.analysis import equivalent_width
     >>> noisy_gaussian_with_continuum = noisy_gaussian + 1*u.Jy
     >>> equivalent_width(noisy_gaussian_with_continuum)  # doctest:+FLOAT_CMP
-    <Quantity -5.02976212 GHz>
+    <Quantity -4.97951 GHz>
     >>> equivalent_width(noisy_gaussian_with_continuum, regions=SpectralRegion(7*u.GHz, 3*u.GHz))  # doctest:+FLOAT_CMP
-    <Quantity -4.9881 GHz>
+    <Quantity -4.93785 GHz>
 
 
 Centroid

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,7 +94,7 @@ may have downloaded from some archive, or reduced from your own observations.
     >>> from specutils import SpectralRegion
     >>> from specutils.analysis import equivalent_width
     >>> equivalent_width(cont_norm_spec, regions=SpectralRegion(6562 * u.AA, 6575 * u.AA)) # doctest: +REMOTE_DATA +FLOAT_CMP
-    <Quantity -16.25232188 Angstrom>
+    <Quantity -14.7396 Angstrom>
 
 
 While there are other tools and spectral representations detailed more below,

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -176,7 +176,7 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
 
     spectral_axis = calc_spectrum.spectral_axis
 
-    dx = (np.abs(spectral_axis[-1] - spectral_axis[0]))
+    dx = (np.abs(spectral_axis.bin_edges[-1] - spectral_axis.bin_edges[0]))
 
     line_flux = _compute_line_flux(spectrum, regions,
                                    mask_interpolation=mask_interpolation)

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -173,22 +173,21 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
             flux=spectrum.flux[~mask],
             spectral_axis=spectrum.spectral_axis[~mask])
 
-    if continuum == 1:
-        continuum = 1*calc_spectrum.flux.unit
+    # Calculate the continuum flux value
+    continuum = u.Quantity(continuum, unit=spectrum.flux.unit)
 
-    spectral_axis = calc_spectrum.spectral_axis
+    # If continuum is provided as a single scalar/quantity value, create an
+    # array the same size as the processed spectrum. Otherwise, assume that the
+    # continuum was provided as an array and use as-is.
+    if continuum.size == 1:
+        continuum = continuum * np.ones(spectrum.flux.size)
 
-    if regions is not None:
-        cont_spec = Spectrum1D(flux=continuum*np.ones(spectral_axis.shape),
-                               spectral_axis=calc_spectrum.spectral_axis)
-        cont_flux = _compute_line_flux(cont_spec, mask_interpolation=mask_interpolation)
-    else:
-        cont_flux = continuum * (np.abs(spectral_axis.bin_edges[-1] - spectral_axis.bin_edges[0]))
-
-    if mask is not None:
-        line_flux = _compute_line_flux(spectrum, regions, mask_interpolation=mask_interpolation)
-    else:
-        line_flux = _compute_line_flux(calc_spectrum, mask_interpolation=mask_interpolation)
+    cont_spec = Spectrum1D(flux=continuum, 
+                           spectral_axis=spectrum.spectral_axis)
+    cont_flux = _compute_line_flux(cont_spec,
+                                   mask_interpolation=mask_interpolation)
+    line_flux = _compute_line_flux(spectrum,
+                                   mask_interpolation=mask_interpolation)
 
     # Calculate equivalent width
     ew = (cont_flux - line_flux) / continuum

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -190,9 +190,10 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
                                    mask_interpolation=mask_interpolation)
 
     # Calculate equivalent width
-    ew = (cont_flux - line_flux) / continuum
+    dx = np.abs(np.diff(spectrum.spectral_axis.bin_edges))
+    ew = np.sum((1 - line_flux / cont_flux) * dx)
 
-    return ew.to(calc_spectrum.spectral_axis.unit)
+    return ew.to(spectrum.spectral_axis.unit)
 
 
 def is_continuum_below_threshold(spectrum, threshold=0.01):

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -169,7 +169,9 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
     if hasattr(calc_spectrum, 'mask') and calc_spectrum.mask is not None:
         mask = calc_spectrum.mask
         calc_spectrum = Spectrum1D(flux=calc_spectrum.flux[~mask],
-                              spectral_axis=calc_spectrum.spectral_axis[~mask])
+                                   spectral_axis=calc_spectrum.spectral_axis[~mask])
+    else:
+        mask = None
 
     if continuum == 1:
         continuum = 1*calc_spectrum.flux.unit
@@ -179,11 +181,14 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
     if regions is not None:
         cont_spec = Spectrum1D(flux=continuum*np.ones(spectral_axis.shape),
                                spectral_axis=calc_spectrum.spectral_axis)
-        cont_flux = _compute_line_flux(cont_spec, regions, mask_interpolation=mask_interpolation)
+        cont_flux = _compute_line_flux(cont_spec, mask_interpolation=mask_interpolation)
     else:
         cont_flux = continuum * (np.abs(spectral_axis.bin_edges[-1] - spectral_axis.bin_edges[0]))
 
-    line_flux = _compute_line_flux(spectrum, regions, mask_interpolation=mask_interpolation)
+    if mask is not None:
+        line_flux = _compute_line_flux(spectrum, regions, mask_interpolation=mask_interpolation)
+    else:
+        line_flux = _compute_line_flux(calc_spectrum, mask_interpolation=mask_interpolation)
 
     # Calculate equivalent width
     ew = (cont_flux - line_flux) / continuum

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -176,13 +176,17 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
 
     spectral_axis = calc_spectrum.spectral_axis
 
-    dx = (np.abs(spectral_axis.bin_edges[-1] - spectral_axis.bin_edges[0]))
+    if regions is not None:
+        cont_spec = Spectrum1D(flux=continuum*np.ones(spectral_axis.shape),
+                               spectral_axis=calc_spectrum.spectral_axis)
+        cont_flux = _compute_line_flux(cont_spec, regions, mask_interpolation=mask_interpolation)
+    else:
+        cont_flux = continuum * (np.abs(spectral_axis.bin_edges[-1] - spectral_axis.bin_edges[0]))
 
-    line_flux = _compute_line_flux(spectrum, regions,
-                                   mask_interpolation=mask_interpolation)
+    line_flux = _compute_line_flux(spectrum, regions, mask_interpolation=mask_interpolation)
 
     # Calculate equivalent width
-    ew = dx - (line_flux / continuum)
+    ew = (cont_flux - line_flux) / continuum
 
     return ew.to(calc_spectrum.spectral_axis.unit)
 

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -73,7 +73,7 @@ def equivalent_width(spectrum, continuum=1, regions=None,
         The spectrum object overwhich the equivalent width will be calculated.
 
     regions: `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
-        Region within the spectrum to calculate the gaussian sigma width. If
+        Region within the spectrum to calculate the equivalent width. If
         regions is `None`, computation is performed over entire spectrum.
 
     continuum : ``1`` or `~astropy.units.Quantity`, optional
@@ -182,7 +182,7 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
     if continuum.size == 1:
         continuum = continuum * np.ones(spectrum.flux.size)
 
-    cont_spec = Spectrum1D(flux=continuum, 
+    cont_spec = Spectrum1D(flux=continuum,
                            spectral_axis=spectrum.spectral_axis)
     cont_flux = _compute_line_flux(cont_spec,
                                    mask_interpolation=mask_interpolation)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -10,6 +10,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 from ..spectra import Spectrum1D, SpectralRegion
 from ..spectra.spectrum_collection import SpectrumCollection
+from ..spectra.spectral_axis import SpectralAxis
 
 from ..analysis import (line_flux, equivalent_width, snr, centroid,
                         gaussian_sigma_width, gaussian_fwhm, fwhm, moment,
@@ -118,7 +119,7 @@ def test_equivalent_width():
     # be negative
     expected = -(np.sqrt(2*np.pi) * u.GHz)
 
-    assert quantity_allclose(result, expected, atol=0.01*u.GHz)
+    assert quantity_allclose(result, expected, atol=0.0025*u.GHz)
 
 
 def test_equivalent_width_masked ():
@@ -146,12 +147,12 @@ def test_equivalent_width_masked ():
 
     assert result.unit.is_equivalent(spectrum.wcs.unit)
 
-    assert quantity_allclose(result.value, -719.90618, atol=0.001)
+    assert quantity_allclose(result.value, -719.90618, atol=0.0005)
 
     # With flux conserving resampler
     result = equivalent_width(spectrum_masked,
                               mask_interpolation=FluxConservingResampler)
-    assert quantity_allclose(result.value, -719.987425, atol=0.001)
+    assert quantity_allclose(result.value, -719.987425, atol=0.0005)
 
 
 def test_equivalent_width_regions():
@@ -159,17 +160,16 @@ def test_equivalent_width_regions():
     np.random.seed(42)
 
     frequencies = np.linspace(100, 1, 10000) * u.GHz
-    g = models.Gaussian1D(amplitude=1*u.Jy, mean=10*u.GHz, stddev=1*u.GHz)
+    g = models.Gaussian1D(amplitude=1*u.Jy, mean=20*u.GHz, stddev=1*u.GHz)
     noise = np.random.normal(0., 0.001, frequencies.shape) * u.Jy
     flux = g(frequencies) + noise + 1*u.Jy
 
     spec = Spectrum1D(spectral_axis=frequencies, flux=flux)
-    cont_norm_spec = spec / np.median(spec.flux)
-    result = equivalent_width(cont_norm_spec, regions=SpectralRegion(97*u.GHz, 3*u.GHz))
+    result = equivalent_width(spec, regions=SpectralRegion(60*u.GHz, 10*u.GHz))
 
     expected = -(np.sqrt(2*np.pi) * u.GHz)
 
-    assert quantity_allclose(result, expected, atol=0.02*u.GHz)
+    assert quantity_allclose(result, expected, atol=0.005*u.GHz)
 
 
 @pytest.mark.parametrize('continuum', [1*u.Jy, 2*u.Jy, 5*u.Jy])
@@ -192,7 +192,7 @@ def test_equivalent_width_continuum(continuum):
     # be negative
     expected = -(np.sqrt(2*np.pi) * u.GHz) / continuum.value
 
-    assert quantity_allclose(result, expected, atol=0.01*u.GHz)
+    assert quantity_allclose(result, expected, atol=0.005*u.GHz)
 
 
 def test_equivalent_width_absorption():
@@ -214,7 +214,35 @@ def test_equivalent_width_absorption():
 
     expected = amplitude*np.sqrt(2*np.pi) * u.GHz
 
-    assert quantity_allclose(result, expected, atol=0.01*u.GHz)
+    assert quantity_allclose(result, expected, atol=0.005*u.GHz)
+
+
+def test_equivalent_width_bin_edges():
+    """
+    Test spectrum with wavelength points defining bin edges, and at modest sampling.
+    """
+
+    np.random.seed(42)
+
+    wavelengths = np.linspace(500, 2500, 401) * u.AA
+    spectral_axis = SpectralAxis(wavelengths, bin_specification="edges")
+
+    flunit = u.Unit('W m-2 AA-1')
+    amplitude = 0.5
+    g = models.Gaussian1D(amplitude=amplitude*flunit, mean=1000*u.AA, stddev=100*u.AA)
+    continuum = 1*flunit
+    noise = np.random.normal(0., 0.01, wavelengths[1:].shape) * flunit
+    flux = continuum - g(wavelengths[1:]) + noise
+
+    spectrum = Spectrum1D(spectral_axis=spectral_axis, flux=flux)
+
+    result = equivalent_width(spectrum)
+
+    assert result.unit.is_equivalent(spectrum.wcs.unit, equivalencies=u.spectral())
+
+    expected = amplitude*np.sqrt(2*np.pi) * 100*u.AA
+
+    assert quantity_allclose(result, expected, atol=0.5*u.AA)
 
 
 def test_snr(simulated_spectra):

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -152,7 +152,7 @@ def test_equivalent_width_masked ():
     # With flux conserving resampler
     result = equivalent_width(spectrum_masked,
                               mask_interpolation=FluxConservingResampler)
-    assert quantity_allclose(result.value, -719.987425, atol=0.0005)
+    assert quantity_allclose(result.value, -719.89962, atol=0.0005)
 
 
 def test_equivalent_width_regions():


### PR DESCRIPTION
#841 shows a significant underestimate of the EW from `_compute_equivalent_width` for relatively coarsely sampled spectra, which appears to be due to inconsistent integration of the spectral/line flux (using the spectral axis range over `bin_edges` in `_compute_line_flux`) and continuum (using `spectral_axis` points/bin centres).
Modifying the continuum integration to use `bin_edges` as well, decreased tolerances of the tests, which lets them fail with the old version, and added one test using the `edges` definition with coarser sampling (which would result in errors of several Å using the old calculation).