### PR TITLE
Pin matplotlib in oldestdeps job

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -30,7 +30,7 @@ jobs:
             toxposargs: --open-files --remote-data=astropy
 
           - name: Python 3.8 with oldest supported version of key dependencies
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             python: 3.8
             toxenv: py38-test-oldestdeps
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ deps =
     oldestdeps: asdf-astropy==0.3.*
     oldestdeps: asdf==2.10.*
     oldestdeps: ndcube==2.0.*
+    oldestdeps: matplotlib==3.6.*
 
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0


### PR DESCRIPTION
matplotlib 3.7 bumped minversion of numpy.

Fix #1014 