### PR TITLE
Change to deprecation warning for redshift/RV setters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- The Spectrum1D redshift and radial_velocity attribute setters were deprecated
+  in favor of the more explicit set_redshift_to, shift_spectrum_to, and
+  set_radial_velocity_to methods. [#946, #943]
+
 1.7.0 (2022-02-21)
 ------------------
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 import numpy as np
 from astropy import units as u
 from astropy.utils.decorators import lazyproperty
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.nddata import NDUncertainty, NDIOMixin, NDArithmeticMixin
 
 from .spectral_axis import SpectralAxis
@@ -662,19 +663,20 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
 
     @redshift.setter
     def redshift(self, val):
-        warnings.warn(
-            "Setting the redshift of a spectrum is ambiguous, use either "
-            "set_redshift_to or shift_spectrum_to to be explicit."
-        )
+        warnings.warn(AstropyDeprecationWarning(
+            "Setting the redshift attribute of a spectrum directly is deprecated "
+            "as of version 1.8.0 and will be removed in a future release. Use "
+            "set_redshift_to or shift_spectrum_to instead."
+        ))
         self.shift_spectrum_to(redshift=val)
 
     @radial_velocity.setter
     def radial_velocity(self, val):
-        warnings.warn(
-            "Setting the radial velocity of a spectrum is ambiguous, use "
-            "either set_radial_velocity_to or shift_spectrum_to to be "
-            "explicit."
-        )
+        warnings.warn(AstropyDeprecationWarning(
+            "Setting the radial_velocity attribute of a spectrum directly is deprecated "
+            "as of version 1.8.0 and will be removed in a future release. Use "
+            "set_radial_velocity_to or shift_spectrum_to instead."
+        ))
         self.shift_spectrum_to(radial_velocity=val)
 
     def __add__(self, other):

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import numpy as np
 from astropy import units as u
 from astropy.utils.decorators import lazyproperty
-from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.decorators import deprecated
 from astropy.nddata import NDUncertainty, NDIOMixin, NDArithmeticMixin
 
 from .spectral_axis import SpectralAxis
@@ -662,21 +662,13 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
             raise ValueError("One of redshift or radial_velocity must be set.")
 
     @redshift.setter
+    @deprecated('1.8.0', alternative='set_redshift_to or shift_spectrum_to')
     def redshift(self, val):
-        warnings.warn(AstropyDeprecationWarning(
-            "Setting the redshift attribute of a spectrum directly is deprecated "
-            "as of version 1.8.0 and will be removed in a future release. Use "
-            "set_redshift_to or shift_spectrum_to instead."
-        ))
         self.shift_spectrum_to(redshift=val)
 
     @radial_velocity.setter
+    @deprecated('1.8.0', alternative='set_radial_velocity_to or shift_spectrum_to')
     def radial_velocity(self, val):
-        warnings.warn(AstropyDeprecationWarning(
-            "Setting the radial_velocity attribute of a spectrum directly is deprecated "
-            "as of version 1.8.0 and will be removed in a future release. Use "
-            "set_radial_velocity_to or shift_spectrum_to instead."
-        ))
         self.shift_spectrum_to(radial_velocity=val)
 
     def __add__(self, other):

--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -4,6 +4,7 @@ import pytest
 from astropy import time
 from astropy.coordinates import (SkyCoord, EarthLocation, ICRS, Galactic,
                                  SpectralCoord, FK5)
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from ..spectra.spectral_axis import SpectralAxis
 from ..spectra.spectrum1d import Spectrum1D
@@ -131,8 +132,8 @@ def test_change_radial_velocity():
     assert spec.radial_velocity == 0 * u.km/u.s
 
     with pytest.warns(
-        UserWarning,
-        match="Setting the radial velocity of a spectrum is ambiguous"
+        AstropyDeprecationWarning,
+        match="Use set_radial_velocity_to or shift_spectrum_to instead"
     ):
         spec.radial_velocity = 1 * u.km / u.s
 
@@ -144,8 +145,8 @@ def test_change_radial_velocity():
     assert spec.radial_velocity == 10 * u.km / u.s
 
     with pytest.warns(
-        UserWarning,
-        match="Setting the radial velocity of a spectrum is ambiguous"
+        AstropyDeprecationWarning,
+        match="Use set_radial_velocity_to or shift_spectrum_to instead"
     ):
         spec.radial_velocity = 5 * u.km / u.s
 
@@ -174,7 +175,8 @@ def test_change_redshift():
     assert type(spec.spectral_axis) == SpectralAxis
 
     with pytest.warns(
-        UserWarning, match="Setting the redshift of a spectrum is ambiguous"
+        AstropyDeprecationWarning,
+        match="Use set_redshift_to or shift_spectrum_to instead"
     ):
         spec.redshift = 0.1
 
@@ -189,7 +191,8 @@ def test_change_redshift():
     assert type(spec.spectral_axis) == SpectralAxis
 
     with pytest.warns(
-        UserWarning, match="Setting the redshift of a spectrum is ambiguous"
+        AstropyDeprecationWarning,
+        match="Use set_redshift_to or shift_spectrum_to instead"
     ):
         spec.redshift = 0.4
 


### PR DESCRIPTION
Simple enough, updates these warnings from "don't use these" to an explicit deprecation warning.

Closes #953 