### PR TITLE
Allow descending spectral axes and more flexible SpectralRegion bounds

### DIFF
--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -30,9 +30,13 @@ create it explicitly from arrays or `~astropy.units.Quantity` objects:
     >>> ax.set_ylabel("Flux")  # doctest: +SKIP
 
 .. note::
-    Note that the ``spectral_axis`` can also be provided as a :class:`~specutils.SpectralAxis` object,
+    The ``spectral_axis`` can also be provided as a :class:`~specutils.SpectralAxis` object,
     and in fact will internally convert the spectral_axis to :class:`~specutils.SpectralAxis` if it
     is provided as an array or `~astropy.units.Quantity`.
+
+.. note::
+    The ``spectral_axis`` can be either ascending or descending, but must be monotonic
+    in either case. 
 
 Reading from a File
 -------------------

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -13,20 +13,16 @@ __all__ = ['extract_region', 'extract_bounding_spectral_region', 'spectral_slab'
 def _edge_value_to_pixel(edge_value, spectrum, order, side):
     spectral_axis = spectrum.spectral_axis
     if order == "ascending":
-        if side == "right":
-            if edge_value > spectral_axis[-1]:
-                return len(spectral_axis)
-        elif side == "left":
-            if edge_value < spectral_axis[0]:
-                return 0
+        if edge_value > spectral_axis[-1]:
+            return len(spectral_axis)
+        if edge_value < spectral_axis[0]:
+            return 0
 
     elif order == "descending":
-        if side == "right":
-            if edge_value < spectral_axis[-1]:
-                return len(spectral_axis)
-        elif side == "left":
-            if edge_value > spectral_axis[0]:
-                return 0
+        if edge_value < spectral_axis[-1]:
+            return len(spectral_axis)
+        if edge_value > spectral_axis[0]:
+            return 0
 
     try:
         if hasattr(spectrum.wcs, "spectral"):
@@ -149,23 +145,11 @@ def extract_region(spectrum, region, return_single_spectrum=False):
         left_index, right_index = _subregion_to_edge_pixels(subregion, spectrum)
 
         # If both indices are out of bounds then return an empty spectrum
-        if left_index is None and right_index is None:
+        if left_index == right_index:
             empty_spectrum = Spectrum1D(spectral_axis=[]*spectrum.spectral_axis.unit,
                                         flux=[]*spectrum.flux.unit)
             extracted_spectrum.append(empty_spectrum)
         else:
-
-            # If only one index is out of bounds then set it to
-            # the lower or upper extent
-            if left_index is None:
-                left_index = 0
-
-            if right_index is None:
-                right_index = len(spectrum.spectral_axis)
-
-            if left_index > right_index:
-                left_index, right_index = right_index, left_index
-
             extracted_spectrum.append(spectrum[..., left_index:right_index])
 
     # If there is only one subregion in the region then we will

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -39,9 +39,11 @@ def _edge_value_to_pixel(edge_value, spectrum, order, side):
         elif side == "right":
             index = int(np.floor(index)) + 1
 
+        return index
+
     except Exception as e:
         raise ValueError(f"Bound {edge_value}, could not be converted to pixel index"
-                         "using spectrum's WCS {spectrum.wcs}. Exception: {e}".format)
+                         f" using spectrum's WCS. Exception: {e}")
 
 def _subregion_to_edge_pixels(subregion, spectrum):
     """
@@ -70,7 +72,7 @@ def _subregion_to_edge_pixels(subregion, spectrum):
         left_func = min
         right_func = max
     else:
-        order = "descendng"
+        order = "descending"
         left_func = max
         right_func = min
 
@@ -145,7 +147,6 @@ def extract_region(spectrum, region, return_single_spectrum=False):
     extracted_spectrum = []
     for subregion in region._subregions:
         left_index, right_index = _subregion_to_edge_pixels(subregion, spectrum)
-        print(left_index, right_index)
 
         # If both indices are out of bounds then return an empty spectrum
         if left_index is None and right_index is None:

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -59,9 +59,6 @@ def _subregion_to_edge_pixels(subregion, spectrum):
         Left and right indices defined by the lower and upper bounds.
 
     """
-    # TODO: spectral regions cannot handle strictly ascending spectral axis
-    #  values. Instead, convert to length space if axis given in a descending
-    #  unit space (e.g. frequency). We should find a more elegant solution.
     spectral_axis = spectrum.spectral_axis
     if spectral_axis[-1] > spectral_axis[0]:
         order = "ascending"

--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -89,7 +89,7 @@ def _subregion_to_edge_pixels(subregion, spectrum):
         right_reg_in_spec_unit = right_func(subregion).to(spectral_axis.unit,
                                                  u.spectral())
 
-        right_index = _edge_value_to_pixel(right_reg_in_spec_unit, spectrum, order, "left")
+        right_index = _edge_value_to_pixel(right_reg_in_spec_unit, spectrum, order, "right")
 
     return left_index, right_index
 

--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -186,6 +186,8 @@ class SpectralRegion:
         for x in self._subregions:
             if x[0].unit != bound_unit or x[1].unit != bound_unit:
                 raise ValueError("All SpectralRegion bounds must have the same unit.")
+            if x[0] == x[1]:
+                raise ValueError("Upper and lower bound must be different values.")
 
         return True
 

--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -53,9 +53,7 @@ class SpectralRegion:
                             f'positional arguments but {len(args)} were given')
 
         #  Check validity of the input sub regions.
-        if not self._valid():
-            raise ValueError("SpectralRegion 2-tuple lower extent must be "
-                             "less than upper extent.")
+        self._valid()
 
         # The sub-regions are to always be ordered based on the lower bound.
         self._reorder()
@@ -184,14 +182,10 @@ class SpectralRegion:
 
     def _valid(self):
 
-        # Lower bound < Upper bound for all sub regions in length physical type
-        with u.set_enabled_equivalencies(u.spectral()):
-            sub_regions = [(x[0].to('m'), x[1].to('m'))
-                           if x[0].unit.is_equivalent(u.m) else x
-                           for x in self._subregions]
-
-        if any(x[0] >= x[1] for x in sub_regions):
-            raise ValueError('Lower bound must be strictly less than the upper bound')
+        bound_unit = self._subregions[0][0].unit
+        for x in self._subregions:
+            if x[0].unit != bound_unit or x[1].unit != bound_unit:
+                raise ValueError("All SpectralRegion bounds must have the same unit.")
 
         return True
 

--- a/specutils/tests/spectral_examples.py
+++ b/specutils/tests/spectral_examples.py
@@ -37,6 +37,9 @@ class SpectraExamples:
 
         5. s1_um_mJy_e1_masked - same as 1, but with a random set of pixels
                                  masked.
+
+        6. s1_um_mJy_e1_desc - same as 1, but with the spectral axis in
+                               descending rather than ascending order.
     """
 
     def __init__(self):
@@ -91,12 +94,15 @@ class SpectraExamples:
         self._s1_AA_nJy_e4 = Spectrum1D(spectral_axis=self.wavelengths_AA * u.AA,
                                         flux=self._flux_e4 * u.nJy)
 
-
         #
         # Create one spectrum like 1 but with a mask
         #
         self._s1_um_mJy_e1_masked = copy(self._s1_um_mJy_e1)  # SHALLOW copy - the data are shared with the above non-masked case
         self._s1_um_mJy_e1_masked.mask = (np.random.randn(*self.base_flux.shape) + 1) > 0
+
+        # Create a spectrum like 1, but with descending spectral axis
+        self._s1_um_mJy_e1_desc = Spectrum1D(spectral_axis=self.wavelengths_um[::-1] * u.um,
+                                             flux=self._flux_e1[::-1] * u.mJy)
 
 
     @property
@@ -135,6 +141,9 @@ class SpectraExamples:
     def s1_um_mJy_e1_masked(self):
         return self._s1_um_mJy_e1_masked
 
+    @property
+    def s1_um_mJy_e1_desc(self):
+        return self._s1_um_mJy_e1_desc
 
 
 @pytest.fixture

--- a/specutils/tests/test_region_extract.py
+++ b/specutils/tests/test_region_extract.py
@@ -127,6 +127,38 @@ def test_region_empty(simulated_spectra):
         region = SpectralRegion(3*u.um, 3*u.um)
 
 
+def test_region_descending(simulated_spectra):
+    np.random.seed(42)
+
+    spectrum = simulated_spectra.s1_um_mJy_e1
+    uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
+    spectrum.uncertainty = uncertainty
+
+    region = SpectralRegion(0.8*u.um, 0.6*u.um)
+
+    sub_spectrum = extract_region(spectrum, region)
+
+    sub_spectrum_flux_expected = np.array(FLUX_ARRAY)
+
+    assert quantity_allclose(sub_spectrum.flux.value, sub_spectrum_flux_expected)
+
+
+def test_descending_spectral_axis(simulated_spectra):
+    spectrum = simulated_spectra.s1_um_mJy_e1_desc
+
+    sub_spectrum_flux_expected = np.array(FLUX_ARRAY[::-1])
+
+    region = SpectralRegion(0.8*u.um, 0.6*u.um)
+    sub_spectrum = extract_region(spectrum, region)
+
+    assert quantity_allclose(sub_spectrum.flux.value, sub_spectrum_flux_expected)
+
+    region = SpectralRegion(0.6*u.um, 0.8*u.um)
+    sub_spectrum = extract_region(spectrum, region)
+
+    assert quantity_allclose(sub_spectrum.flux.value, sub_spectrum_flux_expected)
+
+
 def test_region_two_sub(simulated_spectra):
     np.random.seed(42)
 


### PR DESCRIPTION
Addresses #796  and #615 and additionally no longer requires that spectral axes be ascending in wavelength space by fixing the previous failure in `world_to_pixel` in the case of descending spectral axes. This also removes the need for some internal unit conversions to Angstrom, which is probably a minor performance improvement.

I'm still working on some failing unit tests, so I'm opening as draft for now.