### PR TITLE
Replace all uncertainty conversion with represent_as()

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -56,9 +56,9 @@ jobs:
             toxenv: py38-test-alldeps
             toxposargs: --durations=50
 
-          - name: Python 3.8 doc build
+          - name: Python 3.9 doc build
             os: ubuntu-latest
-            python: 3.8
+            python: 3.9
             toxenv: build_docs
 
     steps:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,47 +18,47 @@ jobs:
             python: 3.x
             toxenv: codestyle
 
-          - name: Python 3.7 with minimal dependencies
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test
-
-          - name: Python 3.8 with all optional dependencies
+          - name: Python 3.8 with minimal dependencies
             os: ubuntu-latest
             python: 3.8
-            toxenv: py38-test-alldeps
+            toxenv: py38-test
+
+          - name: Python 3.9 with all optional dependencies
+            os: ubuntu-latest
+            python: 3.9
+            toxenv: py39-test-alldeps
             toxargs: -v --develop
             toxposargs: --open-files
 
           # NOTE: In the build below we also check that tests do not open and
           # leave open any files. This has a performance impact on running the
           # tests, hence why it is not enabled by default.
-          - name: Python 3.7 with oldest supported version of all dependencies
+          - name: Python 3.8 with oldest supported version of all dependencies
             os: ubuntu-18.04
-            python: 3.7
-            toxenv: py37-test-oldestdeps
+            python: 3.8
+            toxenv: py38-test-oldestdeps
 
-          - name: Python 3.7 with numpy 1.17 and full coverage
+          - name: Python 3.8 with numpy 1.17 and full coverage
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test-alldeps-numpy117-cov
+            python: 3.8
+            toxenv: py38-test-alldeps-numpy117-cov
             toxposargs: --remote-data=astropy
 
-          - name: Python 3.8 with all optional dependencies (Windows)
+          - name: Python 3.9 with all optional dependencies (Windows)
             os: windows-latest
+            python: 3.9
+            toxenv: py39-test-alldeps
+            toxposargs: --durations=50
+
+          - name: Python 3.8 with all optional dependencies (MacOS X)
+            os: macos-latest
             python: 3.8
             toxenv: py38-test-alldeps
             toxposargs: --durations=50
 
-          - name: Python 3.7 with all optional dependencies (MacOS X)
-            os: macos-latest
-            python: 3.7
-            toxenv: py37-test-alldeps
-            toxposargs: --durations=50
-
-          - name: Python 3.7 doc build
+          - name: Python 3.8 doc build
             os: ubuntu-latest
-            python: 3.7
+            python: 3.8
             toxenv: build_docs
 
     steps:
@@ -93,10 +93,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: (Allowed Failure) Python 3.8 with remote data and dev version of key dependencies
+          - name: (Allowed Failure) Python 3.9 with remote data and dev version of key dependencies
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-test-devdeps
+            python: 3.9
+            toxenv: py39-test-devdeps
             toxposargs: --remote-data=any
 
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Bug Fixes
 - Fix bug in fitting with weights if weights argument is set to 'unc'. [#979]
 - Fix bug in JWST reader which caused multi-extension files to load only the
   primary HDU [#982]
+- Implemented conversion to expected uncertainty type in a few functions that
+  were still just assuming the uncertainty was the correct type. [#984]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -50,10 +50,12 @@ py:obj n
 py:obj axis1
 py:obj axis2
 py:obj data_as
+py:obj ndarray.astype
 py:obj ndarray.setflags
 py:obj ndarray.reshape
 py:obj ndarray.flat
 py:obj ndarray.T
+py:obj ndarray.view
 py:obj a.size
 py:obj x
 py:obj order

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = astropy/specutils
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     astropy>=5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
-    astropy>=4.1
+    astropy>=5.1
     gwcs>=0.17.0
     scipy
     asdf>=2.10,!=2.12.0

--- a/specutils/analysis/correlation.py
+++ b/specutils/analysis/correlation.py
@@ -1,6 +1,7 @@
 import astropy.units as u
 import numpy as np
 from astropy import constants as const
+from astropy.nddata import StdDevUncertainty
 from astropy.units import Quantity
 from scipy.signal.windows import tukey
 
@@ -241,9 +242,8 @@ def _normalize(observed_spectrum, template_spectrum):
         A float which will normalize the template spectrum's flux so that it
         can be compared to the observed spectrum.
     """
-    num = np.nansum((observed_spectrum.flux*template_spectrum.flux)/
-                 (observed_spectrum.uncertainty.array**2))
-    denom = np.nansum((template_spectrum.flux/
-                    observed_spectrum.uncertainty.array)**2)
+    unc = observed_spectrum.uncertainty.represent_as(StdDevUncertainty)
+    num = np.nansum((observed_spectrum.flux*template_spectrum.flux)/(unc.array**2))
+    denom = np.nansum((template_spectrum.flux/unc.array)**2)
 
     return num/denom

--- a/specutils/analysis/flux.py
+++ b/specutils/analysis/flux.py
@@ -11,7 +11,6 @@ from astropy.nddata import VarianceUncertainty
 from .. import conf
 from ..spectra import Spectrum1D
 from ..manipulation import extract_region, LinearInterpolatedResampler
-from .uncertainty import _convert_uncertainty
 from .utils import computation_wrapper
 import astropy.units as u
 from astropy.stats import mad_std
@@ -142,7 +141,7 @@ def _compute_line_flux(spectrum, regions=None,
         # Can't handle masks via interpolation here, since interpolators
         # only work with the flux array.
         try:
-            variance_q = _convert_uncertainty(calc_spectrum.uncertainty, VarianceUncertainty)
+            variance_q = calc_spectrum.uncertainty.represent_as(VarianceUncertainty).quantity
         except ValueError:
             warnings.warn(f"Uncertainty type "
                           f"'{calc_spectrum.uncertainty.uncertainty_type}' "

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -10,7 +10,6 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from ..spectra import SpectralRegion
 from ..manipulation import extract_region
-from .uncertainty import _convert_uncertainty
 
 
 __all__ = ['centroid']
@@ -95,7 +94,7 @@ def _centroid_single_region(spectrum, region=None):
         calc_spectrum = spectrum
 
     if spectrum.uncertainty is not None:
-        flux_uncert = _convert_uncertainty(calc_spectrum.uncertainty, StdDevUncertainty)
+        flux_uncert = calc_spectrum.uncertainty.represent_as(StdDevUncertainty).quantity
     else:
         # dummy value for uncertainties to avoid extra if-statements when applying mask
         flux_uncert = np.zeros_like(spectrum.flux)

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -8,7 +8,6 @@ from astropy.nddata import StdDevUncertainty
 from astropy.stats.funcs import gaussian_sigma_to_fwhm
 from ..manipulation import extract_region
 from . import centroid
-from .uncertainty import _convert_uncertainty
 from .utils import computation_wrapper
 from scipy.signal import find_peaks, peak_widths
 
@@ -211,7 +210,7 @@ def _compute_gaussian_sigma_width(spectrum, regions=None):
         calc_spectrum = spectrum
 
     if spectrum.uncertainty is not None:
-        flux_uncert = _convert_uncertainty(calc_spectrum.uncertainty, StdDevUncertainty)
+        flux_uncert = calc_spectrum.uncertainty.represent_as(StdDevUncertainty).quantity
     else:
         # dummy value for uncertainties to avoid extra if-statements when applying mask
         flux_uncert = np.zeros_like(calc_spectrum.flux)

--- a/specutils/manipulation/manipulation.py
+++ b/specutils/manipulation/manipulation.py
@@ -6,6 +6,8 @@ spectra.
 import copy
 import operator
 
+from astropy.nddata import StdDevUncertainty
+
 __all__ = ['snr_threshold']
 
 
@@ -73,7 +75,7 @@ def snr_threshold(spectrum, value, op=operator.gt):
 
     # NDData convention: Masks should follow the numpy convention that valid
     # data points are marked by False and invalid ones with True.
-    mask = ~op(data / (spectrum.uncertainty.quantity), value)
+    mask = ~op(data / (spectrum.uncertainty.represent_as(StdDevUncertainty).quantity), value)
 
     spectrum_out = copy.copy(spectrum)
     spectrum_out._mask = mask

--- a/specutils/manipulation/resample.py
+++ b/specutils/manipulation/resample.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 import numpy as np
-from astropy.nddata import StdDevUncertainty, VarianceUncertainty, InverseVariance
+from astropy.nddata import VarianceUncertainty, InverseVariance
 from astropy.units import Quantity
 from scipy.interpolate import CubicSpline
 
@@ -160,12 +160,7 @@ class FluxConservingResampler(ResamplerBase):
 
         # Get provided uncertainty into variance
         if orig_spectrum.uncertainty is not None:
-            if isinstance(orig_spectrum.uncertainty, StdDevUncertainty):
-                pixel_uncer = np.square(orig_spectrum.uncertainty.array)
-            elif isinstance(orig_spectrum.uncertainty, VarianceUncertainty):
-                pixel_uncer = orig_spectrum.uncertainty.array
-            elif isinstance(orig_spectrum.uncertainty, InverseVariance):
-                pixel_uncer = np.reciprocal(orig_spectrum.uncertainty.array)
+            pixel_uncer = orig_spectrum.uncertainty.represent_as(VarianceUncertainty).array
         else:
             pixel_uncer = None
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-alldeps,-devdeps}{,-cov}
-    py{37,38,39,310}-test-numpy{116,117,118}
-    py{37,38,39,310}-test-astropy{30,40,lts}
-    py{37,38,39,310}-test-external
+    py{38,39,310}-test{,-alldeps,-devdeps}{,-cov}
+    py{38,39,310}-test-numpy{116,117,118}
+    py{38,39,310}-test-astropy{40,50,lts}
+    py{38,39,310}-test-external
     build_docs
     linkcheck
     codestyle
@@ -47,7 +47,6 @@ description =
     numpy116: with numpy 1.16.*
     numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
-    astropy30: with astropy 3.0.*
     astropy40: with astropy 4.0.*
     astropylts: with the latest astropy LTS
     external: with outside packages as dependencies
@@ -59,7 +58,6 @@ deps =
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
 
-    astropy30: astropy==3.0.*
     astropy40: astropy==4.0.*
     astropylts: astropy==5.0.*
 


### PR DESCRIPTION
As of astropy 5.1, `NDUncertainty` objects now have a built-in `represent_as` method to convert between types. This PR replaces the multiple ways we were doing conversion between uncertainty types with consistent use of this method, as well as converting between types in a few places where the uncertainty was assumed to be standard deviation, but not enforced. This definitely needs another set of eyes to check that my types are correct in those places where I added conversion.

Closes #983 