### PR TITLE
Fix moment with order > 1 and non-square spatial dimensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Fixed a bug with moment map orders greater than 1 not being able to handle
+  cubes with non-square spatial dimensions. [#970]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -73,10 +73,12 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
 
     if order > 1:
         m0 = np.sum(flux, axis=axis)
-        m1 = np.sum(flux * dispersion, axis=axis) / np.sum(flux, axis=axis)
 
-        if len(flux.shape) > 1 and (axis == len(flux.shape)-1 or axis == -1):
-            _shape = flux.shape[-1:] + tuple(np.ones(flux.ndim - 1, dtype='i'))
-            m1 = np.tile(m1, _shape).T
+        # By setting keepdims to True, the axes which are reduced are
+        # left in the result as dimensions with size one. This means
+        # that we can broadcast m1 correctly against dispersion.
+        m1 = (np.sum(flux * spectral_axis, axis=axis, keepdims=True)
+              / np.sum(flux, axis=axis, keepdims=True))
 
-        return np.sum(flux * (dispersion - m1) ** order, axis=axis) / m0
+        mn = np.sum(flux * (dispersion - m1) ** order, axis=axis) / m0
+        return mn

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -80,5 +80,4 @@ def _compute_moment(spectrum, regions=None, order=0, axis=-1):
         m1 = (np.sum(flux * spectral_axis, axis=axis, keepdims=True)
               / np.sum(flux, axis=axis, keepdims=True))
 
-        mn = np.sum(flux * (dispersion - m1) ** order, axis=axis) / m0
-        return mn
+        return np.sum(flux * (dispersion - m1) ** order, axis=axis) / m0

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -1016,12 +1016,10 @@ def test_moment_cube():
     assert quantity_allclose(moment_1, frequencies, rtol=1.E-5)
 
     # higher order
-    # FIXME: operands could not be broadcast together with shapes (9,10,10000) (10,9,10000)
-    with pytest.raises(ValueError, match='operands could not be broadcast together'):
-        moment_2 = moment(spectrum, order=2)
-        assert moment_2.shape == (9, 10)
-        assert moment_2.unit.is_equivalent(u.GHz**2)
-        assert quantity_allclose(moment_2, 816.648*u.GHz**2, atol=0.01*u.GHz**2)
+    moment_2 = moment(spectrum, order=2)
+    assert moment_2.shape == (9, 10)
+    assert moment_2.unit.is_equivalent(u.GHz**2)
+    assert quantity_allclose(moment_2, 816.648*u.GHz**2, atol=0.01*u.GHz**2)
 
 
 def test_moment_cube_order_2():
@@ -1048,6 +1046,10 @@ def test_moment_cube_order_2():
     assert moment_2.unit.is_equivalent(u.GHz**2)
     assert quantity_allclose(moment_2, 816.648*u.GHz**2, atol=0.01*u.GHz**2)
 
+    # TODO: Remove test completely if it is agreed it is no longer needed
+    # Github issue https://github.com/astropy/specutils/issues/930
+    # mentions that removing ability to set axis makes this test invalid
+
     # spatial higher order (what's the meaning of this?)
     moment_2 = moment(spectrum, order=2, axis=1)
 
@@ -1056,7 +1058,7 @@ def test_moment_cube_order_2():
     # check assorted values.
     assert quantity_allclose(moment_2[0][0], 2.019e-28*u.GHz**2, rtol=0.01)
     assert quantity_allclose(moment_2[1][0], 2.019e-28*u.GHz**2, rtol=0.01)
-    assert quantity_allclose(moment_2[0][3], 8.078e-28*u.GHz**2, rtol=0.01)
+    assert quantity_allclose(moment_2[0][3], 2.019e-28*u.GHz**2, rtol=0.01)
 
 
 @pytest.mark.filterwarnings('ignore:Not all spectra have associated uncertainties of the same type')

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -1061,6 +1061,53 @@ def test_moment_cube_order_2():
     assert quantity_allclose(moment_2[0][3], 2.019e-28*u.GHz**2, rtol=0.01)
 
 
+def test_moment_cube_order_1_to_6():
+
+    np.random.seed(42)
+
+    frequencies = np.linspace(100, 1, 10000) * u.Hz
+    sig = 5
+    mean = 50
+    amp = 1./(sig*np.sqrt(2*np.pi))
+    g = models.Gaussian1D(amplitude=amp, mean=mean*u.Hz, stddev=sig*u.Hz)
+    flux = g(frequencies)
+
+    flux_multid = np.broadcast_to(flux, [9, 10, flux.shape[0]]) * u.Jy
+
+    spectrum = Spectrum1D(spectral_axis=frequencies, flux=flux_multid)
+
+    moment_1 = moment(spectrum, order=1)
+
+    assert moment_1.shape == (9, 10)
+    assert moment_1.unit.is_equivalent(u.Hz)
+    assert quantity_allclose(moment_1, 50.0*u.Hz, atol=0.01*u.Hz)
+
+    moment_2 = moment(spectrum, order=2)
+    assert moment_2.shape == (9, 10)
+    assert moment_2.unit.is_equivalent(u.Hz**2)
+    assert quantity_allclose(moment_2, 25.0*u.Hz**2, atol=0.01*u.Hz**2)
+
+    moment_3 = moment(spectrum, order=3)
+    assert moment_3.shape == (9, 10)
+    assert moment_3.unit.is_equivalent(u.Hz**3)
+    assert quantity_allclose(moment_3, 0.0*u.Hz**3, atol=0.01*u.Hz**3)
+
+    moment_4 = moment(spectrum, order=4)
+    assert moment_4.shape == (9, 10)
+    assert moment_4.unit.is_equivalent(u.Hz**4)
+    assert quantity_allclose(moment_4, 1875.0*u.Hz**4, atol=0.01*u.Hz**4)
+
+    moment_5 = moment(spectrum, order=5)
+    assert moment_5.shape == (9, 10)
+    assert moment_5.unit.is_equivalent(u.Hz**5)
+    assert quantity_allclose(moment_5, 0.0*u.Hz**5, atol=0.01*u.Hz**5)
+
+    moment_6 = moment(spectrum, order=6)
+    assert moment_6.shape == (9, 10)
+    assert moment_6.unit.is_equivalent(u.Hz**6)
+    assert quantity_allclose(moment_6, 234375.0*u.Hz**6, atol=0.01*u.Hz**6)
+
+
 @pytest.mark.filterwarnings('ignore:Not all spectra have associated uncertainties of the same type')
 @pytest.mark.filterwarnings('ignore:Not all spectra have associated masks')
 def test_moment_collection():


### PR DESCRIPTION
Fixes https://github.com/spacetelescope/jdaviz/issues/947
Fixes #931 

I thought we would need to revisit the topic of dropping support for different axes, but then I found the `keepdims` paremeter in `np.sum` and now it all seems to work. I did have to update one test, hopefully someone can confirm if that fix is ok. Will definitely need to get a science review on this from @PatrickOgle if he is able.