### PR TITLE
Speed up jwst s3d loader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Speed up JWST s3d loader and reduce memory usage. [#874]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -582,13 +582,14 @@ def _jwst_s3d_loader(filename, **kwargs):
             flux = Quantity(flux_array, unit=flux_unit)
 
             # Get the wavelength array from the GWCS object which returns a
-            # tuple of (RA, Dec, lambda)
-            grid = grid_from_bounding_box(wcs.bounding_box)
-            _, _, lam = wcs(*grid)
-            _, _, lam_unit = wcs.output_frame.unit
+            # tuple of (RA, Dec, lambda).
+            # Since the spatial and spectral axes are orthogonal in s3d data,
+            # it is much faster to compute a slice down the spectral axis.
+            grid = grid_from_bounding_box(wcs.bounding_box)[:, :, 0, 0]
+            _, _, wavelength_array = wcs(*grid)
+            _, _, wavelength_unit = wcs.output_frame.unit
 
-            wavelength_array = lam[:, 0, 0]
-            wavelength = Quantity(wavelength_array, unit=lam_unit)
+            wavelength = Quantity(wavelength_array, unit=wavelength_unit)
 
             # Merge primary and slit headers and dump into meta
             slit_header = hdu.header


### PR DESCRIPTION
This PR:

```
In [2]: %timeit Spectrum1D.read("allcube_ch1-2-3-4-shortlongmedium-_s3d.fits")
1.85 s ± 9.91 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Resolves #688

🏎️ 