### PR TITLE
Fix bug with weights if unc

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
-- Fix bug in fitting with weights if 'unc'. [#979]
+- Fix bug in fitting with weights if weights argument is set to 'unc'. [#979]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Fix bug in fitting with weights if 'unc'. [#979]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 from astropy import units as u
+from astropy.nddata import StdDevUncertainty
 from astropy.modeling import fitting, Model, models
 from astropy.table import QTable
 from scipy.signal import convolve
@@ -11,7 +12,8 @@ from scipy.signal import convolve
 from ..spectra.spectral_region import SpectralRegion
 from ..spectra.spectrum1d import Spectrum1D
 from ..utils import QuantityModel
-from ..analysis import fwhm, gaussian_sigma_width, centroid, warn_continuum_below_threshold
+from ..analysis import (fwhm, gaussian_sigma_width, centroid, warn_continuum_below_threshold,
+                        uncertainty)
 from ..manipulation import extract_region
 from ..manipulation.utils import excise_regions
 
@@ -382,7 +384,7 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertaintie
 
     if isinstance(weights, str):
         if weights == 'unc':
-            uncerts = spectrum.uncertainty
+            uncerts = uncertainty._convert_uncertainty(spectrum.uncertainty, StdDevUncertainty)
 
             # Astropy fitters expect weights in 1/sigma
             if uncerts is not None:

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -388,6 +388,7 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertaintie
             if uncerts is not None:
                 weights = uncerts.array ** -1
             else:
+                weights = None
                 warnings.warn("Uncertainty values are not defined, but are "
                               "trying to be used in model fitting.")
         else:

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -384,7 +384,9 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertaintie
 
     if isinstance(weights, str):
         if weights == 'unc':
-            uncerts = uncertainty._convert_uncertainty(spectrum.uncertainty, StdDevUncertainty)
+            # Convert uncertainty to StdDev, then invert
+            uncerts = StdDevUncertainty(uncertainty._convert_uncertainty(spectrum.uncertainty,
+                                                                         StdDevUncertainty))
 
             # Astropy fitters expect weights in 1/sigma
             if uncerts is not None:

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -392,8 +392,8 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertaintie
                 weights = uncerts.array ** -1
             else:
                 weights = None
-                warnings.warn("Uncertainty values are not defined, but are "
-                              "trying to be used in model fitting.")
+                warnings.warn("Fitting is set to use uncertainties as weights,"
+                              " but the input spectrum's uncertainty is None")
         else:
             raise ValueError("Unrecognized value `%s` in keyword argument.",
                              weights)

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -384,12 +384,11 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertaintie
 
     if isinstance(weights, str):
         if weights == 'unc':
-            # Convert uncertainty to StdDev, then invert
-            uncerts = StdDevUncertainty(uncertainty._convert_uncertainty(spectrum.uncertainty,
-                                                                         StdDevUncertainty))
-
-            # Astropy fitters expect weights in 1/sigma
-            if uncerts is not None:
+            if spectrum.uncertainty is not None:
+                # Convert uncertainty to StdDev, then invert
+                uncerts = StdDevUncertainty(uncertainty._convert_uncertainty(spectrum.uncertainty,
+                                                                             StdDevUncertainty))
+                # Astropy fitters expect weights in 1/sigma
                 weights = uncerts.array ** -1
             else:
                 weights = None

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -199,7 +199,7 @@ def test_single_peak_fit():
     assert np.allclose(list(g_fit.stds), [0.04627, 0.01427, 0.01427], rtol=0.05)
 
 
-def test_single_peak_fit_with_uncertainties():
+def test_single_peak_fit_with_and_without_uncertainties():
     """
     Single peak fit
     """
@@ -214,16 +214,19 @@ def test_single_peak_fit_with_uncertainties():
                                  stddev=30*u.angstrom) + models.Const1D(8 * u.Jy)
     x = np.linspace(6400, 6700, 300) * u.AA
 
-    def calculate_rms(x, init_mod, implicit_weights):
+    def calculate_rms(x, init_mod, implicit_weights, valid_uncertainty):
         rms = []
 
         for _ in range(100):
             ymod = line_mod(x)
             y = np.random.poisson(ymod)
             unc = np.sqrt(ymod)
-
-            spec = Spectrum1D(spectral_axis=x, flux=y * u.Jy,
-                              uncertainty=StdDevUncertainty(unc * u.Jy))
+            if valid_uncertainty:
+                spec = Spectrum1D(spectral_axis=x, flux=y * u.Jy,
+                                  uncertainty=StdDevUncertainty(unc * u.Jy))
+            else:
+                spec = Spectrum1D(spectral_axis=x, flux=y * u.Jy,
+                                  uncertainty=None)
 
             weights = 'unc' if implicit_weights else unc ** -1
 
@@ -233,10 +236,15 @@ def test_single_peak_fit_with_uncertainties():
 
         return np.median(rms)
 
-    assert np.allclose(calculate_rms(x, init_mod, implicit_weights=True),
+    assert np.allclose(calculate_rms(x, init_mod, implicit_weights=True, valid_uncertainty=True),
                        5.101611033799086)
-    assert np.allclose(calculate_rms(x, init_mod, implicit_weights=False),
+    assert np.allclose(calculate_rms(x, init_mod, implicit_weights=False, valid_uncertainty=True),
                        5.113697654869089)
+    with pytest.warns(UserWarning, match='Uncertainty values are not defined, '
+                                         'but are trying to be used in model fitting.'):
+        calculate_rms(x, init_mod, implicit_weights=True, valid_uncertainty=False)
+    assert np.allclose(calculate_rms(x, init_mod, implicit_weights=False, valid_uncertainty=False),
+                       5.098289708242831)
 
 
 def test_single_peak_fit_window():

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -240,8 +240,8 @@ def test_single_peak_fit_with_and_without_uncertainties():
                        5.101611033799086)
     assert np.allclose(calculate_rms(x, init_mod, implicit_weights=False, valid_uncertainty=True),
                        5.113697654869089)
-    with pytest.warns(UserWarning, match='Uncertainty values are not defined, '
-                                         'but are trying to be used in model fitting.'):
+    with pytest.warns(UserWarning, match='Fitting is set to use uncertainties as weights,'
+                                         ' but the input spectrum's uncertainty is None'):
         calculate_rms(x, init_mod, implicit_weights=True, valid_uncertainty=False)
     assert np.allclose(calculate_rms(x, init_mod, implicit_weights=False, valid_uncertainty=False),
                        5.098289708242831)

--- a/specutils/tests/test_fitting.py
+++ b/specutils/tests/test_fitting.py
@@ -240,8 +240,8 @@ def test_single_peak_fit_with_and_without_uncertainties():
                        5.101611033799086)
     assert np.allclose(calculate_rms(x, init_mod, implicit_weights=False, valid_uncertainty=True),
                        5.113697654869089)
-    with pytest.warns(UserWarning, match='Fitting is set to use uncertainties as weights,'
-                                         ' but the input spectrum's uncertainty is None'):
+    with pytest.warns(UserWarning, match="Fitting is set to use uncertainties as weights,"
+                                         " but the input spectrum's uncertainty is None"):
         calculate_rms(x, init_mod, implicit_weights=True, valid_uncertainty=False)
     assert np.allclose(calculate_rms(x, init_mod, implicit_weights=False, valid_uncertainty=False),
                        5.098289708242831)


### PR DESCRIPTION
If `weights` is set to "unc", it will go through this code block and - if `uncerts` is None - `weights` will be used as a list. By setting `weights` to None here, that later code block (line ~492) is not executed and the traceback is avoided.