### PR TITLE
update docs to reflect missing snr_der broken links

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -50,8 +50,8 @@ spectrum:
 A second method to calculate SNR does not require the uncertainty defined
 on the `~specutils.Spectrum1D` object. This computes the signal to noise
 ratio DER_SNR following the definition set forth by the Spectral
-Container Working Group of ST-ECF, MAST and CADC. This is based on the
-code at http://www.stecf.org/software/ASTROsoft/DER_SNR/.
+Container Working Group of ST-ECF, MAST and CADC. This algorithm is described at
+https://esahubble.org/static/archives/stecfnewsletters/pdf/hst_stecf_0042.pdf
 
 .. code-block:: python
 

--- a/specutils/analysis/uncertainty.py
+++ b/specutils/analysis/uncertainty.py
@@ -122,8 +122,9 @@ def snr_derived(spectrum, region=None):
     regions, the signal over the scale of 5 or more pixels can be approximated
     by a straight line.
 
-    Code and some docs copied from
-    ``http://www.stecf.org/software/ASTROsoft/DER_SNR/der_snr.py``
+    The code and some documentation is derived from
+    ``http://www.stecf.org/software/ASTROsoft/DER_SNR/der_snr.py``, and the
+    algorithm itself is documented at https://esahubble.org/static/archives/stecfnewsletters/pdf/hst_stecf_0042.pdf
     """
 
     # No region, therefore whole spectrum.


### PR DESCRIPTION
While the docs currently point the snr_derived function to the implementation this function came from - https://www.stecf.org/software/ASTROsoft/DER_SNR/, that web site's link to the original definition of the algorithm is broken. So this PR updates the links to point to the actual newsletter that is the canonical description of the DER_SNR algorithm: https://esahubble.org/static/archives/stecfnewsletters/pdf/hst_stecf_0042.pdf