### PR TITLE
Add workaround for GWCS error in some JWST IFU cubes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Bug Fixes
 - Fixed a bug with moment map orders greater than 1 not being able to handle
   cubes with non-square spatial dimensions. [#970]
 
+- Added a workaround for reading JWST IFUs with incorrect GWCS. [#973]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -7,6 +7,7 @@ from astropy.units import Quantity
 from astropy.table import Table
 from astropy.io import fits
 from astropy.nddata import StdDevUncertainty, VarianceUncertainty, InverseVariance
+from astropy.time import Time
 from astropy.wcs import WCS
 import asdf
 from gwcs.wcstools import grid_from_bounding_box


### PR DESCRIPTION
Closes #956 with a workaround until the pipeline team fixes the underlying GWCS problem. MJD-OBS code taken from [jdaviz](https://github.com/spacetelescope/jdaviz/blob/70eb5f16aa78e8de68faa3c7b8afbb7096f067ad/jdaviz/configs/cubeviz/plugins/parsers.py#L125), which solved a similar issue there.