### PR TITLE
Set loader priorities so surveys override generic

### DIFF
--- a/specutils/io/default_loaders/aaomega_2df.py
+++ b/specutils/io/default_loaders/aaomega_2df.py
@@ -43,7 +43,7 @@ def identify_aaomega(origin, *args, **kwargs):
 
 @data_loader(
     label=AAOMEGA_LOADER, extensions=FITS_FILE_EXTS, dtype=SpectrumList,
-    identifier=identify_aaomega
+    identifier=identify_aaomega, priority=10,
 )
 def load_aaomega_file(filename, *args, **kwargs):
     with read_fileobj_or_hdulist(filename, *args, **kwargs) as fits_file:

--- a/specutils/io/default_loaders/apogee.py
+++ b/specutils/io/default_loaders/apogee.py
@@ -65,7 +65,10 @@ def aspcapStar_identify(origin, *args, **kwargs):
                 hdulist[-1].header.get('TTYPE45') == 'ASPCAPFLAG')
 
 
-@data_loader(label="APOGEE apVisit", identifier=apVisit_identify, extensions=['fits'])
+@data_loader(
+    label="APOGEE apVisit", identifier=apVisit_identify, extensions=['fits'],
+    priority=10,
+)
 def apVisit_loader(file_obj, **kwargs):
     """
     Loader for APOGEE apVisit files.
@@ -110,7 +113,10 @@ def apVisit_loader(file_obj, **kwargs):
                       meta=meta)
 
 
-@data_loader(label="APOGEE apStar", identifier=apStar_identify, extensions=['fits'])
+@data_loader(
+    label="APOGEE apStar", identifier=apStar_identify, extensions=['fits'],
+    priority=10,
+)
 def apStar_loader(file_obj, **kwargs):
     """
     Loader for APOGEE apStar files.
@@ -149,7 +155,10 @@ def apStar_loader(file_obj, **kwargs):
                       meta=meta)
 
 
-@data_loader(label="APOGEE aspcapStar", identifier=aspcapStar_identify, extensions=['fits'])
+@data_loader(
+    label="APOGEE aspcapStar", identifier=aspcapStar_identify,
+    extensions=['fits'], priority=10,
+)
 def aspcapStar_loader(file_obj, **kwargs):
     """
     Loader for APOGEE aspcapStar files.

--- a/specutils/io/default_loaders/ascii.py
+++ b/specutils/io/default_loaders/ascii.py
@@ -22,7 +22,10 @@ def ascii_identify(origin, *args, **kwargs):
     return False
 
 
-@data_loader(label="ASCII", identifier=ascii_identify, extensions=['txt', 'ascii'])
+@data_loader(
+    label="ASCII", identifier=ascii_identify, extensions=['txt', 'ascii'],
+    priority=-10
+)
 def ascii_loader(file_name, column_mapping=None, **kwargs):
     """
     Load spectrum from ASCII file.

--- a/specutils/io/default_loaders/gama.py
+++ b/specutils/io/default_loaders/gama.py
@@ -114,7 +114,7 @@ def identify_2qz(origin, *args, **kwargs):
 
 @data_loader(
     label="GAMA-2QZ", extensions=FITS_FILE_EXTS, dtype=SpectrumList,
-    identifier=identify_2qz,
+    identifier=identify_2qz, priority=10,
 )
 def twoqz_loader(filename):
     spectra = SpectrumList.read(
@@ -136,7 +136,7 @@ def identify_2slaq_qso(origin, *args, **kwargs):
 
 @data_loader(
     label="GAMA-2SLAQ-QSO", extensions=FITS_FILE_EXTS, dtype=SpectrumList,
-    identifier=identify_2slaq_qso,
+    identifier=identify_2slaq_qso, priority=10,
 )
 def twoslaq_qso_loader(filename):
     spectra = SpectrumList.read(
@@ -158,7 +158,7 @@ def identify_gama(origin, *args, **kwargs):
 
 @data_loader(
     label="GAMA", extensions=FITS_FILE_EXTS, dtype=SpectrumList,
-    identifier=identify_gama,
+    identifier=identify_gama, priority=10,
 )
 def gama_loader(filename):
     spectra = SpectrumList.read(
@@ -180,7 +180,7 @@ def identify_gama_lt(origin, *args, **kwargs):
 
 @data_loader(
     label="GAMA-LT", extensions=FITS_FILE_EXTS, dtype=SpectrumList,
-    identifier=identify_gama_lt,
+    identifier=identify_gama_lt, priority=10,
 )
 def gama_lt_loader(filename):
     spectra = SpectrumList.read(
@@ -202,7 +202,7 @@ def identify_mgc(origin, *args, **kwargs):
 
 @data_loader(
     label="GAMA-MGC", extensions=FITS_FILE_EXTS, dtype=SpectrumList,
-    identifier=identify_mgc,
+    identifier=identify_mgc, priority=10,
 )
 def mgc_loader(filename):
     spectra = SpectrumList.read(
@@ -224,7 +224,7 @@ def identify_wigglez(origin, *args, **kwargs):
 
 @data_loader(
     label="GAMA-WiggleZ", extensions=FITS_FILE_EXTS, dtype=SpectrumList,
-    identifier=identify_wigglez,
+    identifier=identify_wigglez, priority=10,
 )
 def wigglez_loader(filename):
     spectra = SpectrumList.read(
@@ -246,7 +246,7 @@ def identify_2dfgrs(origin, *args, **kwargs):
 
 @data_loader(
     label="GAMA-2dFGRS", extensions=FITS_FILE_EXTS, dtype=SpectrumList,
-    identifier=identify_2dfgrs,
+    identifier=identify_2dfgrs, priority=10,
 )
 def gama_2dfgrs_loader(filename):
     spectra = SpectrumList.read(

--- a/specutils/io/default_loaders/generic_ecsv_reader.py
+++ b/specutils/io/default_loaders/generic_ecsv_reader.py
@@ -14,7 +14,7 @@ def identify_ecsv(origin, *args, **kwargs):
             os.path.splitext(args[0].lower())[1] == '.ecsv')
 
 
-@data_loader("ECSV", identifier=identify_ecsv, dtype=Spectrum1D)
+@data_loader("ECSV", identifier=identify_ecsv, dtype=Spectrum1D, priority=-10)
 def generic_ecsv(file_name, column_mapping=None, **kwargs):
     """
     Read a spectrum from an ECSV file, using generic_spectrum_from_table_loader()

--- a/specutils/io/default_loaders/hst_cos.py
+++ b/specutils/io/default_loaders/hst_cos.py
@@ -17,7 +17,10 @@ def cos_identify(origin, *args, **kwargs):
         return (hdulist[0].header['TELESCOP'] == 'HST' and hdulist[0].header['INSTRUME'] == 'COS')
 
 
-@data_loader(label="HST/COS", identifier=cos_identify, extensions=['FITS', 'FIT', 'fits', 'fit'])
+@data_loader(
+    label="HST/COS", identifier=cos_identify,
+    extensions=['FITS', 'FIT', 'fits', 'fit'], priority=10,
+)
 def cos_spectrum_loader(file_obj, **kwargs):
     """
     Load COS spectral data from the MAST archive into a spectrum object.

--- a/specutils/io/default_loaders/hst_stis.py
+++ b/specutils/io/default_loaders/hst_stis.py
@@ -19,7 +19,10 @@ def stis_identify(origin, *args, **kwargs):
     return False
 
 
-@data_loader(label="HST/STIS", identifier=stis_identify, extensions=['FITS', 'FIT', 'fits', 'fit'])
+@data_loader(
+    label="HST/STIS", identifier=stis_identify,
+    extensions=['FITS', 'FIT', 'fits', 'fit'], priority=10,
+)
 def stis_spectrum_loader(file_obj, **kwargs):
     """
     Load STIS spectral data from the MAST archive into a spectrum object.

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -131,8 +131,10 @@ def _identify_jwst_fits(*args):
         return False
 
 
-@data_loader("JWST c1d", identifier=identify_jwst_c1d_fits, dtype=Spectrum1D,
-             extensions=['fits'])
+@data_loader(
+    "JWST c1d", identifier=identify_jwst_c1d_fits, dtype=Spectrum1D,
+    extensions=['fits'], priority=10,
+)
 def jwst_c1d_single_loader(file_obj, **kwargs):
     """
     Loader for JWST c1d 1-D spectral data in FITS format
@@ -155,8 +157,10 @@ def jwst_c1d_single_loader(file_obj, **kwargs):
                            "Use SpectrumList.read() instead.")
 
 
-@data_loader("JWST c1d multi", identifier=identify_jwst_c1d_multi_fits,
-             dtype=SpectrumList, extensions=['fits'])
+@data_loader(
+    "JWST c1d multi", identifier=identify_jwst_c1d_multi_fits,
+    dtype=SpectrumList, extensions=['fits'], priority=10,
+)
 def jwst_c1d_multi_loader(file_obj, **kwargs):
     """
     Loader for JWST x1d 1-D spectral data in FITS format
@@ -175,8 +179,10 @@ def jwst_c1d_multi_loader(file_obj, **kwargs):
     return _jwst_spec1d_loader(file_obj, extname='COMBINE1D', **kwargs)
 
 
-@data_loader("JWST x1d", identifier=identify_jwst_x1d_fits, dtype=Spectrum1D,
-             extensions=['fits'])
+@data_loader(
+    "JWST x1d", identifier=identify_jwst_x1d_fits, dtype=Spectrum1D,
+    extensions=['fits'], priority=10
+)
 def jwst_x1d_single_loader(file_obj, **kwargs):
     """
     Loader for JWST x1d 1-D spectral data in FITS format
@@ -199,8 +205,10 @@ def jwst_x1d_single_loader(file_obj, **kwargs):
                            "Use SpectrumList.read() instead.")
 
 
-@data_loader("JWST x1d multi", identifier=identify_jwst_x1d_multi_fits,
-             dtype=SpectrumList, extensions=['fits'])
+@data_loader(
+    "JWST x1d multi", identifier=identify_jwst_x1d_multi_fits,
+    dtype=SpectrumList, extensions=['fits'], priority=10,
+)
 def jwst_x1d_multi_loader(file_obj, **kwargs):
     """
     Loader for JWST x1d 1-D spectral data in FITS format
@@ -219,8 +227,10 @@ def jwst_x1d_multi_loader(file_obj, **kwargs):
     return _jwst_spec1d_loader(file_obj, extname='EXTRACT1D', **kwargs)
 
 
-@data_loader("JWST x1d MIRI MRS", identifier=identify_jwst_miri_mrs,
-             dtype=SpectrumList, extensions=['*'])
+@data_loader(
+    "JWST x1d MIRI MRS", identifier=identify_jwst_miri_mrs, dtype=SpectrumList,
+    extensions=['*'], priority=10,
+)
 def jwst_x1d_miri_mrs_loader(input, missing="raise", **kwargs):
     """
     Loader for JWST x1d MIRI MRS spectral data in FITS format.
@@ -358,8 +368,10 @@ def _jwst_spec1d_loader(file_obj, extname='EXTRACT1D', **kwargs):
     return SpectrumList(spectra)
 
 
-@data_loader("JWST s2d", identifier=identify_jwst_s2d_fits, dtype=Spectrum1D,
-             extensions=['fits'])
+@data_loader(
+    "JWST s2d", identifier=identify_jwst_s2d_fits, dtype=Spectrum1D,
+    extensions=['fits'], priority=10,
+)
 def jwst_s2d_single_loader(filename, **kwargs):
     """
     Loader for JWST s2d 2D rectified spectral data in FITS format.
@@ -384,8 +396,10 @@ def jwst_s2d_single_loader(filename, **kwargs):
         raise RuntimeError(f"Input data has {len(spectrum_list)} spectra.")
 
 
-@data_loader("JWST s2d multi", identifier=identify_jwst_s2d_multi_fits, dtype=SpectrumList,
-             extensions=['fits'])
+@data_loader(
+    "JWST s2d multi", identifier=identify_jwst_s2d_multi_fits,
+    dtype=SpectrumList, extensions=['fits'], priority=10,
+)
 def jwst_s2d_multi_loader(filename, **kwargs):
     """
     Loader for JWST s2d 2D rectified spectral data in FITS format.
@@ -496,8 +510,10 @@ def _jwst_s2d_loader(filename, **kwargs):
     return SpectrumList(spectra)
 
 
-@data_loader("JWST s3d", identifier=identify_jwst_s3d_fits, dtype=Spectrum1D,
-             extensions=['fits'])
+@data_loader(
+    "JWST s3d", identifier=identify_jwst_s3d_fits, dtype=Spectrum1D,
+    extensions=['fits'], priority=10,
+)
 def jwst_s3d_single_loader(filename, **kwargs):
     """
     Loader for JWST s3d 3D rectified spectral data in FITS format.

--- a/specutils/io/default_loaders/manga.py
+++ b/specutils/io/default_loaders/manga.py
@@ -33,8 +33,10 @@ def identify_manga_rss(origin, *args, **kwargs):
                 and hdulist[1].header["NAXIS"] == 2)
 
 
-@data_loader("MaNGA cube", identifier=identify_manga_cube, dtype=Spectrum1D,
-             extensions=['fits'])
+@data_loader(
+    "MaNGA cube", identifier=identify_manga_cube, dtype=Spectrum1D,
+    extensions=['fits'], priority=10,
+)
 def manga_cube_loader(file_obj, **kwargs):
     """
     Loader for MaNGA 3D rectified spectral data in FITS format.
@@ -58,8 +60,10 @@ def manga_cube_loader(file_obj, **kwargs):
     return spectrum
 
 
-@data_loader("MaNGA rss", identifier=identify_manga_rss, dtype=Spectrum1D,
-             extensions=['fits'])
+@data_loader(
+    "MaNGA rss", identifier=identify_manga_rss, dtype=Spectrum1D,
+    extensions=['fits'], priority=10,
+)
 def manga_rss_loader(file_obj, **kwargs):
     """
     Loader for MaNGA 2D row-stacked spectral data in FITS format.

--- a/specutils/io/default_loaders/muscles_sed.py
+++ b/specutils/io/default_loaders/muscles_sed.py
@@ -25,8 +25,10 @@ def identify_muscles_sed(origin, *args, **kwargs):
                 hdulist[0].header.get('PROPOSID') == 13650)
 
 
-@data_loader(label="MUSCLES SED", identifier=identify_muscles_sed,
-             dtype=Spectrum1D, extensions=['fits'])
+@data_loader(
+    label="MUSCLES SED", identifier=identify_muscles_sed, dtype=Spectrum1D,
+    extensions=['fits'], priority=10,
+)
 def muscles_sed(file_obj, **kwargs):
     """
     Load spectrum from a MUSCLES Treasury Survey panchromatic SED FITS file.

--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -98,7 +98,10 @@ def spPlate_identify(origin, *args, **kwargs):
                 hdulist[0].data.shape[0] > 5)
 
 
-@data_loader(label="SDSS-III/IV spec", identifier=spec_identify, extensions=['fits'])
+@data_loader(
+    label="SDSS-III/IV spec", identifier=spec_identify, extensions=['fits'],
+    priority=10,
+)
 def spec_loader(file_obj, **kwargs):
     """
     Loader for SDSS-III/IV optical spectrum "spec" files.
@@ -139,7 +142,10 @@ def spec_loader(file_obj, **kwargs):
                       uncertainty=uncertainty, meta=meta, mask=mask)
 
 
-@data_loader(label="SDSS-I/II spSpec", identifier=spSpec_identify, extensions=['fit', 'fits'])
+@data_loader(
+    label="SDSS-I/II spSpec", identifier=spSpec_identify,
+    extensions=['fit', 'fits'], priority=10,
+)
 def spSpec_loader(file_obj, **kwargs):
     """
     Loader for SDSS-I/II spSpec files.

--- a/specutils/io/default_loaders/sixdfgs_reader.py
+++ b/specutils/io/default_loaders/sixdfgs_reader.py
@@ -61,9 +61,10 @@ def identify_6dfgs_combined_fits(origin, *args, **kwargs):
         return True
 
 
-@data_loader("6dFGS-tabular",
-             identifier=identify_6dfgs_tabular_fits, dtype=Spectrum1D,
-             extensions=["fit", "fits"])
+@data_loader(
+    "6dFGS-tabular", identifier=identify_6dfgs_tabular_fits, dtype=Spectrum1D,
+    extensions=["fit", "fits"], priority=10,
+)
 def sixdfgs_tabular_fits_loader(file_obj, **kwargs):
     """
     Load the tabular variant of a 6dF Galaxy Survey (6dFGS) file.
@@ -103,9 +104,10 @@ def sixdfgs_tabular_fits_loader(file_obj, **kwargs):
     return Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)
 
 
-@data_loader("6dFGS-split",
-             identifier=identify_6dfgs_split_fits, dtype=Spectrum1D,
-             extensions=["fit", "fits"])
+@data_loader(
+    "6dFGS-split", identifier=identify_6dfgs_split_fits, dtype=Spectrum1D,
+    extensions=["fit", "fits"], priority=10,
+)
 def sixdfgs_split_fits_loader(file_obj, **kwargs):
     """
     Load the split variant of a 6dF Galaxy Survey (6dFGS) file.
@@ -136,9 +138,10 @@ def sixdfgs_split_fits_loader(file_obj, **kwargs):
     return spec
 
 
-@data_loader("6dFGS-combined",
-             identifier=identify_6dfgs_combined_fits, dtype=SpectrumList,
-             extensions=["fit", "fits"])
+@data_loader(
+    "6dFGS-combined", identifier=identify_6dfgs_combined_fits,
+    dtype=SpectrumList, extensions=["fit", "fits"], priority=10,
+)
 def sixdfgs_combined_fits_loader(file_obj, **kwargs):
     """
     Load the combined variant of a 6dF Galaxy Survey (6dFGS) file.

--- a/specutils/io/default_loaders/subaru_pfs_spec.py
+++ b/specutils/io/default_loaders/subaru_pfs_spec.py
@@ -35,8 +35,10 @@ def identify_pfs_spec(origin, *args, **kwargs):
     return _fits_identify_by_name(origin, *args, pattern=_spec_pattern)
 
 
-@data_loader(label="Subaru-pfsObject", identifier=identify_pfs_spec,
-             extensions=['fits'])
+@data_loader(
+    label="Subaru-pfsObject", identifier=identify_pfs_spec, extensions=['fits'],
+    priority=10,
+)
 def pfs_spec_loader(file_obj, **kwargs):
     """
     Loader for PFS combined spectrum files.

--- a/specutils/io/default_loaders/twodfgrs_reader.py
+++ b/specutils/io/default_loaders/twodfgrs_reader.py
@@ -42,8 +42,10 @@ def load_spectrum_from_extension(hdu, primary_header):
     return Spectrum1D(flux=spectrum, wcs=wcs, meta=meta, uncertainty=variance)
 
 
-@data_loader("2dFGRS", identifier=identify_2dfgrs, dtype=SpectrumList,
-             extensions=["fit", "fits"])
+@data_loader(
+    "2dFGRS", identifier=identify_2dfgrs, dtype=SpectrumList,
+    extensions=["fit", "fits"], priority=10,
+)
 def twodfgrs_fits_loader(file_obj, **kwargs):
     """
     Load a file from the 2dF Galaxy Redshift Survey.

--- a/specutils/io/default_loaders/twoslaq_lrg.py
+++ b/specutils/io/default_loaders/twoslaq_lrg.py
@@ -20,8 +20,10 @@ def identify_2slaq_lrg(origin, *args, **kwargs):
                 return True
 
 
-@data_loader("2SLAQ-LRG", identifier=identify_2slaq_lrg, dtype=SpectrumList,
-             extensions=["fit", "fits"])
+@data_loader(
+    "2SLAQ-LRG", identifier=identify_2slaq_lrg, dtype=SpectrumList,
+    extensions=["fit", "fits"], priority=10,
+)
 def twoslaq_lrg_fits_loader(file_obj, **kwargs):
     """
     Load a file from the LRG subset of the 2dF-SDSS LRG/QSO survey (2SLAQ-LRG)

--- a/specutils/io/default_loaders/wigglez.py
+++ b/specutils/io/default_loaders/wigglez.py
@@ -27,7 +27,7 @@ def identify_wigglez(origin, *args, **kwargs):
 
 @data_loader(
     label="WiggleZ", extensions=FITS_FILE_EXTS, dtype=SpectrumList,
-    identifier=identify_wigglez,
+    identifier=identify_wigglez, priority=10,
 )
 def wigglez_loader(fname):
     spectra = SpectrumList.read(


### PR DESCRIPTION
This modifies loader priorities using the following rules:
 * Leave the generic fits loader priorities alone, otherwise set generic loaders to -10
 * For survey-specific fits loaders, set to 10
 * Don't change non-fits survey loaders

Fixes #859.