### PR TITLE
Fix warnings in doc build due to ndcube 2.1.X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ docs/_build
 
 # Visual Studio Code project files
 .vscode
+.history
 
 # Packages/installer info
 *.egg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,8 @@ highlight_language = 'python3'
 # Include other packages to link against
 intersphinx_mapping['astropy'] = ('https://docs.astropy.org/en/latest/', None)
 intersphinx_mapping['gwcs'] = ('https://gwcs.readthedocs.io/en/latest/', None)
+intersphinx_mapping['reproject'] = ('https://reproject.readthedocs.io/en/stable/', None)
+intersphinx_mapping['mpl_animators'] = ('https://docs.sunpy.org/projects/mpl-animators/en/stable/', None)
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -15,28 +15,22 @@ py:obj SpectralQuantity
 py:obj SkyCoord
 
 # Super class for Spectrum1D for which we don't control the API links.
-py:class ndcube.ndcube.NDCube
-py:class ndcube.ndcube.NDCubeBase
-py:class ndcube.ndcube.NDCubeABC
-py:class ndcube.mixins.plotting.NDCubePlotMixin
 py:class ndcube.mixins.ndslicing.NDCubeSlicingMixin
-py:obj ndcube.NDCube
-py:obj NDCube
-py:obj NDCube.plotter
+py:class ndcube.ndcube.NDCube
+py:class ndcube.ndcube.NDCubeABC
+py:class ndcube.ndcube.NDCubeBase
+py:meth ndcube.NDCube.axis_world_coords
+py:meth ndcube.NDCube.crop
+py:meth ndcube.NDCube.rebin
 py:obj MatplotlibPlotter
-py:obj ExtraCoords
-py:obj GlobalCoords
-py:obj ndcube.NDCube.world_axis_physical_types
-py:obj specutils.Spectrum1D.crop
-py:obj pixel_edges
-py:obj pixel_values
-py:obj ndcube.NDCube.wcs.world_axis_physical_types
+py:obj ndcube.NDCube
+py:obj ndcube.NDCube.crop
+py:obj ndcube.ndcube.NDCubeABC
+py:obj ndcube.ndcube.NDCubeBase
+py:obj ndcube.NDCube.plotter
+py:obj ndcube.NDCubeABC
 py:obj ndcube.NDCubeSequence
-py:obj sunpy.visualization.animator.ArrayAnimatorWCS
-py:obj ndcube.mixins.plotting.NDCubePlotMixin.plot
-py:obj astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_array_index_values
-py:obj matplotllib.pyplot.imshow
-py:obj matplotllib.pyplot.plot
+py:obj ndcube.utils.cube.propagate_rebin_uncertainties
 
 # SpectralAxis inherits methods which have warnings we can't fix here.
 # FIXME: https://github.com/astropy/sphinx-automodapi/issues/101

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,6 @@ docs =
     sphinx-astropy
     matplotlib
     graphviz
-    # TODO: Remove pinning when ndcube fixed
-    # See https://github.com/astropy/specutils/issues/1028
-    ndcube<2.1
 
 [options.package_data]
 specutils.io.asdf = schemas/*.yaml,manifests/*.yaml


### PR DESCRIPTION
With ndcube 2.1.2, we have activated nitpicky and fixed the build upstream.
With this PR, I update the docs config and ignore file to make RTD pass.

### EDIT

* https://github.com/sunpy/ndcube/issues/604
* fix #1028 