### PR TITLE
centroid: implement propagated uncertainties

### DIFF
--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -21,9 +21,9 @@ def centroid(spectrum, region):
     Parameters
     ----------
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
-        The spectrum object overwhich the centroid will be calculated.  If the uncertainty
+        The spectrum object over which the centroid will be calculated.  If the uncertainty
         is populated, the returned quantity will include an uncertainty attribute with
-        the propagated uncertainty (in stddev).
+        the propagated uncertainty (as Standard Deviation-style uncertainties).
 
     region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the centroid.
@@ -58,8 +58,8 @@ def centroid(spectrum, region):
 def _centroid_single_region(spectrum, region=None):
     """
     Calculate the centroid of the spectrum based on the flux in the spectrum.
-    The returned quantity object will have an uncertainty attribute which
-    will be populated if ``spectrum`` has uncertainties assigned.
+    The returned quantity object will have a ``.uncertainty`` attribute which
+    will be populated if ``spectrum`` has uncertainties assigned, or ``None`` if not.
 
     Parameters
     ----------

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -23,7 +23,8 @@ def centroid(spectrum, region):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object over which the centroid will be calculated.  If the uncertainty
         is populated, the returned quantity will include an uncertainty attribute with
-        the propagated uncertainty (as Standard Deviation-style uncertainties).
+        the propagated uncertainty (as Standard Deviation-style uncertainties).  This uncertainty
+        assumes the input uncertainties are uncorrelated.
 
     region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the centroid.
@@ -116,17 +117,17 @@ def _centroid_single_region(spectrum, region=None):
     if spectrum.uncertainty is not None:
         disp_uncert = 0.0 * dispersion.unit
 
-        # uncertainty for each flux*dispersion term, frationally added in quadrature
+        # uncertainty for each flux*dispersion term, fractionally added in quadrature
         num_term_uncerts = flux*dispersion * np.sqrt((flux_uncert/flux)**2 +
                                                      (disp_uncert/dispersion)**2)
         # uncertainty for the numerator sum, added in quadrature
-        num_uncert = np.sqrt(np.sum(num_term_uncerts**2, axis=-1))
+        num_uncertsq = np.sum(num_term_uncerts**2, axis=-1)
         # uncertainty for the denom sum, added in quadrature
-        denom_uncert = np.sqrt(np.sum(flux_uncert**2, axis=-1))
+        denom_uncertsq = np.sum(flux_uncert**2, axis=-1)
 
-        # centroid uncertainty, fractional added in quadrature of numerator and denom
-        centroid.uncertainty = numerator/denom * np.sqrt((num_uncert/numerator)**2 +
-                                                         (denom_uncert/denom)**2)
+        # centroid uncertainty, fractionally added in quadrature of numerator and denom
+        centroid.uncertainty = numerator/denom * np.sqrt(num_uncertsq * numerator**-2 +
+                                                         denom_uncertsq * denom**-2)
     else:
         centroid.uncertainty = None
 

--- a/specutils/analysis/uncertainty.py
+++ b/specutils/analysis/uncertainty.py
@@ -4,6 +4,7 @@ spectra.
 """
 
 import numpy as np
+from astropy.nddata import StdDevUncertainty, VarianceUncertainty, InverseVariance
 from ..spectra import SpectralRegion
 from ..manipulation import extract_region
 
@@ -186,3 +187,26 @@ def _snr_derived(spectrum, region=None):
         return signal / noise
     else:
         return 0.0
+
+
+def _convert_uncertainty(uncertainty, to_class):
+    if isinstance(uncertainty, to_class):
+        return uncertainty.quantity
+
+    if isinstance(uncertainty, StdDevUncertainty):
+        variance = uncertainty.quantity ** 2
+    elif isinstance(uncertainty, VarianceUncertainty):
+        variance = uncertainty.quantity
+    elif isinstance(uncertainty, InverseVariance):
+        variance = 1/uncertainty.quantity
+    else:
+        raise ValueError("uncertainties only supported in StdDev, Variance, or InverseVariance")
+
+    if to_class == VarianceUncertainty:
+        return variance
+    elif to_class == InverseVariance:
+        return 1/variance
+    elif to_class == StdDevUncertainty:
+        return variance**0.5
+    else:
+        raise ValueError("to_class only supports StdDev, Variance, or InverseVariance")

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -468,6 +468,7 @@ def test_centroid(simulated_spectra):
     assert isinstance(spec_centroid, u.Quantity)
     assert np.allclose(spec_centroid.value, spec_centroid_expected.value)
     assert hasattr(spec_centroid, 'uncertainty')
+    assert quantity_allclose(spec_centroid.uncertainty, 3.91834165e-06*u.um, rtol=5e-5)
 
 
 def test_centroid_masked(simulated_spectra):

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -467,6 +467,7 @@ def test_centroid(simulated_spectra):
 
     assert isinstance(spec_centroid, u.Quantity)
     assert np.allclose(spec_centroid.value, spec_centroid_expected.value)
+    assert hasattr(spec_centroid, 'uncertainty')
 
 
 def test_centroid_masked(simulated_spectra):


### PR DESCRIPTION
* follows same pattern as in `line_flux` of setting an uncertainty attribute on the returned quantity if the input `Spectrum1D` has assigned uncertainties.
* implements a private `uncertainty._convert_uncertainty` function to convert the `Spectrum1D.uncertainty` to any assumed type.  This is now used in `line_flux` as well.
* hardcodes dispersion uncertainty to zero for now, but keeps the terms in the equations in case we want to support passing/storing dispersion uncertainties in the future.  Alternatively, the equations would simplify somewhat significantly if we drop support for uncertainties on dispersion entirely.