### PR TITLE
guassian_fwhm and gaussian_sigma_width: propagated uncertainties

### DIFF
--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -4,9 +4,11 @@ spectral features.
 """
 
 import numpy as np
+from astropy.nddata import StdDevUncertainty
 from astropy.stats.funcs import gaussian_sigma_to_fwhm
 from ..manipulation import extract_region
 from . import centroid
+from .uncertainty import _convert_uncertainty
 from .utils import computation_wrapper
 from scipy.signal import find_peaks, peak_widths
 
@@ -186,8 +188,15 @@ def _compute_gaussian_fwhm(spectrum, regions=None):
     This is a helper function for the above `gaussian_fwhm()` method.
     """
 
-    fwhm = _compute_gaussian_sigma_width(spectrum, regions) * gaussian_sigma_to_fwhm
+    sigma = _compute_gaussian_sigma_width(spectrum, regions)
 
+    fwhm = sigma * gaussian_sigma_to_fwhm
+    if sigma.uncertainty is not None:
+        fwhm.uncertainty = sigma.uncertainty * gaussian_sigma_to_fwhm
+    else:
+        fwhm.uncertainty = None
+
+    fwhm.uncertainty_type = 'std'
     return fwhm
 
 
@@ -201,9 +210,16 @@ def _compute_gaussian_sigma_width(spectrum, regions=None):
     else:
         calc_spectrum = spectrum
 
+    if spectrum.uncertainty is not None:
+        flux_uncert = _convert_uncertainty(calc_spectrum.uncertainty, StdDevUncertainty)
+    else:
+        # dummy value for uncertainties to avoid extra if-statements when applying mask
+        flux_uncert = np.zeros_like(calc_spectrum.flux)
+
     if hasattr(spectrum, 'mask') and spectrum.mask is not None:
         flux = calc_spectrum.flux[~spectrum.mask]
         spectral_axis = calc_spectrum.spectral_axis[~spectrum.mask]
+        flux_uncert = flux_uncert[~calc_spectrum.mask]
     else:
         flux = calc_spectrum.flux
         spectral_axis = calc_spectrum.spectral_axis
@@ -212,11 +228,36 @@ def _compute_gaussian_sigma_width(spectrum, regions=None):
 
     if flux.ndim > 1:
         spectral_axis = np.broadcast_to(spectral_axis, flux.shape, subok=True)
+        centroid_result_uncert = centroid_result.uncertainty
         centroid_result = centroid_result[:, np.newaxis]
+        centroid_result.uncertainty = centroid_result_uncert[:, np.newaxis] if centroid_result_uncert is not None else None  # noqa
 
     dx = (spectral_axis - centroid_result)
-    sigma = np.sqrt(np.sum((dx * dx) * flux, axis=-1) / np.sum(flux, axis=-1))
+    numerator = np.sum((dx * dx) * flux, axis=-1)
+    denom = np.sum(flux, axis=-1)
+    sigma2 = numerator / denom
+    sigma = np.sqrt(sigma2)
+    if centroid_result.uncertainty is not None:
+        # NOTE: until/unless disp_uncert is supported, dx_uncert == centroid_result.uncertainty
+        disp_uncert = 0.0 * spectral_axis.unit
+        dx_uncert = np.sqrt(disp_uncert**2 + centroid_result.uncertainty**2)
+        # dx_uncert = centroid_result.uncertainty
 
+        # uncertainty for each term in the numerator sum
+        num_term_uncerts = dx * dx * flux * np.sqrt(2*(dx_uncert/dx)**2 + (flux_uncert/flux)**2)
+        # uncertainty (squared) for the numerator, added in quadrature
+        num_uncertsq = np.sum(num_term_uncerts**2, axis=-1)
+        # uncertainty (squared) for the denomenator
+        denom_uncertsq = np.sum(flux_uncert**2)
+
+        sigma2_uncert = numerator/denom * np.sqrt(num_uncertsq * numerator**-2 +
+                                                  denom_uncertsq * denom**-2)
+
+        sigma.uncertainty = 0.5 * sigma2_uncert / sigma2 * sigma.unit
+    else:
+        sigma.uncertainty = None
+
+    sigma.uncertainty_type = 'std'
     return sigma
 
 

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -469,6 +469,7 @@ def test_centroid(simulated_spectra):
     assert isinstance(spec_centroid, u.Quantity)
     assert np.allclose(spec_centroid.value, spec_centroid_expected.value)
     assert hasattr(spec_centroid, 'uncertainty')
+    # NOTE: value has not been scientifically validated
     assert quantity_allclose(spec_centroid.uncertainty, 3.91834165e-06*u.um, rtol=5e-5)
 
 
@@ -557,14 +558,19 @@ def test_gaussian_sigma_width():
 
     # Create a (centered) gaussian spectrum for testing
     mean = 5
-    frequencies = np.linspace(0, mean*2, 100) * u.GHz
+    frequencies = np.linspace(0, mean*2, 101)[1:] * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=mean*u.GHz, stddev=0.8*u.GHz)
 
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies))
+    uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
+    spectrum.uncertainty = uncertainty
 
     result = gaussian_sigma_width(spectrum)
 
     assert quantity_allclose(result, g1.stddev, atol=0.01*u.GHz)
+    assert hasattr(result, 'uncertainty')
+    # NOTE: value has not been scientifically validated!
+    assert quantity_allclose(result.uncertainty, 4.8190546890398186e-05*u.GHz, rtol=5e-5)
 
 
 def test_gaussian_sigma_width_masked():
@@ -573,7 +579,7 @@ def test_gaussian_sigma_width_masked():
 
     # Create a (centered) gaussian masked spectrum for testing
     mean = 5
-    frequencies = np.linspace(0, mean*2, 100) * u.GHz
+    frequencies = np.linspace(0, mean*2, 101)[1:] * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=mean*u.GHz, stddev=0.8*u.GHz)
     uncertainty = StdDevUncertainty(0.1*np.random.random(len(frequencies))*u.Jy)
 
@@ -585,13 +591,16 @@ def test_gaussian_sigma_width_masked():
     result = gaussian_sigma_width(spectrum)
 
     assert quantity_allclose(result, g1.stddev, atol=0.01*u.GHz)
+    assert hasattr(result, 'uncertainty')
+    # NOTE: value has not been scientifically validated!
+    assert quantity_allclose(result.uncertainty, 0.06852821940808544*u.GHz, rtol=5e-5)
 
 
 def test_gaussian_sigma_width_regions():
 
     np.random.seed(42)
 
-    frequencies = np.linspace(100, 0, 10000) * u.GHz
+    frequencies = np.linspace(100, 0, 10000)[:-1] * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=10*u.GHz, stddev=0.8*u.GHz)
     g2 = models.Gaussian1D(amplitude=5*u.Jy, mean=2*u.GHz, stddev=0.3*u.GHz)
     g3 = models.Gaussian1D(amplitude=5*u.Jy, mean=70*u.GHz, stddev=10*u.GHz)
@@ -654,15 +663,20 @@ def test_gaussian_fwhm():
 
     # Create a (centered) gaussian spectrum for testing
     mean = 5
-    frequencies = np.linspace(0, mean*2, 100) * u.GHz
+    frequencies = np.linspace(0, mean*2, 101)[1:] * u.GHz
     g1 = models.Gaussian1D(amplitude=5*u.Jy, mean=mean*u.GHz, stddev=0.8*u.GHz)
 
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies))
+    uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
+    spectrum.uncertainty = uncertainty
 
     result = gaussian_fwhm(spectrum)
 
     expected = g1.stddev * gaussian_sigma_to_fwhm
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)
+    assert hasattr(result, 'uncertainty')
+    # NOTE: value has not been scientifically validated!
+    assert quantity_allclose(result.uncertainty, 0.00011348006579851353*u.GHz, rtol=5e-5)
 
 
 def test_gaussian_fwhm_masked():
@@ -684,6 +698,9 @@ def test_gaussian_fwhm_masked():
 
     expected = g1.stddev * gaussian_sigma_to_fwhm
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)
+    assert hasattr(result, 'uncertainty')
+    # NOTE: value has not been scientifically validated!
+    assert quantity_allclose(result.uncertainty, 0.16688079501948674*u.GHz, rtol=5e-5)
 
 
 @pytest.mark.parametrize('mean', range(3, 8))
@@ -795,7 +812,6 @@ def test_fwhm():
 
     spectrum = Spectrum1D(spectral_axis=wavelengths, flux=flux)
     result = fwhm(spectrum)
-
     assert quantity_allclose(result, 1.01 * u.um)
 
     # Highest point at the last point


### PR DESCRIPTION
Similar to #938 and #939 and making use of the new `uncertainty_type` introduced in #961, this propagates uncertainties through the `gaussian_fwhm` and `gaussian_sigma_width` functions.

Note that the values in the test coverage have not been validated (they are just set to the current returned values).