### PR TITLE
TST: Pin dask in oldest deps job because it is upgrading numpy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ deps =
     oldestdeps: asdf==2.10.*
     oldestdeps: ndcube==2.0.*
     oldestdeps: matplotlib==3.6.*
+    oldestdeps: dask==2023.2.0
 
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0


### PR DESCRIPTION
New dask release is upgrading numpy. It is being pulled in by a dependency.