### PR TITLE
Replace deprecated AsdfInFits

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ test =
     graphviz
     coverage
     spectral-cube
-    stdatamodels
+    stdatamodels>=1.1.0
 docs =
     sphinx-astropy
     matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,12 +33,14 @@ test =
     graphviz
     coverage
     spectral-cube
+    stdatamodels
 docs =
-    # TODO: Remove numpy pinning when astropy v5.2.1 is released.
-    numpy<1.24
     sphinx-astropy
     matplotlib
     graphviz
+    # TODO: Remove pinning when ndcube fixed
+    # See https://github.com/astropy/specutils/issues/1028
+    ndcube<2.1
 
 [options.package_data]
 specutils = data/*

--- a/specutils/tests/test_io.py
+++ b/specutils/tests/test_io.py
@@ -32,8 +32,8 @@ def test_generic_spectrum_from_table(recwarn):
     assert spectrum.spectral_axis.unit == table['wave'].unit
     assert spectrum.flux.unit == table['flux'].unit
     assert spectrum.spectral_axis.unit == table['wave'].unit
-    assert np.alltrue(spectrum.spectral_axis == table['wave'])
-    assert np.alltrue(spectrum.flux == table['flux'])
+    assert np.all(spectrum.spectral_axis == table['wave'])
+    assert np.all(spectrum.flux == table['flux'])
 
     # Add uncertainties and retest
     err = 0.01*flux
@@ -43,9 +43,9 @@ def test_generic_spectrum_from_table(recwarn):
     assert spectrum.flux.unit == table['flux'].unit
     assert spectrum.uncertainty.unit == table['err'].unit
     assert spectrum.spectral_axis.unit == table['wave'].unit
-    assert np.alltrue(spectrum.spectral_axis == table['wave'])
-    assert np.alltrue(spectrum.flux == table['flux'])
-    assert np.alltrue(spectrum.uncertainty.array == table['err'])
+    assert np.all(spectrum.spectral_axis == table['wave'])
+    assert np.all(spectrum.flux == table['flux'])
+    assert np.all(spectrum.uncertainty.array == table['err'])
 
     # Test for warning if standard deviation is zero or negative
     err[0] = 0.

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -105,9 +105,9 @@ def test_generic_ecsv_reader(tmpdir):
     assert spectrum.flux.unit == table['flux'].unit
     assert spectrum.uncertainty.unit == table['uncertainty'].unit
     assert spectrum.spectral_axis.unit == table['wave'].unit
-    assert np.alltrue(spectrum.spectral_axis == table['wave'])
-    assert np.alltrue(spectrum.flux == table['flux'])
-    assert np.alltrue(spectrum.uncertainty.array == table['uncertainty'])
+    assert np.all(spectrum.spectral_axis == table['wave'])
+    assert np.all(spectrum.flux == table['flux'])
+    assert np.all(spectrum.uncertainty.array == table['uncertainty'])
 
 
 @remote_access([{'id': '1481119', 'filename': 'COS_FUV.fits'},

--- a/tox.ini
+++ b/tox.ini
@@ -53,11 +53,6 @@ deps =
     devdeps: scipy>=0.0.dev0
     devdeps: git+https://github.com/spacetelescope/gwcs.git#egg=gwcs
 
-    # While nice to test in principle, we cannot enable this in CI
-    # because this will generate AsdfWarning and AstropyDeprecationWarning
-    # so this setting is not used.
-    external: jwst
-
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test


### PR DESCRIPTION
This pull request:

* fix #1006 (which adds `stdatamodels` to test dependencies)
* works around #1028 
* remove outdated numpy pin for docs
* remove unused and non-existent "jwst" deps flag
* replace deprecated `np.alltrue` in numpy 1.25

