### PR TITLE
DOC: Use astropy<5.3 for doctest in spectral_cube.rst and analysis.rst

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,9 @@ xfail_strict = true
 doctest_plus = enabled
 doctest_norecursedirs =
     */__init__.py
+doctest_subpackage_requires =
+    docs/analysis.rst = astropy<5.3
+    docs/spectral_cube.rst = astropy<5.3
 text_file_format = rst
 addopts = --color=yes --doctest-rst
 asdf_schema_root = specutils/io/asdf/schemas


### PR DESCRIPTION
Address doctest failures caused by https://github.com/astropy/astropy/pull/14439 .

Fix to RTD is not covered. I did that in https://github.com/astropy/specutils/pull/1032 .

[🐱](https://jira.stsci.edu/browse/JDAT-3166) (1 of 2) xref #1035 