### PR TITLE
Run update before installing language pack in CI

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -74,7 +74,9 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install language-pack-de and tzdata
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get install language-pack-de tzdata graphviz
+      run: |
+          sudo apt-get update
+          sudo apt-get install language-pack-de tzdata graphviz
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox codecov
     - name: Run tests
@@ -110,7 +112,9 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install language-pack-de and tzdata
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get install language-pack-de tzdata
+      run: |
+          sudo apt-get update
+          sudo apt-get install language-pack-de tzdata
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox codecov
     - name: Run tests


### PR DESCRIPTION
Fix CI failures (see e.g. #850), same as in https://github.com/astropy/astropy/pull/12068. 