### PR TITLE
Spectrum1D.with_spectral_units: fallback on spectral_axis unit if not available in WCS

### DIFF
--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -280,16 +280,18 @@ class OneDSpectrumMixin():
         # Store the original unit information for posterity
         meta = self._meta.copy()
 
+        orig_unit = self.wcs.unit[0] if hasattr(self.wcs, 'unit') else self.spectral_axis.unit
+
         if 'original_unit' not in self._meta:
-            meta['original_unit'] = self.wcs.unit[0]
+            meta['original_unit'] = orig_unit
 
         # Create the new wcs object
         if isinstance(unit, u.UnitBase) and unit.is_equivalent(
-                self.wcs.unit[0], equivalencies=u.spectral()):
+                orig_unit, equivalencies=u.spectral()):
             return gwcs_from_array(self.spectral_axis), meta
 
         log.error("WCS units incompatible: {} and {}.".format(
-            unit, self._wcs_unit))
+            unit, orig_unit))
 
 
 class InplaceModificationMixin:


### PR DESCRIPTION
for cases where the attached WCS does not have a `unit` attribute, this now allows a fallback on `spectral_axis.unit`.  This prevents the unit attribute error in #676, but does not address the actual lack of unit conversion brought up in #676 and #889.