### PR TITLE
Catch warning from deprecation of `CustomType`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:unclosed file:ResourceWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
+    ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:invalid value encountered in .*divide:RuntimeWarning
     ignore:.*contains multiple slashes:astropy.units.core.UnitsWarning
     ignore::astropy.wcs.wcs.FITSFixedWarning

--- a/specutils/io/asdf/extension.py
+++ b/specutils/io/asdf/extension.py
@@ -3,14 +3,23 @@ Defines extension that is used by ASDF for recognizing specutils types
 """
 import os
 import urllib
+import warnings
 
 from asdf.util import filepath_to_url
 from asdf.extension import AsdfExtension
-
-from astropy.io.misc.asdf.extension import ASTROPY_SCHEMA_URI_BASE
+from asdf.exceptions import AsdfDeprecationWarning
 
 from .tags.spectra import *  # noqa
 from .types import _specutils_types
+
+
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        category=AsdfDeprecationWarning,
+        message=r".*from astropy.io.misc.asdf.* subclasses the deprecated CustomType .*",
+    )
+    from astropy.io.misc.asdf.extension import ASTROPY_SCHEMA_URI_BASE
 
 
 SCHEMA_PATH = os.path.abspath(

--- a/specutils/io/asdf/types.py
+++ b/specutils/io/asdf/types.py
@@ -1,3 +1,6 @@
+import warnings
+
+from asdf.exceptions import AsdfDeprecationWarning
 from asdf.types import CustomType, ExtensionTypeMeta
 
 
@@ -17,9 +20,16 @@ class SpecutilsTypeMeta(ExtensionTypeMeta):
         return cls
 
 
-class SpecutilsType(CustomType, metaclass=SpecutilsTypeMeta):
-    """
-    Parent class of all specutils tag implementations used by ASDF
-    """
-    organization = 'astropy.org'
-    standard = 'specutils'
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        category=AsdfDeprecationWarning,
+        message=r"SpecutilsType from specutils.io.asdf.types subclasses the deprecated CustomType .*",
+    )
+
+    class SpecutilsType(CustomType, metaclass=SpecutilsTypeMeta):
+        """
+        Parent class of all specutils tag implementations used by ASDF
+        """
+        organization = 'astropy.org'
+        standard = 'specutils'


### PR DESCRIPTION
In issue #1011, it was mentioned the `CustomType` was going to be deprecated by ASDF. This has now occurred meaning testing with `specutils` installed under the development version of ASDF will now cause warnings to be emitted by `specutils` every time an ASDF file is loaded. This PR seeks to resolve this warning while a permanent fix  for #1011 can be created.