### PR TITLE
MNT: Remove empty file and outdated docs nitpick

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -8,10 +8,6 @@ py:obj NDUncertainty
 # Links that might not work yet, depending on the astropy version
 py:obj astropy.coordinates.SpectralQuantity
 
-# Classes that now live in astropy and which don't want to expose here
-py:class specutils.extern.spectralcoord.spectral_coordinate.SpectralCoord
-py:class specutils.extern.spectralcoord.spectral_quantity.SpectralQuantity
-
 # Classes in the SpectralCoord/SpectralQuantity methods for which we can't
 # control the API links.
 py:obj SpectralCoord


### PR DESCRIPTION
I don't know the history but pretty sure these are not needed anymore?

Fix #940 