### PR TITLE
Fix SpectralAxis.with_observer_stationary_relative_to

### DIFF
--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -75,8 +75,8 @@ class SpectralAxis(SpectralCoord):
         if self.unit is u.pixel:
             raise u.UnitsError("Cannot transform spectral coordinates in pixel units")
         return super().with_observer_stationary_relative_to(frame,
-                                                     velocity=velocity,
-                                                     preserve_observer_frame=preserve_observer_frame)
+                                                            velocity=velocity,
+                                                            preserve_observer_frame=preserve_observer_frame)
 
     def with_radial_velocity_shift(self, target_shift=None, observer_shift=None):
         if self.unit is u.pixel:

--- a/specutils/spectra/spectral_axis.py
+++ b/specutils/spectra/spectral_axis.py
@@ -74,7 +74,7 @@ class SpectralAxis(SpectralCoord):
                                              preserve_observer_frame=False):
         if self.unit is u.pixel:
             raise u.UnitsError("Cannot transform spectral coordinates in pixel units")
-        super().with_observer_stationary_relative_to(frame,
+        return super().with_observer_stationary_relative_to(frame,
                                                      velocity=velocity,
                                                      preserve_observer_frame=preserve_observer_frame)
 


### PR DESCRIPTION
`SpectralAxis.with_observer_stationary_relative_to` should call the function of same name defined on the parent class, and actually return the axis so created.