### PR TITLE
Accelerate region extraction with `np.searchsorted()`

### DIFF
--- a/specutils/manipulation/extract_spectral_region.py
+++ b/specutils/manipulation/extract_spectral_region.py
@@ -12,34 +12,20 @@ __all__ = ['extract_region', 'extract_bounding_spectral_region', 'spectral_slab'
 
 def _edge_value_to_pixel(edge_value, spectrum, order, side):
     spectral_axis = spectrum.spectral_axis
-    if order == "ascending":
-        if edge_value > spectral_axis[-1]:
-            return len(spectral_axis)
-        if edge_value < spectral_axis[0]:
-            return 0
 
-    elif order == "descending":
-        if edge_value < spectral_axis[-1]:
-            return len(spectral_axis)
-        if edge_value > spectral_axis[0]:
-            return 0
-
-    try:
-        if hasattr(spectrum.wcs, "spectral"):
-            index = spectrum.wcs.spectral.world_to_pixel(edge_value)
-        else:
-            index = spectrum.wcs.world_to_pixel(edge_value)
-
-        if side == "left":
-            index = int(np.ceil(index))
-        elif side == "right":
-            index = int(np.floor(index)) + 1
-
+    if order == 'ascending':
+        index = np.searchsorted(spectral_axis, edge_value, side=side)
         return index
 
-    except Exception as e:
-        raise ValueError(f"Bound {edge_value}, could not be converted to pixel index"
-                         f" using spectrum's WCS. Exception: {e}")
+    elif order == 'descending':
+
+        if side == 'left':
+            opposite_side = 'right'
+        else:
+            opposite_side = 'left'
+
+        index = len(spectral_axis) - np.searchsorted(spectral_axis[::-1], edge_value, side=opposite_side)
+        return index
 
 
 def _subregion_to_edge_pixels(subregion, spectrum):


### PR DESCRIPTION
Current implementation of `extract_region()` relies on the `world_to_pixel()` method of the WCS. This method is quite slow when it comes to a relatively simple task of finding an index (pixel) where value should be inserted to maintain array (spectral axis) order. This pull request solves this issue by replacing `world_to_pixel()` with `np.searchsorted()`.

Reproducible example to demonstrate the performance improvement:

```
import astropy.units as u
import numpy as np
from specutils import Spectrum1D, SpectralRegion
from specutils.manipulation import extract_region

import timeit

flux = np.random.randn(500) * u.Jy
wavelength = np.arange(5000, 5500) * u.AA
spec1d = Spectrum1D(spectral_axis=wavelength, flux=flux)

reg = SpectralRegion(5100 * u.AA, 5200 * u.AA)


def extract():
    extract_region(spec1d, reg)


print(timeit.timeit("extract()", globals=locals(), number=100))
```

Using `astropy.wcs.WCS.world_to_pixel()`: 8.453231014998892s
Using `np.searchsorted()`: 0.11922155800129985s