### PR TITLE
Subclass Spectrum1D from `NDArithmeticMixin`

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -26,6 +26,7 @@ py:class ndcube.mixins.plotting.NDCubePlotMixin
 py:class ndcube.mixins.ndslicing.NDCubeSlicingMixin
 py:obj ndcube.NDCube
 py:obj NDCube
+py:obj NDCube.plotter
 py:obj ExtraCoords
 py:obj GlobalCoords
 py:obj ndcube.NDCube.world_axis_physical_types

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     gwcs!=0.16.0
     scipy
     asdf>=2.5
-    ndcube@git+https://github.com/sunpy/ndcube.git@947799ea213728d6215cb791508ef186ca53b24f
+    ndcube@git+https://github.com/sunpy/ndcube.git@v2.0.0rc1
 
 [options.extras_require]
 test =

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 from astropy import units as u
 from astropy.utils.decorators import lazyproperty
-from astropy.nddata import NDUncertainty
+from astropy.nddata import NDUncertainty, NDArithmeticMixin
 
 from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
@@ -18,7 +18,7 @@ __all__ = ['Spectrum1D']
 log = logging.getLogger(__name__)
 
 
-class Spectrum1D(OneDSpectrumMixin, NDCube):
+class Spectrum1D(OneDSpectrumMixin, NDCube, NDArithmeticMixin):
     """
     Spectrum container for 1D spectral data.
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 from astropy import units as u
 from astropy.utils.decorators import lazyproperty
-from astropy.nddata import NDUncertainty, NDArithmeticMixin
+from astropy.nddata import NDUncertainty
 
 from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
@@ -18,7 +18,7 @@ __all__ = ['Spectrum1D']
 log = logging.getLogger(__name__)
 
 
-class Spectrum1D(OneDSpectrumMixin, NDCube, NDArithmeticMixin):
+class Spectrum1D(OneDSpectrumMixin, NDCube):
     """
     Spectrum container for 1D spectral data.
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 from astropy import units as u
 from astropy.utils.decorators import lazyproperty
-from astropy.nddata import NDUncertainty
+from astropy.nddata import NDUncertainty, NDIOMixin, NDArithmeticMixin
 
 from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
@@ -18,7 +18,7 @@ __all__ = ['Spectrum1D']
 log = logging.getLogger(__name__)
 
 
-class Spectrum1D(OneDSpectrumMixin, NDCube):
+class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
     """
     Spectrum container for 1D spectral data.
 

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 import astropy.units.equivalencies as eq
 from astropy import units as u
-from astropy.nddata import NDIOMixin
+from astropy.nddata import NDIOMixin, NDArithmeticMixin
 from astropy.utils.decorators import lazyproperty, deprecated
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 
@@ -20,7 +20,7 @@ __all__ = ['OneDSpectrumMixin']
 log = logging.getLogger(__name__)
 
 
-class OneDSpectrumMixin(NDIOMixin):
+class OneDSpectrumMixin(NDIOMixin, NDArithmeticMixin):
     @property
     def _spectral_axis_numpy_index(self):
         return self.data.ndim - 1 - self.wcs.wcs.spec

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -4,7 +4,6 @@ import logging
 import numpy as np
 import astropy.units.equivalencies as eq
 from astropy import units as u
-from astropy.nddata import NDIOMixin, NDArithmeticMixin
 from astropy.utils.decorators import lazyproperty, deprecated
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 
@@ -20,7 +19,7 @@ __all__ = ['OneDSpectrumMixin']
 log = logging.getLogger(__name__)
 
 
-class OneDSpectrumMixin(NDIOMixin, NDArithmeticMixin):
+class OneDSpectrumMixin():
     @property
     def _spectral_axis_numpy_index(self):
         return self.data.ndim - 1 - self.wcs.wcs.spec


### PR DESCRIPTION
This implements a required modification to restore arithmetic functionality that has been removed from `NDCube` in https://github.com/sunpy/ndcube/pull/457 .
Subclassing `Spectrum1D` from `~astropy.nddata.NDArithmeticMixin` here; might be up for discussion if this should be done directly in `OneDSpectrumMixin` instead.

Note that `ndcube` has removed the arithmetic operations since they are not (yet) WCS-aware; I think `specutils` at this point does not offer consistent handling of addition on different spectral axes etc. either.
E.g. one can `+` two spectra with completely different `spectral_axis` as long as their shapes are matching without having as much as a warning raised.

To elaborate a but further; recently there has been some discussion on the mailing list on recommendations for correctly co-adding spectra on different wavelength grids along the lines implemented in https://github.com/hamogu/spectrum/blob/master/spectrum/coadd.py
Obviously this has never been further integrated in Astropy, and @hamogu has not been working on it for years, but there is certainly demand for some more automatic functionality beyond what is shown in https://specutils.readthedocs.io/en/stable/manipulation.html#resampling.