### PR TITLE
Add collapse methods to Spectrum1D

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -10,7 +10,6 @@ from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
 from .spectral_region import SpectralRegion
 from ..utils.wcs_utils import gwcs_from_array
-from ..manipulation import extract_region
 from astropy.coordinates import SpectralCoord
 from ndcube import NDCube
 
@@ -443,7 +442,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         reg = SpectralRegion(start, stop)
         return extract_region(self, reg)
 
-    def collapse(self, method, axis=None, physical_type=None, spectral_region=None):
+    def collapse(self, method, axis=None, physical_type=None):
         """
         Collapse the flux array given a method. Will collapse either to a single
         value (default), over a specified numerical axis or axes if specified, or
@@ -466,9 +465,6 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
             The axis or axes over which to collapse the flux array.
         physical_type : str, optional
             Either 'spectral' or 'spatial'.
-        spectral_region : :class:`~specutils.SpectralRegion`
-            Limits the operation to only collapse the flux within the specified
-            spectral region.
 
         Returns
         -------
@@ -490,13 +486,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
             if physical_type is not None:
                 raise ValueError("physical_type must be 'spatial' or 'spectral'")
 
-        if spectral_region is not None:
-            spec_to_collapse = extract_region(self, spectral_region,
-                                              return_single_spectrum=True)
-        else:
-            spec_to_collapse = self
-
-        collapsed_flux = collapse_func[method](spec_to_collapse.flux, axis=axis)
+        collapsed_flux = collapse_func[method](self.flux, axis=axis)
 
         # Return a Spectrum1D if we collapsed over the spectral axis, a Quantity if not
         if axis in (-1, None, len(self.flux.shape)-1):

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -446,7 +446,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         """
         Collapse the flux array given a method. Will collapse either to a single
         value (default), over a specified numerical axis or axes if specified, or
-        over the spectral or non-spectral axes if `physical_type` is specified.
+        over the spectral or non-spectral axes if ``physical_type`` is specified.
 
         If the collapse leaves the spectral axis unchanged, a `~specutils.Spectrum1D`
         will be returned. Otherwise an `~astropy.units.Quantity` array will be

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -10,6 +10,7 @@ from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
 from .spectral_region import SpectralRegion
 from ..utils.wcs_utils import gwcs_from_array
+from ..manipulation import extract_region
 from astropy.coordinates import SpectralCoord
 from ndcube import NDCube
 
@@ -445,8 +446,15 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
     def collapse(self, method, axis=None, physical_type=None, spectral_region=None):
         """
         Collapse the flux array given a method. Will collapse either to a single
-        value (default), over a given axis if specified, or over the spectral or
-        non-spectral axes if `type` is specificied.
+        value (default), over a specified numerical axis or axes if specified, or
+        over the spectral or non-spectral axes if `physical_type` is specified.
+
+        If the collapse leaves the spectral axis unchanged, a `~specutils.Spectrum1D`
+        will be returned. Otherwise an `~astropy.units.Quantity` array will be
+        returned.
+
+        Note that these calculations are not currently uncertainty-aware, but do
+        respect masks.
 
         Parameters
         ----------
@@ -483,7 +491,8 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
                 raise ValueError("physical_type must be 'spatial' or 'spectral'")
 
         if spectral_region is not None:
-            spec_to_collapse = extract_spectral_region(spectral_region)
+            spec_to_collapse = extract_region(self, spectral_region,
+                                              return_single_spectrum=True)
         else:
             spec_to_collapse = self
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -442,6 +442,44 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         reg = SpectralRegion(start, stop)
         return extract_region(self, reg)
 
+    def collapse(method, axis=None, physical_type=None, spectral_region=None):
+        """
+        Collapse the flux array given a method. Will collapse either to a single
+        value (default), over a given axis if specified, or over the spectral or
+        non-spectral axes if `type` is specificied.
+
+        Parameters
+        ----------
+
+        method : str
+            The method by which the flux will be collapsed. Options are 'mean',
+            'min', 'max', 'sum', and 'median'.
+        axis : int, tuple, optional
+            The axis or axes over which to collapse the flux array.
+        physical_type : str, optional
+            Either 'spectral' or 'spatial'.
+        spectral_region : :class:`~specutils.SpectralRegion`
+            Limits the operation to only collapse the flux within the specified
+            spectral region.
+
+        Returns
+        -------
+        :class:`~specutils.Spectrum1D`
+
+        """
+        if physical_type is not None and axis is not None:
+            raise ValueError("Cannot set both axis and physical_type inputs")
+
+        if physical_type == 'spectral':
+            axis = -1
+        elif physical_type == 'spatial':
+            # generate tuple if needed for multiple spatial axes
+            axis = tuple([x for x in range(len(self.flux.shape) - 1)])
+        else:
+            raise ValueError("physical_type must be 'spatial' or 'spectral'")
+
+
+
     @NDCube.mask.setter
     def mask(self, value):
         # Impose stricter checks than the base NDData mask setter

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -486,7 +486,12 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
             if physical_type is not None:
                 raise ValueError("physical_type must be 'spatial' or 'spectral'")
 
-        collapsed_flux = collapse_func[method](self.flux, axis=axis)
+        # Set masked locations to NaN for the calculation, since the `where` argument
+        # does not seem to work consistently in the numpy functions.
+        flux_to_collapse = self.flux.copy()
+        flux_to_collapse[np.where(self.mask != 0)] = np.nan
+
+        collapsed_flux = collapse_func[method](flux_to_collapse, axis=axis)
 
         # Return a Spectrum1D if we collapsed over the spectral axis, a Quantity if not
         if axis in (-1, None, len(self.flux.shape)-1):

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -459,3 +459,36 @@ def test_equivalencies():
     assert u.micron.is_equivalent(u.eV) is False
     assert u.Hz.is_equivalent(u.cm**-1) is False
     assert u.Hz.is_equivalent(u.eV) is False
+
+
+def test_collapse_flux():
+    flux = [[2,4,6], [0, 8, 12]] * u.Jy
+    sa = [100,200,300]*u.um
+    mask = [[False, True, False], [True, False, False]]
+    spec = Spectrum1D(flux, sa, mask=mask)
+
+    assert spec.mean() == 7 * u.Jy
+    assert spec.max() == 12 * u.Jy
+    assert spec.min() == 2 * u.Jy
+    assert spec.sum() == 28 * u.Jy
+    assert spec.median() == 7 * u.Jy
+
+    sum_spec = spec.sum(axis = 0)
+    assert isinstance(sum_spec, Spectrum1D)
+    assert np.all(sum_spec.flux == [2, 8, 18] * u.Jy)
+
+    mean_spec = spec.mean(axis = 0)
+    assert isinstance(mean_spec, Spectrum1D)
+    assert np.all(mean_spec.flux == [2, 8, 9] * u.Jy)
+
+    max_spec = spec.max(axis = 0)
+    assert isinstance(max_spec, Spectrum1D)
+    assert np.all(max_spec.flux == [2, 8, 12] * u.Jy)
+
+    min_spec = spec.min(axis = 0)
+    assert isinstance(min_spec, Spectrum1D)
+    assert np.all(min_spec.flux == [2, 8, 6] * u.Jy)
+
+    median_spec = spec.mean(axis = 0)
+    assert isinstance(median_spec, Spectrum1D)
+    assert np.all(median_spec.flux == [2, 8, 9] * u.Jy)


### PR DESCRIPTION
Adds `mean`, `median`, `max`, `min`, and `sum` methods to `Spectrum1D` to collapse the flux array. These currently respect the mask on the input `Spectrum1D`, but don't do anything with any attached uncertainties. 

I was a bit undecided on whether to return `Spectrum1D` where it makes sense (i.e. when the collapse is done over a non-spectral axis, such that the spectral axis is unchanged) versus just returning a `Quantity` array with the collapsed flux in all instances. Opinions welcome.

Opening as a draft for now until I add test coverage. 