### PR TITLE
Update NDCube pin to released version

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -27,6 +27,7 @@ py:class ndcube.mixins.ndslicing.NDCubeSlicingMixin
 py:obj ndcube.NDCube
 py:obj NDCube
 py:obj NDCube.plotter
+py:obj MatplotlibPlotter
 py:obj ExtraCoords
 py:obj GlobalCoords
 py:obj ndcube.NDCube.world_axis_physical_types
@@ -37,6 +38,7 @@ py:obj ndcube.NDCube.wcs.world_axis_physical_types
 py:obj ndcube.NDCubeSequence
 py:obj sunpy.visualization.animator.ArrayAnimatorWCS
 py:obj ndcube.mixins.plotting.NDCubePlotMixin.plot
+py:obj astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_array_index_values
 py:obj matplotllib.pyplot.imshow
 py:obj matplotllib.pyplot.plot
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     gwcs!=0.16.0
     scipy
     asdf>=2.5
-    ndcube==v2.0.0rc1
+    ndcube>=2.0
 
 [options.extras_require]
 test =


### PR DESCRIPTION
NDCube 2.0 has been released, and what I thought were errors resulting from updating from RC1 to the release version locally seem to have been resolved (possibly they were GWCS or Astropy related and have been fixed, or my pytest was misconfigured). Either way, this updates the pin, and we'll see if the Github CI is successful.