### PR TITLE
Add workaround for unitless WCS in SpectralGWCS

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: (Allowed Failure) Python 3.7 with remote data and dev version of key dependencies
+          - name: (Allowed Failure) Python 3.8 with remote data and dev version of key dependencies
             os: ubuntu-latest
             python: 3.8
             toxenv: py38-test-devdeps

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -214,6 +214,8 @@ def gwcs_from_array(array):
 
     class SpectralGWCS(GWCS):
         def pixel_to_world(self, *args, **kwargs):
+            if orig_array.unit == '':
+                return u.Quantity(super().pixel_to_world_values(*args, **kwargs))
             return super().pixel_to_world(*args, **kwargs).to(
                 orig_array.unit, equivalencies=u.spectral())
 

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ deps =
 
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: git+https://github.com/spacetelescope/gwcs.git#egg=gwcs
 
     external: asdf
     external: git+https://github.com/spacetelescope/jwst@stable


### PR DESCRIPTION
This should be the last thing we need for #893. Full compatibility with astropy 5.0 also will require pinning a new gwcs release once that is available.

The context here is that gwcs switched from using `Quantity` in `SpectralFrame` to using `SpectralCoord`, which was causing errors when doing arithmetic on `Spectrum1D` instances with unitless arrays (see error trace below). This change allows the `NDArithmetic` machinery to internally convert the array operand to a `Spectrum1D` with a unitless WCS (and thus a `spectral_axis` in pixels), allowing arithmetic operations for e.g. correlation to work again.

To test: Install the latest dev versions of astropy and gwcs, run the specutils tests. 

The trace this fixes:

```
>>> spec*window
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rosteen/projects/specutils/specutils/spectra/spectrum1d.py", line 557, in __mul__
    return self.multiply(other)
  File "/Users/rosteen/projects/astropy/astropy/nddata/mixins/ndarithmetic.py", line 530, in multiply
    return self._prepare_then_do_arithmetic(np.multiply, operand, operand2,
  File "/Users/rosteen/projects/astropy/astropy/nddata/mixins/ndarithmetic.py", line 610, in _prepare_then_do_arithmetic
    operand2 = cls(operand2)
  File "/Users/rosteen/projects/specutils/specutils/spectra/spectrum1d.py", line 289, in __init__
    spec_axis = self.wcs.pixel_to_world(np.arange(self.flux.shape[-1]))
  File "/Users/rosteen/projects/specutils/specutils/utils/wcs_utils.py", line 217, in pixel_to_world
    return super().pixel_to_world(*args, **kwargs).to(
  File "/Users/rosteen/projects/gwcs/gwcs/api.py", line 299, in pixel_to_world
    return self(*pixels, with_units=True)
  File "/Users/rosteen/projects/gwcs/gwcs/wcs.py", line 369, in __call__
    result = self.output_frame.coordinates(result)
  File "/Users/rosteen/projects/gwcs/gwcs/coordinate_frames.py", line 463, in coordinates
    return coord.SpectralCoord(*args).to(self.unit[0])
  File "/Users/rosteen/projects/astropy/astropy/units/decorators.py", line 304, in wrapper
    return_ = wrapped_function(*func_args, **func_kwargs)
  File "/Users/rosteen/projects/astropy/astropy/coordinates/spectral_coordinate.py", line 193, in __new__
    obj = super().__new__(cls, value, unit=unit, **kwargs)
  File "/Users/rosteen/projects/astropy/astropy/coordinates/spectral_quantity.py", line 57, in __new__
    obj = super().__new__(cls, value, unit=unit, **kwargs)
  File "/Users/rosteen/projects/astropy/astropy/units/quantity.py", line 425, in __new__
    value = value.view(cls)
  File "/Users/rosteen/projects/astropy/astropy/coordinates/spectral_coordinate.py", line 242, in __array_finalize__
    super().__array_finalize__(obj)
  File "/Users/rosteen/projects/astropy/astropy/coordinates/spectral_quantity.py", line 72, in __array_finalize__
    super().__array_finalize__(obj)
  File "/Users/rosteen/projects/astropy/astropy/units/quantity.py", line 550, in __array_finalize__
    self._set_unit(unit)
  File "/Users/rosteen/projects/astropy/astropy/units/quantity.py", line 1933, in _set_unit
    raise UnitTypeError(
astropy.units.core.UnitTypeError: SpectralCoord instances require units equivalent to '(Unit("Hz"), Unit("m"), Unit("J"), Unit("1 / m"), Unit("km / s"))', so cannot set it to ''.
```