### PR TITLE
Fix bad unit string in some JWST headers to avoid a UnitWarning on read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Other Changes and Additions
   As a result, minversion of ``asdf`` has been bumped to 2.14.
   Redundant ASDF schema for ``SpectralCoord`` is removed. [#1042]
 
+- JWST X1D reader will no longer raise a ``UnitWarning`` for surface brightness
+  error. [#1050]
+
 1.9.1 (2022-11-22)
 ------------------
 


### PR DESCRIPTION
Currently, using `Spectrum1D.read()` on some JWST X1D files results in the following warning:

```
WARNING: UnitsWarning: '(MJy/sr)^2' did not parse as fits unit: Syntax error parsing unit '(MJy/sr)^2' If this is meant to be a custom unit, define it with 'u.def_unit'. To have it recognized inside a file reader or other code, enable it with 'u.add_enabled_units'. For details, see https://docs.astropy.org/en/latest/units/combining_and_defining.html [astropy.units.core]
```

It would be nice if the JWST pipeline used valid strings for all the units, but for now we can work around this by replacing the offending units in the HDU columns. This is the only bad unit I know of at the moment but I coded the replacement as a dictionary so we can add more later if needed. 