### PR TITLE
Some updates to specutils.analysis functions

### DIFF
--- a/specutils/analysis/template_comparison.py
+++ b/specutils/analysis/template_comparison.py
@@ -31,7 +31,10 @@ def _normalize_for_template_matching(observed_spectrum, template_spectrum, stdde
     if stddev is None:
         stddev = observed_spectrum.uncertainty.represent_as(StdDevUncertainty).quantity
     num = np.nansum((observed_spectrum.flux*template_spectrum.flux) / (stddev**2))
-    denom = np.nansum((template_spectrum.flux / stddev)**2)
+    # We need to limit this sum to where observed_spectrum is not NaN as well.
+    template_filtered = ((template_spectrum.flux / stddev)**2)
+    template_filtered = template_filtered[np.where(~np.isnan(observed_spectrum.flux))]
+    denom = np.nansum(template_filtered)
 
     return num/denom
 

--- a/specutils/analysis/template_comparison.py
+++ b/specutils/analysis/template_comparison.py
@@ -30,8 +30,8 @@ def _normalize_for_template_matching(observed_spectrum, template_spectrum, stdde
     """
     if stddev is None:
         stddev = observed_spectrum.uncertainty.represent_as(StdDevUncertainty).quantity
-    num = np.sum((observed_spectrum.flux*template_spectrum.flux) / (stddev**2))
-    denom = np.sum((template_spectrum.flux / stddev)**2)
+    num = np.nansum((observed_spectrum.flux*template_spectrum.flux) / (stddev**2))
+    denom = np.nansum((template_spectrum.flux / stddev)**2)
 
     return num/denom
 
@@ -107,7 +107,7 @@ def _chi_square_for_templates(observed_spectrum, template_spectrum, resample_met
 
     # Get chi square
     result = (num/denom)**2
-    chi2 = np.sum(result.value)
+    chi2 = np.nansum(result.value)
 
     # Create normalized template spectrum, which will be returned with
     # corresponding chi2
@@ -262,5 +262,6 @@ def template_redshift(observed_spectrum, template_spectrum, redshift):
         if not np.isnan(chi2) and (chi2_min is None or chi2 < chi2_min):
             chi2_min = chi2
             final_redshift = rs
+            final_spectrum = redshifted_spectrum
 
-    return redshifted_spectrum, final_redshift, normalized_spectral_template, chi2_min, chi2_list
+    return final_spectrum, final_redshift, normalized_spectral_template, chi2_min, chi2_list

--- a/specutils/tests/test_template_comparison.py
+++ b/specutils/tests/test_template_comparison.py
@@ -30,7 +30,7 @@ def test_template_match_no_overlap():
 
     # Get result from template_match
     tm_result = template_comparison.template_match(spec, spec1)
-    assert np.isnan(tm_result[3])
+    assert tm_result[3] == 0.0
 
     # Create new spectrum for comparison
     spec_result = Spectrum1D(spectral_axis=spec_axis,
@@ -65,7 +65,7 @@ def test_template_match_minimal_overlap():
 
     # Get result from template_match
     tm_result = template_comparison.template_match(spec, spec1)
-    assert np.isnan(tm_result[3])
+    assert tm_result[3] == 0.0
 
     # Create new spectrum for comparison
     spec_result = Spectrum1D(spectral_axis=spec_axis,
@@ -73,7 +73,7 @@ def test_template_match_minimal_overlap():
     try:
         assert quantity_allclose(tm_result[0].flux, spec_result.flux, atol=0.01*u.Jy)
     except AssertionError:
-        pytest.xfail('TODO: investigate why the all elements in tm_result[1] are NaN even with overlap')
+        pytest.xfail('TODO: investigate why all elements in tm_result[0] are NaN even with overlap')
 
 
 def test_template_match_spectrum():
@@ -332,7 +332,7 @@ def test_template_redshift_with_multiple_template_spectra_in_match():
     # TODO: Determine cause of and fix failing assert
     # np.testing.assert_almost_equal(tm_result[1], redshift)
 
-    np.testing.assert_almost_equal(tm_result[3], 6803.922741644725)
+    np.testing.assert_almost_equal(tm_result[3], 1172.135458895792)
 
     # When a spectrum collection is matched with a redshift
     # grid, a list-of-lists is returned with the trial chi2


### PR DESCRIPTION
- Updated `_normalize_for_template_matching()`: changed `np.sum` to `np.nansum` on lines 60 and 61.  Due to resampling of the spectra (resampling methods fill arrays with NaNs to have points beyond the edges set to NaN), all redshifts compared in `template_redshift()` were producing a `chi2` of NaN (even for a test case using the correct redshift).
- Updated `_chi_square_for_templates()`: changed `np.sum` to `np.nansum` on line 137 for the same reason as above.
- Updated `template_redshift()`: Added `final_spectrum = redshifted_spectrum` on line 292 and added `final_spectrum` to return instead of `redshifted spectrum`.  This is important specifically for if you feed a list of redshifts - the function was not returning the spectrum redshifted by the best-fitting redshift (i.e. the one corresponding to `chi2_min`), but rather was returning the spectrum redshifted by the last redshift in the list (not necessarily the best-fitting one). 