### PR TITLE
support Spectrum1D reading from file with flux in counts

### DIFF
--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -209,7 +209,7 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
         u.spectral_density() equivalencies. If none meet that criterion,
         look for other likely length units such as 'adu' or 'cts/s'.
         """
-        additional_valid_units = [u.Unit('adu'), u.Unit('ct/s')]
+        additional_valid_units = [u.Unit('adu'), u.Unit('ct/s'), u.Unit('count')]
         found_column = None
 
         # First, search for a column with units compatible with Janskies

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -357,6 +357,18 @@ def test_create_with_uncertainty():
         Spectrum1D(spectral_axis=wavelengths*u.um, flux=flux, uncertainty=uncertainty)
 
 
+def test_flux_unit_io_roundtrip(tmpdir):
+    # regression test for https://github.com/astropy/specutils/pull/1018
+    fname = str(tmpdir.join('flux_unit_io_roundtrip.fits'))
+    for flux_unit in ('adu', 'ct/s', 'count'):
+        sp = Spectrum1D(flux=np.linspace(0,1,11)*u.Unit(flux_unit),
+                        spectral_axis=np.random.random(11)*u.Unit('Hz'))
+        sp.write(fname, overwrite=True)
+
+        sp_load = Spectrum1D.read(fname)
+        assert sp_load.flux.unit == sp.unit
+
+
 @pytest.mark.filterwarnings('ignore::astropy.io.fits.verify.VerifyWarning')
 @remote_access([{'id': '1481190', 'filename': 'L5g_0355+11_Cruz09.fits'}])
 def test_read_linear_solution(remote_data_path):

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -357,16 +357,16 @@ def test_create_with_uncertainty():
         Spectrum1D(spectral_axis=wavelengths*u.um, flux=flux, uncertainty=uncertainty)
 
 
-def test_flux_unit_io_roundtrip(tmpdir):
+@pytest.mark.parametrize("flux_unit", ["adu", "ct/s", "count"])
+def test_flux_unit_io_roundtrip(tmp_path, flux_unit):
     # regression test for https://github.com/astropy/specutils/pull/1018
-    fname = str(tmpdir.join('flux_unit_io_roundtrip.fits'))
-    for flux_unit in ('adu', 'ct/s', 'count'):
-        sp = Spectrum1D(flux=np.linspace(0,1,11)*u.Unit(flux_unit),
-                        spectral_axis=np.random.random(11)*u.Unit('Hz'))
-        sp.write(fname, overwrite=True)
+    fname = str(tmp_path / 'flux_unit_io_roundtrip.fits')
+    sp = Spectrum1D(flux=np.ones(11) * u.Unit(flux_unit),
+                    spectral_axis=np.arange(1, 12) * u.Unit('Hz'))
+    sp.write(fname, overwrite=True)
 
-        sp_load = Spectrum1D.read(fname)
-        assert sp_load.flux.unit == sp.unit
+    sp_load = Spectrum1D.read(fname)
+    assert sp_load.flux.unit == sp.flux.unit
 
 
 @pytest.mark.filterwarnings('ignore::astropy.io.fits.verify.VerifyWarning')


### PR DESCRIPTION
this PR implements an exception to support reading a Spectrum1D from a file with fluxes in counts.  This does not however address more general reading round-tripping such as the one reported in #997.  Note also that this is just hardcoding an additional exception, `Spectrum1D` currently doesn't seem to do any unit checking on the inputs for flux, and so other units might result in the same error (including non-sensical units, like fluxes with units of meters).

Example (that used to raise an `OSError: Could not identify column containing the flux`):

```
import specutils
import numpy as np
import astropy.units as u

sp = specutils.Spectrum1D(flux=np.linspace(0,1,11)*u.Unit('count'), spectral_axis=np.random.random(11)*u.Unit('J'))
sp.write("spec.fits", overwrite=True)

specutils.Spectrum1D.read("spec.fits")
```