### PR TITLE
equivalent_width: propagate line_flux uncertainty

### DIFF
--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -101,6 +101,7 @@ def test_equivalent_width():
     result = equivalent_width(spectrum)
 
     assert result.unit.is_equivalent(spectrum.wcs.unit, equivalencies=u.spectral())
+    assert hasattr(result, 'uncertainty')
 
     # Since this is an emission line, we expect the equivalent width value to
     # be negative


### PR DESCRIPTION
Propagates the already assigned uncertainties from `line_flux` through the equations used to compute `equivalent_width`.  We likely need to think about the type of uncertainty being returned though, ~as `line_flux` uses (and seems to return) variance, but centroid was implemented in #938 to use standard deviation~ (edit: see https://github.com/astropy/specutils/pull/939#discussion_r856450839).

This follows the same pattern as elsewhere to assign the uncertainty as an attribute on the returned quantity object, but it should be noted that these will be dropped when manipulating the quantity externally (unit conversion, for example), so may not be an ideal pattern.