### PR TITLE
Fix slicing to actually drop and recreate WCS as intended

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -369,11 +369,12 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
                 spectral_axis=self.spectral_axis[spec_item],
                 uncertainty=self.uncertainty[item]
                 if self.uncertainty is not None else None,
-                mask=self.mask[item] if self.mask is not None else None)
+                mask=self.mask[item] if self.mask is not None else None,
+                wcs=None)
 
         if not isinstance(item, slice):
             if isinstance(item, u.Quantity):
-                raise ValueError("Indexing on a single spectral axis values is not"
+                raise ValueError("Indexing on a single spectral axis value is not"
                                  " currently allowed, please use a slice.")
             # Handle tuple slice as input by NDCube crop method
             elif isinstance(item, tuple):
@@ -397,8 +398,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         #  we create a new ``Spectrum1D`` that includes the sliced spectral
         #  axis. This means that a new wcs object will be created with the
         #  appropriate unit translation handling.
-        return tmp_spec._copy(
-            spectral_axis=self.spectral_axis[item])
+        return tmp_spec._copy(spectral_axis=self.spectral_axis[item], wcs=None)
 
     def _copy(self, **kwargs):
         """

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -364,13 +364,19 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
                     # Drop the spectral axis slice and perform only the spatial part
                     return temp_spec[item[:-1]]
 
+            if "original_wcs" not in self.meta:
+                new_meta = deepcopy(self.meta)
+                new_meta["original_wcs"] = deepcopy(self.wcs)
+            else:
+                new_meta = deepcopy(self.meta)
+
             return self._copy(
                 flux=self.flux[item],
                 spectral_axis=self.spectral_axis[spec_item],
                 uncertainty=self.uncertainty[item]
                 if self.uncertainty is not None else None,
                 mask=self.mask[item] if self.mask is not None else None,
-                wcs=None)
+                meta=new_meta, wcs=None)
 
         if not isinstance(item, slice):
             if isinstance(item, u.Quantity):
@@ -398,7 +404,14 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         #  we create a new ``Spectrum1D`` that includes the sliced spectral
         #  axis. This means that a new wcs object will be created with the
         #  appropriate unit translation handling.
-        return tmp_spec._copy(spectral_axis=self.spectral_axis[item], wcs=None)
+        if "original_wcs" not in self.meta:
+            new_meta = deepcopy(self.meta)
+            new_meta["original_wcs"] = deepcopy(self.wcs)
+        else:
+            new_meta = deepcopy(self.meta)
+
+        return tmp_spec._copy(spectral_axis=self.spectral_axis[item], wcs=None,
+                              meta=new_meta)
 
     def _copy(self, **kwargs):
         """

--- a/specutils/tests/test_slicing.py
+++ b/specutils/tests/test_slicing.py
@@ -94,6 +94,7 @@ def test_slicing_multidim():
 
     spec1 = spec[0]
     spec2 = spec[1:3]
+    spec3 = spec[..., 4:7]
 
     assert spec1.flux[0] == spec.flux[0][0]
     assert quantity_allclose(spec1.spectral_axis, spec.spectral_axis)
@@ -104,3 +105,6 @@ def test_slicing_multidim():
 
     assert spec1.mask[0] == spec.mask[0][0]
     assert spec1.mask.shape == (10,)
+
+    assert quantity_allclose(spec3.spectral_axis, spec.spectral_axis[4:7])
+    assert quantity_allclose(spec3.wcs.pixel_to_world([0,1,2]), spec3.spectral_axis[0:3])


### PR DESCRIPTION
From the comments in the code, it looks like the intent here was always to create a new lookup table SpectralGWCS when slicing, but the `copy` method defaults to `self.wcs` and thus sliced spectra were ending up with the original spectrum's WCS. This doesn't solve the fact that spatial WCS components may end up incorrect if the spatial dimensions are sliced, but it at least fixes the spectral part. We may be able to fall back more on the NDCube machinery for spatial slicing than we are now, I'll open a follow-up issue for that. I'll also add a test for this case shortly.