### PR TITLE
RTD: Use mamba to pick up new graphviz

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,12 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
-  apt_packages:
-    - graphviz
+  os: "ubuntu-20.04"
   tools:
-    python: "3.9"
+    python: "mambaforge-4.10"
+
+conda:
+  environment: docs/rtd_environment.yaml
 
 sphinx:
   builder: html
@@ -23,4 +24,3 @@ python:
 
 # Don't build any extra formats
 formats: []
-

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,0 +1,8 @@
+name: rtd311
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.11
+  - pip
+  - graphviz


### PR DESCRIPTION
Use mamba to pick up new graphviz so inheritance diagrams won't get cropped. This patch is similar to what was deployed to astropy and other packages.

You can see this currently at the bottom of https://specutils.readthedocs.io/en/latest/spectrum1d.html

![Screenshot 2023-02-21 181212](https://user-images.githubusercontent.com/2090236/220479854-5343b333-a6d6-46b9-bb91-684ae38dfcd5.jpg)

With this patch: https://specutils--1020.org.readthedocs.build/en/1020/spectrum1d.html#class-inheritance-diagram
