### PR TITLE
Catch deprecation from AsdfExtension

### DIFF
--- a/specutils/io/asdf/extension.py
+++ b/specutils/io/asdf/extension.py
@@ -6,7 +6,6 @@ import urllib
 import warnings
 
 from asdf.util import filepath_to_url
-from asdf.extension import AsdfExtension
 from asdf.exceptions import AsdfDeprecationWarning
 
 from .tags.spectra import *  # noqa
@@ -14,11 +13,13 @@ from .types import _specutils_types
 
 
 with warnings.catch_warnings():
+    msg = r"[.* is deprecated.*, .*from astropy.io.misc.asdf.* subclasses the deprecated CustomType .*]"
     warnings.filterwarnings(
         "ignore",
         category=AsdfDeprecationWarning,
-        message=r".*from astropy.io.misc.asdf.* subclasses the deprecated CustomType .*",
+        message=msg,
     )
+    from asdf.extension import AsdfExtension
     from astropy.io.misc.asdf.extension import ASTROPY_SCHEMA_URI_BASE
 
 


### PR DESCRIPTION
asdf-format/asdf#1429 deprecated the `AsdfExtension` class. This PR catches that deprecation warning.