### PR TITLE
Bugfix: shuffled arg order in _fit_lines

### DIFF
--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -354,7 +354,7 @@ def fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertainties
 
         fit_model = _fit_lines(spectrum, model_guess, fitter,
                                exclude_regions, weights, model_window,
-                               ignore_units, get_fit_info, **kwargs)
+                               get_fit_info, ignore_units, **kwargs)
         if model_guess.name is not None:
             fit_model.name = model_guess.name
 


### PR DESCRIPTION
If you compare the ordered arguments to the `_fit_lines` function:
https://github.com/astropy/specutils/blob/6eb7f96498072882c97763d4cd10e07cf81b6d33/specutils/fitting/fitmodels.py#L369-L371
to the ordered arguments given to its call in `fit_lines`:
https://github.com/astropy/specutils/blob/6eb7f96498072882c97763d4cd10e07cf81b6d33/specutils/fitting/fitmodels.py#L355-L357
You'll see the order of `ignore_units` and `get_fit_info` are swapped in the latter.

This PR puts them in the correct order.