### PR TITLE
Adds uncertainty and mask to JWST s3d loader

### DIFF
--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -1,16 +1,18 @@
 import os
 import glob
 import logging
+from astropy.nddata.nduncertainty import VarianceUncertainty
 
 import astropy.units as u
 from astropy.units import Quantity
 from astropy.table import Table
 from astropy.io import fits
-from astropy.nddata import StdDevUncertainty
+from astropy.nddata import StdDevUncertainty, InverseVariance
 import logging
 import numpy as np
 import asdf
 from gwcs.wcstools import grid_from_bounding_box
+from traitlets.traitlets import Undefined
 
 from ...spectra import Spectrum1D, SpectrumList
 from ..registers import data_loader
@@ -595,7 +597,32 @@ def _jwst_s3d_loader(filename, **kwargs):
             header.extend(slit_header, strip=True, update=True)
             meta = {'header': header}
 
-            spec = Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta)
+            # get uncertainty information
+            ext_name = primary_header.get("ERREXT", "ERR")
+            err_type = hdulist[ext_name].header.get("ERRTYPE", 'ERR')
+            err_unit = hdulist[ext_name].header.get("BUNIT", None)
+            err_array = hdulist[ext_name].data.T
+
+            # ERRTYPE can be one of "ERR", "IERR", "VAR", "IVAR"
+            # but mostly ERR for JWST cubes
+            # see https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/science_products.html#s3d
+            if err_type == "ERR":
+                err = StdDevUncertainty(err_array, unit=err_unit)
+            elif err_type == 'VAR':
+                err = VarianceUncertainty(err_array, unit=err_unit)
+            elif err_type == 'IVAR':
+                err = InverseVariance(err_array, unit=err_unit)
+            elif err_type == 'IERR':
+                log.warning("Inverse Error is not yet a supported Astropy.nddata "
+                            "uncertainty. Setting err to None.")
+                err = None
+
+            # get mask information
+            mask_name = primary_header.get("MASKEXT", "DQ")
+            mask = hdulist[mask_name].data.T
+
+            spec = Spectrum1D(flux=flux, spectral_axis=wavelength, meta=meta,
+                              uncertainty=err, mask=mask)
             spectra.append(spec)
 
     return SpectrumList(spectra)

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -12,7 +12,6 @@ import logging
 import numpy as np
 import asdf
 from gwcs.wcstools import grid_from_bounding_box
-from traitlets.traitlets import Undefined
 
 from ...spectra import Spectrum1D, SpectrumList
 from ..registers import data_loader


### PR DESCRIPTION
This PR updates the JWST s3d loader to include uncertainty and mask information from cubes.  It checks for the extension name from the primary header using `ERREXT`, checks the type of error using `ERRTYPE`, and loads the proper `astropy.nddata.uncertainty` object given the `ERRTYPE`.  See s3d extension description here, https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/science_products.html#s3d.  