### PR TITLE
Fix SNR computations with masks + regions

### DIFF
--- a/specutils/analysis/uncertainty.py
+++ b/specutils/analysis/uncertainty.py
@@ -86,13 +86,12 @@ def _snr_single_region(spectrum, region=None):
     else:
         calc_spectrum = spectrum
 
-    if hasattr(spectrum, 'mask') and spectrum.mask is not None:
-        flux = calc_spectrum.flux[~spectrum.mask]
-        uncertainty = calc_spectrum.uncertainty.represent_as(StdDevUncertainty).quantity
-        uncertainty = uncertainty[~spectrum.mask]
-    else:
-        flux = calc_spectrum.flux
-        uncertainty = calc_spectrum.uncertainty.represent_as(StdDevUncertainty).quantity
+    flux = calc_spectrum.flux
+    uncertainty = calc_spectrum.uncertainty.represent_as(StdDevUncertainty).quantity
+
+    if hasattr(calc_spectrum, 'mask') and calc_spectrum.mask is not None:
+        flux = flux[~calc_spectrum.mask]
+        uncertainty = uncertainty[~calc_spectrum.mask]
 
     # the axis=-1 will enable this to run on single-dispersion, single-flux
     # and single-dispersion, multiple-flux

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -406,6 +406,32 @@ def test_snr_two_regions(simulated_spectra):
     assert np.allclose(spec_snr, spec_snr_expected)
 
 
+def test_snr_masked_with_region(simulated_spectra):
+    """
+    Test the simple version of the spectral SNR over a region of the masked spectrum.
+    """
+
+    np.random.seed(42)
+
+    spectrum = simulated_spectra.s1_um_mJy_e1_masked
+    uncertainty = StdDevUncertainty(0.1 * np.random.random(len(spectrum.flux)) * u.mJy)
+    spectrum.uncertainty = uncertainty
+
+    wavelengths = spectrum.spectral_axis[~spectrum.mask]
+    flux = spectrum.flux[~spectrum.mask]
+    uncertainty_array = uncertainty.array[~spectrum.mask]
+
+    region = SpectralRegion(0.52 * u.um, 0.59 * u.um)
+    l = np.nonzero(wavelengths >= region.lower)[0][0]
+    r = np.nonzero(wavelengths <= region.upper)[0][-1] + 1
+
+    spec_snr_expected = np.mean(flux[l:r] / (uncertainty_array[l:r] * uncertainty.unit))
+
+    spec_snr = snr(spectrum, region)
+
+    assert np.allclose(spec_snr.value, spec_snr_expected.value)
+
+
 def test_snr_derived():
     np.random.seed(42)
 


### PR DESCRIPTION
Calculating a S/N over a region of a **masked** spectrum throws an error:

`IndexError: boolean index did not match indexed array along dimension 0; dimension is 2601 but corresponding boolean dimension is 6800`

This pull request fixes this bug by replacing `spectrum.mask` with `calc_spectrum.mask` in the S/N helper function.