### PR TITLE
Exclude problematic asdf version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     astropy>=4.1
     gwcs>=0.17.0
     scipy
-    asdf>=2.5,!=2.12.0
+    asdf>=2.10,!=2.12.0
     ndcube>=2.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     astropy>=4.1
     gwcs>=0.17.0
     scipy
-    asdf>=2.5
+    asdf>=2.5,!=2.12.0
     ndcube>=2.0
 
 [options.extras_require]


### PR DESCRIPTION
There have been some problems with `asdf` recently relating to a `jsonschema` release, and while they did a couple backport releases with the fix, apparently version 2.12.0 was erroneously marked as python 3.7 compatible when it really needs 3.8. I'm hoping that excluding that specific version will fix our tests. 