### PR TITLE
uncertainty_type exposed for analysis functions that implement uncertainty

### DIFF
--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -136,6 +136,7 @@ def _compute_line_flux(spectrum, regions=None,
     line_flux = np.sum(flux * dx)
 
     line_flux.uncertainty = None
+    line_flux.uncertainty_type = 'stddev'
 
     if calc_spectrum.uncertainty is not None:
         # Can't handle masks via interpolation here, since interpolators
@@ -200,6 +201,7 @@ def _compute_equivalent_width(spectrum, continuum=1, regions=None,
     else:
         ew.uncertainty = None
 
+    ew.uncertainty_type = 'stddev'
     return ew
 
 

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -131,4 +131,5 @@ def _centroid_single_region(spectrum, region=None):
     else:
         centroid.uncertainty = None
 
+    centroid.uncertainty_type = 'stddev'
     return centroid


### PR DESCRIPTION
analysis.line_flux, equivalent_width, and centroid currently return a quantity object with the `.uncertainty` attribute set to a float (see #938, #939).  This PR also sets `.uncertainty_type = 'stddev'` as an intermediate way to expose that these are standard-deviation uncertainties until a more permanent framework for exposing uncertainties attached to the quantity objects is implemented.

Closes #958