### PR TITLE
[TST]: Fix build_docs test by registering options in conf file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ import os
 import sys
 import datetime
 from importlib import import_module
+import doctest
 
 try:
     from sphinx_astropy.conf.v1 import *  # noqa
@@ -67,6 +68,12 @@ exclude_patterns.append('_templates')
 # be used globally.
 rst_epilog += """
 """
+
+# Manually register doctest options since matplotlib 3.5 messed up allowing them
+# from pytest-doctestplus
+IGNORE_OUTPUT = doctest.register_optionflag('IGNORE_OUTPUT')
+REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
+FLOAT_CMP = doctest.register_optionflag('FLOAT_CMP')
 
 # -- Project information ------------------------------------------------------
 


### PR DESCRIPTION
Apparently matplotlib 3.5 broke the recognition of doctest option flags from pytest-doctestplus within `plot` directives in the docs, so we have to register these in `conf.py` to get the docs build to pass. Thanks to @pllim for pointing me to the solution here. See https://github.com/matplotlib/matplotlib/issues/21668. 