### PR TITLE
add stdatamodels as a dependency and replace asdf.fits_embed uses with stdatamodels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 New Features
 ^^^^^^^^^^^^
 
+- Add ``stdatamodels`` as a dependency and use it to support ASDF-in-FITS
+  files like those produced by JWST. [#1029]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     asdf-astropy>=0.3
     asdf>=2.10,!=2.12.0
     ndcube>=2.0
+    stdatamodels>=1.2.0
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     asdf-astropy>=0.3
     asdf>=2.10,!=2.12.0
     ndcube>=2.0
-    stdatamodels>=1.2.0
+    stdatamodels>=1.1.0
 
 [options.extras_require]
 test =

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -10,8 +10,8 @@ from astropy.io import fits
 from astropy.nddata import StdDevUncertainty, VarianceUncertainty, InverseVariance
 from astropy.time import Time
 from astropy.wcs import WCS
-import asdf
 from gwcs.wcstools import grid_from_bounding_box
+import stdatamodels.asdf_in_fits
 
 from ...spectra import Spectrum1D, SpectrumList
 from ..registers import data_loader
@@ -437,7 +437,7 @@ def _jwst_s2d_loader(filename, **kwargs):
     slits = None
 
     # Get a list of GWCS objects from the slits
-    with asdf.open(filename) as af:
+    with stdatamodels.asdf_in_fits.open(filename) as af:
         # Slits can be listed under "slits", "products" or "exposures"
         if "products" in af.tree:
             slits = "products"
@@ -557,7 +557,7 @@ def _jwst_s3d_loader(filename, **kwargs):
     spectra = []
 
     # Get a list of GWCS objects from the slits
-    with asdf.open(filename) as af:
+    with stdatamodels.asdf_in_fits.open(filename) as af:
         wcslist = [af.tree["meta"]["wcs"]]
 
     with fits.open(filename, memmap=False) as hdulist:

--- a/specutils/io/default_loaders/tests/test_jwst_reader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_reader.py
@@ -1,4 +1,3 @@
-import warnings
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table
@@ -10,15 +9,7 @@ from astropy import coordinates as coord
 import gwcs.coordinate_frames as cf
 from gwcs.wcs import WCS
 import pytest
-
-from asdf.exceptions import AsdfDeprecationWarning
-with warnings.catch_warnings():
-    warnings.filterwarnings(
-        "ignore",
-        category=AsdfDeprecationWarning,
-        message=r"AsdfInFits has been deprecated.*",
-    )
-    from asdf import fits_embed
+import stdatamodels.fits_support
 
 from specutils import Spectrum1D, SpectrumList
 
@@ -415,9 +406,9 @@ def cube(tmpdir, tmp_asdf):
 
     # Mock the ASDF extension
     hdulist.append(fits.BinTableHDU(name='ASDF'))
-    ff = fits_embed.AsdfInFits(hdulist, tmp_asdf)
+    stdatamodels.fits_support.to_fits(tmp_asdf, None, hdulist=hdulist)
     tmpfile = str(tmpdir.join('jwst_embedded_asdf.fits'))
-    ff.write_to(tmpfile)
+    hdulist.writeto(tmpfile)
 
     return hdulist
 


### PR DESCRIPTION
fixes #1006 

[ASDF](https://github.com/asdf-format/asdf) is dropping support for `AsdfInFits` (see the above issue for more details). Support for this format has moved to [stdatamodels](https://github.com/spacetelescope/stdatamodels). specutils uses this format to open JWST files.

This PR adds stdatamodels as a dependency and replaces uses of `asdf.fits_embed` and `AsdfInFits` with stdatamodels.