### PR TITLE
basic code example and links to Spectrum1D.write

### DIFF
--- a/docs/custom_loading.rst
+++ b/docs/custom_loading.rst
@@ -143,6 +143,8 @@ many `~specutils.Spectrum1D` objects. This method is available since
 `astropy.io.registry.read`).
 
 
+.. _custom_writer:
+
 Creating a Custom Writer
 ------------------------
 

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -87,6 +87,18 @@ A full list of the supported formats is shown in the table below.
 
 | More information on creating custom loaders can be found in the :doc:`custom loading </custom_loading>` page.
 
+Writing to a File
+-----------------
+
+Similarly, a `~specutils.Spectrum1D` object can be saved to any file format supported by
+:class:`~astropy.nddata.CCDData` via the :meth:`specutils.Spectrum1D.write` method.
+
+.. code-block:: python
+
+    >>> from specutils import Spectrum1D
+    >>> spec1d = Spectrum1D.read("/path/to/input.fits")  # doctest: +SKIP
+    >>> spec1d.write("/path/to/output.fits")  # doctest: +SKIP
+
 
 Including Uncertainties
 -----------------------

--- a/docs/spectrum1d.rst
+++ b/docs/spectrum1d.rst
@@ -90,15 +90,14 @@ A full list of the supported formats is shown in the table below.
 Writing to a File
 -----------------
 
-Similarly, a `~specutils.Spectrum1D` object can be saved to any file format supported by
-:class:`~astropy.nddata.CCDData` via the :meth:`specutils.Spectrum1D.write` method.
+Similarly, a `~specutils.Spectrum1D` object can be saved to any of the supported formats using the
+:meth:`specutils.Spectrum1D.write` method.
 
 .. code-block:: python
 
-    >>> from specutils import Spectrum1D
-    >>> spec1d = Spectrum1D.read("/path/to/input.fits")  # doctest: +SKIP
     >>> spec1d.write("/path/to/output.fits")  # doctest: +SKIP
 
+| More information on creating custom writers can be found in :ref:`custom_writer`.
 
 Including Uncertainties
 -----------------------


### PR DESCRIPTION
This PR adds a very brief example of how to use `Spectrum1D.write` and links to the API docs within the main spectrum1d landing page on the docs.

See [rendered docs from this PR](https://specutils--1017.org.readthedocs.build/en/1017/spectrum1d.html#writing-to-a-file)