### PR TITLE
Docstring correction for Spectrum1D

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -35,7 +35,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
 
     Parameters
     ----------
-    flux : `~astropy.units.Quantity` or `~astropy.nddata.NDData`-like
+    flux : `~astropy.units.Quantity`
         The flux data for this spectrum. This can be a simple `~astropy.units.Quantity`,
         or an existing `~Spectrum1D` or `~ndcube.NDCube` object.
     spectral_axis : `~astropy.units.Quantity` or `~specutils.SpectralAxis`


### PR DESCRIPTION
`Spectrum1D` accepts a `flux` argument which is required to be a Quantity, see:
https://github.com/astropy/specutils/blob/afa148cd3b4894d941a8d50ade169fa10dc42efc/specutils/spectra/spectrum1d.py#L114-L119

The docstring suggests that you could supply an `NDData`-like object, but this isn't currently supported. If you give it an `NDDataArray` you would get: 
```python
>>> import astropy.units as u
>>> from astropy.nddata import NDDataArray

>>> nd = NDDataArray([1, 2, 3], unit=u.Jy)
>>> Spectrum1D(nd)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In [5], line 1
----> 1 Spectrum1D(nd)

File ~/miniconda3/envs/jdaviz/lib/python3.9/site-packages/specutils/spectra/spectrum1d.py:117, in Spectrum1D.__init__(self, flux, spectral_axis, wcs, velocity_convention, rest_value, redshift, radial_velocity, bin_specification, **kwargs)
    115 if flux is not None:
    116     if not isinstance(flux, u.Quantity):
--> 117         raise ValueError("Flux must be a `Quantity` object.")
    118     elif flux.isscalar:
    119         flux = u.Quantity([flux])

ValueError: Flux must be a `Quantity` object.
```

This PR simply removes "NDData-like" from the docstring.