### PR TITLE
change asdf.tests.helpers uses to asdf.testing.helpers

### DIFF
--- a/specutils/io/asdf/tags/tests/test_spectra.py
+++ b/specutils/io/asdf/tags/tests/test_spectra.py
@@ -8,10 +8,11 @@ import astropy.units as u  # noqa: E402
 from astropy.coordinates import FK5  # noqa: E402
 from astropy.nddata import StdDevUncertainty  # noqa: E402
 
-from asdf.tests.helpers import assert_roundtrip_tree  # noqa: E402
+from asdf.testing.helpers import roundtrip_object  # noqa: E402
 import asdf  # noqa: E402
 
 from specutils import Spectrum1D, SpectrumList, SpectralAxis  # noqa: E402
+from specutils.io.asdf.tags.spectra import Spectrum1DType, SpectrumListType
 
 
 def create_spectrum1d(xmin, xmax, uncertainty=None):
@@ -26,18 +27,16 @@ def create_spectrum1d(xmin, xmax, uncertainty=None):
 def test_asdf_spectrum1d(tmpdir):
 
     spectrum = create_spectrum1d(5100, 5300)
+    Spectrum1DType.assert_equal(spectrum, roundtrip_object(spectrum))
 
-    tree = dict(spectrum=spectrum)
-    assert_roundtrip_tree(tree, tmpdir)
 
 
 @pytest.mark.filterwarnings('ignore:ASDF functionality for astropy is being moved out')
 def test_asdf_spectrum1d_uncertainty(tmpdir):
 
     spectrum = create_spectrum1d(5100, 5300, uncertainty=True)
+    Spectrum1DType.assert_equal(spectrum, roundtrip_object(spectrum))
 
-    tree = dict(spectrum=spectrum)
-    assert_roundtrip_tree(tree, tmpdir)
 
 
 @pytest.mark.xfail
@@ -45,8 +44,9 @@ def test_asdf_spectralaxis(tmpdir):
 
     wavelengths  = np.arange(5100, 5300) * 0.1 * u.nm
     spectral_axis = SpectralAxis(wavelengths, bin_specification="edges")
-    tree = dict(spectral_axis=spectral_axis)
-    assert_roundtrip_tree(tree, tmpdir)
+    # there is no implemented asdf type for SpectralAxis and no defined
+    # equality comparison (assert_equal)
+    assert roundtrip_object(spectral_axis) == spectrum_axis
 
 
 @pytest.mark.filterwarnings('ignore:ASDF functionality for astropy is being moved out')
@@ -58,9 +58,8 @@ def test_asdf_spectrumlist(tmpdir):
         create_spectrum1d(0, 100),
         create_spectrum1d(1, 5)
     ])
+    SpectrumListType.assert_equal(spectra, roundtrip_object(spectra))
 
-    tree = dict(spectra=spectra)
-    assert_roundtrip_tree(tree, tmpdir)
 
 
 @pytest.mark.filterwarnings("error::UserWarning")

--- a/specutils/io/asdf/tags/tests/test_spectra.py
+++ b/specutils/io/asdf/tags/tests/test_spectra.py
@@ -44,7 +44,11 @@ def test_asdf_spectralaxis(tmpdir):
     spectral_axis = SpectralAxis(wavelengths, bin_specification="edges")
     # there is no implemented asdf type for SpectralAxis and no defined
     # equality comparison (assert_equal)
-    assert roundtrip_object(spectral_axis) == spectral_axis
+    # per the comment https://github.com/astropy/specutils/pull/645#issuecomment-614271632
+    # the issue is that SpectralAxis roundtrips as SpectralCoord
+    # so the types should differ
+    rt = roundtrip_object(spectral_axis)
+    assert type(rt) == type(spectral_axis)
 
 
 @pytest.mark.filterwarnings('ignore:ASDF functionality for astropy is being moved out')

--- a/specutils/io/asdf/tags/tests/test_spectra.py
+++ b/specutils/io/asdf/tags/tests/test_spectra.py
@@ -12,7 +12,7 @@ from asdf.testing.helpers import roundtrip_object  # noqa: E402
 import asdf  # noqa: E402
 
 from specutils import Spectrum1D, SpectrumList, SpectralAxis  # noqa: E402
-from specutils.io.asdf.tags.spectra import Spectrum1DType, SpectrumListType
+from specutils.io.asdf.tags.spectra import Spectrum1DType, SpectrumListType  # noqa: E402
 
 
 def create_spectrum1d(xmin, xmax, uncertainty=None):
@@ -30,13 +30,11 @@ def test_asdf_spectrum1d(tmpdir):
     Spectrum1DType.assert_equal(spectrum, roundtrip_object(spectrum))
 
 
-
 @pytest.mark.filterwarnings('ignore:ASDF functionality for astropy is being moved out')
 def test_asdf_spectrum1d_uncertainty(tmpdir):
 
     spectrum = create_spectrum1d(5100, 5300, uncertainty=True)
     Spectrum1DType.assert_equal(spectrum, roundtrip_object(spectrum))
-
 
 
 @pytest.mark.xfail
@@ -46,7 +44,7 @@ def test_asdf_spectralaxis(tmpdir):
     spectral_axis = SpectralAxis(wavelengths, bin_specification="edges")
     # there is no implemented asdf type for SpectralAxis and no defined
     # equality comparison (assert_equal)
-    assert roundtrip_object(spectral_axis) == spectrum_axis
+    assert roundtrip_object(spectral_axis) == spectral_axis
 
 
 @pytest.mark.filterwarnings('ignore:ASDF functionality for astropy is being moved out')
@@ -59,7 +57,6 @@ def test_asdf_spectrumlist(tmpdir):
         create_spectrum1d(1, 5)
     ])
     SpectrumListType.assert_equal(spectra, roundtrip_object(spectra))
-
 
 
 @pytest.mark.filterwarnings("error::UserWarning")


### PR DESCRIPTION
asdf.tests.helpers will be deprecated:
https://github.com/asdf-format/asdf/pull/1440

The uses in specutils are limited to assert_roundtrip_tree

A similar roundtrip_object exists in asdf.testing.helpers which serializes then deserializes an object (without asserting equality). This commit replaces the uses of assert_roundtrip_tree with roundtrip_object and uses the equality comparison built into the custom asdf types implemented in this module to check for equality. These equality comparisons are the same checks that were used internally by assert_roundtrip_tree.