### PR TITLE
SpectrumList.read improvement for multiple FITS files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Bug Fixes
 ^^^^^^^^^
 
 - Fix bug in fitting with weights if weights argument is set to 'unc'. [#979]
+- Fix bug in reader which caused multi-extension files to load only the
+  primary HDU [#982]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Bug Fixes
 ^^^^^^^^^
 
 - Fix bug in fitting with weights if weights argument is set to 'unc'. [#979]
-- Fix bug in reader which caused multi-extension files to load only the
+- Fix bug in JWST reader which caused multi-extension files to load only the
   primary HDU [#982]
 
 Other Changes and Additions

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import warnings
+from itertools import chain
 
 import astropy.units as u
 from astropy.units import Quantity
@@ -278,12 +279,11 @@ def jwst_x1d_miri_mrs_loader(input, missing="raise", **kwargs):
                 raise FileNotFoundError(f"Failed to load {file_obj}: {repr(e)}. "
                                         "To suppress this error, set argument missing='warn'")
 
-        # note that the method above returns a single Spectrum1D instance
-        # packaged in a SpectrumList wrapper. We remove the wrapper so as
-        # to avoid ending up with a depth-2 SpectrumList.
-        spectra.append(sp[0])
+        spectra.append(sp)
 
-    return SpectrumList(spectra)
+    # the call to `chain.from_iterable` allows us to handle multiple HDUs
+    # stored within multiple FITS files, all unpacked into one `SpectrumList`
+    return SpectrumList(chain.from_iterable(spectra))
 
 
 def _jwst_spec1d_loader(file_obj, extname='EXTRACT1D', **kwargs):


### PR DESCRIPTION
Hi folks, 

I was working with some old code by @orifox which called `SpectrumList.read('directory/.')` in order to load all readable FITS files within `directory`. With the latest version of specutils this behavior produces an unexpected result: the `SpectrumList` that gets returned only has the _primary HDUs_ for each readable file within `directory`. This traces back to [this block of code](https://github.com/astropy/specutils/blob/a4038efa0a3cfdbaddf7a2e5bd5ef52c3c2969fd/specutils/io/default_loaders/jwst_reader.py#L281-L284) introduced in #838.

In this PR I've removed the line that extracts only primary HDU and put all available HDUs in the resulting `SpectrumList`.