### PR TITLE
Catch deprecation warning for ASDF entry point

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ filterwarnings =
     ignore:Input WCS indicates that the spectral axis is not last:UserWarning
     ignore:No velocity defined on frame:astropy.coordinates.spectral_coordinate.NoVelocityWarning
     ignore:No observer defined on WCS:astropy.utils.exceptions.AstropyUserWarning
+    ignore:specutils uses the deprecated entry point.*:asdf.exceptions.AsdfDeprecationWarning
 
 [coverage:run]
 omit =


### PR DESCRIPTION
asdf-format/asdf#1361 officially deprecates the legacy entry-point which `specutils` uses for its ASDF extension. This PR ignores that deprecation.

Note, I have tested this locally and it successfully fixes failures due to the entrypoint deprecation warning.