### PR TITLE
Fix centroid and gaussian width analysis functions, add distribution-based implementation

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -132,7 +132,13 @@ estimate the center of a spectral feature:
 
 While this example is "pre-subtracted", this function only performs well if the
 contiuum has already been subtracted, as for the other functions above and
-below.
+below. If the input spectrum has an ``uncertainty``, the result returned by
+`~specutils.analysis.centroid` will also have attached ``uncertainty`` and
+``uncertainty_type`` attributes. By default, the centroid and uncertainty results
+given are the analytical solution, but specifying ``analytic=False`` in the input
+to the function will instead return the mean and standard deviation of an
+`~astropy.uncertainty` Monte Carlo distribution generated using the ``uncertainty``
+values of the input spectrum's flux.
 
 
 Moment
@@ -163,7 +169,10 @@ computing a second-moment-based approximation of the standard deviation.
 The `~gaussian_fwhm` function estimates the width of the spectrum at half max,
 again by computing an approximation of the standard deviation.
 
-Both of these functions assume that the spectrum is approximately gaussian.
+Both of these functions assume that the spectrum is approximately gaussian, and
+also have an ``analytic`` input argument that can be set to ``False`` to use
+an `~astropy.uncertainty` Monte Carlo distribution in the same was as
+`specutils.analysis.centroid`.
 
 The function `~fwhm` provides an estimate of the full width of the spectrum at
 half max that does not assume the spectrum is gaussian. It locates the maximum,

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -98,6 +98,10 @@ def _centroid_single_region(spectrum, region=None, analytic=False):
     This is a helper function for the above `centroid()` method.
 
     """
+    if not analytic and spectrum.uncertainty is None:
+        raise ValueError("Distribution-based calculation can only be used if"
+                         " spectrum.uncertainty is not None")
+
     if region is not None:
         calc_spectrum = extract_region(spectrum, region)
     else:

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -107,9 +107,9 @@ def _centroid_single_region(spectrum, region=None, analytic=False):
         flux_uncert = calc_spectrum.uncertainty.represent_as(StdDevUncertainty).quantity
     else:
         # dummy value for uncertainties to avoid extra if-statements when applying mask
-        flux_uncert = np.zeros_like(spectrum.flux)
+        flux_uncert = np.zeros_like(calc_spectrum.flux)
 
-    if hasattr(spectrum, 'mask') and spectrum.mask is not None:
+    if hasattr(calc_spectrum, 'mask') and calc_spectrum.mask is not None:
         flux = calc_spectrum.flux[~calc_spectrum.mask]
         dispersion = calc_spectrum.spectral_axis[~calc_spectrum.mask].quantity
         flux_uncert = flux_uncert[~calc_spectrum.mask]

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -16,7 +16,7 @@ from ..manipulation import extract_region
 __all__ = ['centroid']
 
 
-def centroid(spectrum, regions=None, region=None, analytic=False):
+def centroid(spectrum, regions=None, region=None, analytic=True):
     """
     Calculate the centroid of a region, or regions, of the spectrum.
 
@@ -70,7 +70,7 @@ def centroid(spectrum, regions=None, region=None, analytic=False):
                 for reg in regions]
 
 
-def _centroid_single_region(spectrum, region=None, analytic=False):
+def _centroid_single_region(spectrum, region=None, analytic=True):
     """
     Calculate the centroid of the spectrum based on the flux in the spectrum.
     The returned quantity object will have a ``.uncertainty`` attribute which

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -28,12 +28,12 @@ def centroid(spectrum, regions=None, region=None, analytic=True):
         the propagated uncertainty (as Standard Deviation-style uncertainties).  This uncertainty
         assumes the input uncertainties are uncorrelated.
 
-    regions : `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    regions : `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
         Region within the spectrum to calculate the centroid.
 
     analytic : bool, optional
-        Set this flag to ``True`` to use the analytic derivation for the centroid and its
-        uncertainty instead of the default `~astropy.uncertainty` distribution-based method.
+        Set this flag to ``False`` to use the `~astropy.uncertainty` distribution-based
+        calculation for the centroid and its uncertainty instead of the default analytic solution.
 
     Returns
     -------
@@ -81,12 +81,12 @@ def _centroid_single_region(spectrum, region=None, analytic=True):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object overwhich the centroid will be calculated.
 
-    region : `~specutils.utils.SpectralRegion`
+    region : `~specutils.SpectralRegion`
         Region within the spectrum to calculate the centroid.
 
     analytic : bool, optional
-        Set this flag to ``True`` to use the analytic derivation for the centroid and its
-        uncertainty instead of the default `~astropy.uncertainty` distribution-based method.
+        Set this flag to ``False`` to use the `~astropy.uncertainty` distribution-based
+        calculation for the centroid and its uncertainty instead of the default analytic solution.
 
     Returns
     -------

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -16,7 +16,7 @@ from ..manipulation import extract_region
 __all__ = ['centroid']
 
 
-def centroid(spectrum, regions=None, region=None, analytic_uncertainty=False):
+def centroid(spectrum, regions=None, region=None, analytic=False):
     """
     Calculate the centroid of a region, or regions, of the spectrum.
 
@@ -28,12 +28,12 @@ def centroid(spectrum, regions=None, region=None, analytic_uncertainty=False):
         the propagated uncertainty (as Standard Deviation-style uncertainties).  This uncertainty
         assumes the input uncertainties are uncorrelated.
 
-    regions: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    regions : `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the centroid.
 
-    analytic_uncertainty: bool, optional
-        Set this flag to ``True`` to use the analytic derivation for the centroid's uncertainty
-        instead of the default `~astropy.uncertainty` distribution-based uncertainty.
+    analytic : bool, optional
+        Set this flag to ``True`` to use the analytic derivation for the centroid and its
+        uncertainty instead of the default `~astropy.uncertainty` distribution-based method.
 
     Returns
     -------
@@ -56,21 +56,21 @@ def centroid(spectrum, regions=None, region=None, analytic_uncertainty=False):
 
     # No region, therefore whole spectrum.
     if regions is None:
-        return _centroid_single_region(spectrum, analytic_uncertainty=analytic_uncertainty)
+        return _centroid_single_region(spectrum, analytic=analytic)
 
     # Single region
     elif isinstance(regions, SpectralRegion):
         return _centroid_single_region(spectrum, region=regions,
-                                       analytic_uncertainty=analytic_uncertainty)
+                                       analytic=analytic)
 
     # List of regions
     elif isinstance(regions, list):
         return [_centroid_single_region(spectrum, region=reg,
-                                        analytic_uncertainty=analytic_uncertainty)
+                                        analytic=analytic)
                 for reg in regions]
 
 
-def _centroid_single_region(spectrum, region=None, analytic_uncertainty=False):
+def _centroid_single_region(spectrum, region=None, analytic=False):
     """
     Calculate the centroid of the spectrum based on the flux in the spectrum.
     The returned quantity object will have a ``.uncertainty`` attribute which
@@ -81,8 +81,12 @@ def _centroid_single_region(spectrum, region=None, analytic_uncertainty=False):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object overwhich the centroid will be calculated.
 
-    region: `~specutils.utils.SpectralRegion`
+    region : `~specutils.utils.SpectralRegion`
         Region within the spectrum to calculate the centroid.
+
+    analytic : bool, optional
+        Set this flag to ``True`` to use the analytic derivation for the centroid and its
+        uncertainty instead of the default `~astropy.uncertainty` distribution-based method.
 
     Returns
     -------
@@ -113,7 +117,7 @@ def _centroid_single_region(spectrum, region=None, analytic_uncertainty=False):
         flux = calc_spectrum.flux
         dispersion = calc_spectrum.spectral_axis.quantity
 
-    if analytic_uncertainty:
+    if analytic:
         centroid = np.sum(flux*dispersion, axis=-1) / np.sum(flux, axis=-1)
         if spectrum.uncertainty is None:
             centroid.uncertainty = None

--- a/specutils/analysis/location.py
+++ b/specutils/analysis/location.py
@@ -94,7 +94,6 @@ def _centroid_single_region(spectrum, region=None, analytic_uncertainty=False):
     This is a helper function for the above `centroid()` method.
 
     """
-    print(analytic_uncertainty)
     if region is not None:
         calc_spectrum = extract_region(spectrum, region)
     else:
@@ -115,7 +114,6 @@ def _centroid_single_region(spectrum, region=None, analytic_uncertainty=False):
         dispersion = calc_spectrum.spectral_axis.quantity
 
     if analytic_uncertainty:
-        print("Analytic")
         centroid = np.sum(flux*dispersion, axis=-1) / np.sum(flux, axis=-1)
         if spectrum.uncertainty is None:
             centroid.uncertainty = None
@@ -127,7 +125,6 @@ def _centroid_single_region(spectrum, region=None, analytic_uncertainty=False):
             centroid.uncertainty = np.sqrt(s2)
             centroid.uncertainty_type = 'stddev'
     else:
-        print("Distribution")
         # Convert flux to an astropy.uncertainties normal distribution
         flux = unc.normal(flux, std=flux_uncert, n_samples=1000)
 

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -14,7 +14,6 @@ from . import centroid
 from .utils import computation_wrapper
 
 
-
 __all__ = ['gaussian_sigma_width', 'gaussian_fwhm', 'fwhm', 'fwzi']
 
 
@@ -235,7 +234,7 @@ def _compute_gaussian_sigma_width(spectrum, regions=None, analytic=False):
         spectral_axis = np.broadcast_to(spectral_axis, flux.shape, subok=True)
         centroid_result = centroid_result[:, np.newaxis]
         centroid_result.uncertainty = centroid_result_uncert[:, np.newaxis] if centroid_result_uncert is not None else None  # noqa
-    
+
     if not analytic:
         centroid_result = unc.normal(centroid_result, std=centroid_result.uncertainty,
                                      n_samples=1000)

--- a/specutils/analysis/width.py
+++ b/specutils/analysis/width.py
@@ -30,9 +30,13 @@ def gaussian_sigma_width(spectrum, regions=None, analytic=True):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object over which the width will be calculated.
 
-    regions: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    regions: `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
         Region within the spectrum to calculate the gaussian sigma width. If
         regions is `None`, computation is performed over entire spectrum.
+
+    analytic : bool, optional
+        Set this flag to ``False`` to use the `~astropy.uncertainty` distribution-based
+        calculation for the width and its uncertainty instead of the default analytic solution.
 
     Returns
     -------
@@ -61,9 +65,13 @@ def gaussian_fwhm(spectrum, regions=None, analytic=True):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object overwhich the width will be calculated.
 
-    regions : `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    regions : `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
         Region within the spectrum to calculate the FWHM value. If regions is
         `None`, computation is performed over entire spectrum.
+
+    analytic : bool, optional
+        Set this flag to ``False`` to use the `~astropy.uncertainty` distribution-based
+        calculation for the fwhm and its uncertainty instead of the default analytic solution.
 
     Returns
     -------
@@ -94,7 +102,7 @@ def fwhm(spectrum, regions=None):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object over which the width will be calculated.
 
-    regions: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    regions: `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
         Region within the spectrum to calculate the FWHM value. If regions is
         `None`, computation is performed over entire spectrum.
 
@@ -125,7 +133,7 @@ def fwzi(spectrum, regions=None):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object over which the width will be calculated.
 
-    regions: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    regions: `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
         Region within the spectrum to calculate the FWZI value. If regions is
         `None`, computation is performed over entire spectrum.
 

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -651,6 +651,7 @@ def test_gaussian_sigma_width_masked(analytic):
     else:
         assert quantity_allclose(result.uncertainty, 0.05004314*u.GHz, rtol=5e-5)
 
+
 def test_gaussian_sigma_width_regions():
 
     np.random.seed(42)
@@ -737,6 +738,7 @@ def test_gaussian_fwhm(analytic):
     else:
         assert quantity_allclose(result.uncertainty, 8.45467409e-05*u.GHz, rtol=5e-5)
 
+
 @pytest.mark.parametrize("analytic", [True, False])
 def test_gaussian_fwhm_masked(analytic):
 
@@ -763,6 +765,7 @@ def test_gaussian_fwhm_masked(analytic):
         assert quantity_allclose(result.uncertainty, 0.16079604*u.GHz, rtol=5e-5)
     else:
         assert quantity_allclose(result.uncertainty, 0.12264682*u.GHz, rtol=5e-5)
+
 
 @pytest.mark.parametrize('mean', range(3, 8))
 def test_gaussian_fwhm_uncentered(mean):

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -600,7 +600,8 @@ def test_centroid_multiple_flux(simulated_spectra, analytic):
         assert np.allclose(centroid_spec.uncertainty.value, np.array([1.11040262e-04, 1.49617388e-04, 1.02730951e-04, 1.21124734e-04, 9.62905679e-05]))
 
 
-def test_gaussian_sigma_width():
+@pytest.mark.parametrize("analytic", [True, False])
+def test_gaussian_sigma_width(analytic):
 
     np.random.seed(42)
 
@@ -613,15 +614,19 @@ def test_gaussian_sigma_width():
     uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
     spectrum.uncertainty = uncertainty
 
-    result = gaussian_sigma_width(spectrum)
+    result = gaussian_sigma_width(spectrum, analytic=analytic)
 
     assert quantity_allclose(result, g1.stddev, atol=0.01*u.GHz)
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
-    assert quantity_allclose(result.uncertainty, 4.79660696e-05*u.GHz, rtol=5e-5)
+    if analytic:
+        assert quantity_allclose(result.uncertainty, 4.79660696e-05*u.GHz, rtol=5e-5)
+    else:
+        assert quantity_allclose(result.uncertainty, 3.59036951e-05*u.GHz, rtol=5e-5)
 
 
-def test_gaussian_sigma_width_masked():
+@pytest.mark.parametrize("analytic", [True, False])
+def test_gaussian_sigma_width_masked(analytic):
 
     np.random.seed(42)
 
@@ -636,13 +641,15 @@ def test_gaussian_sigma_width_masked():
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies),
                           uncertainty=uncertainty, mask=mask)
 
-    result = gaussian_sigma_width(spectrum)
+    result = gaussian_sigma_width(spectrum, analytic=analytic)
 
     assert quantity_allclose(result, g1.stddev, atol=0.01*u.GHz)
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
-    assert quantity_allclose(result.uncertainty, 0.06576328*u.GHz, rtol=5e-5)
-
+    if analytic:
+        assert quantity_allclose(result.uncertainty, 0.06578261*u.GHz, rtol=5e-5)
+    else:
+        assert quantity_allclose(result.uncertainty, 0.05004314*u.GHz, rtol=5e-5)
 
 def test_gaussian_sigma_width_regions():
 
@@ -705,7 +712,8 @@ def test_gaussian_sigma_width_multi_spectrum():
         assert quantity_allclose(result, exp, atol=0.25*exp)
 
 
-def test_gaussian_fwhm():
+@pytest.mark.parametrize("analytic", [True, False])
+def test_gaussian_fwhm(analytic):
 
     np.random.seed(42)
 
@@ -718,16 +726,19 @@ def test_gaussian_fwhm():
     uncertainty = StdDevUncertainty(0.1*np.random.random(len(spectrum.flux))*u.mJy)
     spectrum.uncertainty = uncertainty
 
-    result = gaussian_fwhm(spectrum)
+    result = gaussian_fwhm(spectrum, analytic=analytic)
 
     expected = g1.stddev * gaussian_sigma_to_fwhm
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
-    assert quantity_allclose(result.uncertainty, 0.00011295*u.GHz, rtol=5e-5)
+    if analytic:
+        assert quantity_allclose(result.uncertainty, 0.00011295*u.GHz, rtol=5e-5)
+    else:
+        assert quantity_allclose(result.uncertainty, 8.45467409e-05*u.GHz, rtol=5e-5)
 
-
-def test_gaussian_fwhm_masked():
+@pytest.mark.parametrize("analytic", [True, False])
+def test_gaussian_fwhm_masked(analytic):
 
     np.random.seed(42)
 
@@ -742,14 +753,16 @@ def test_gaussian_fwhm_masked():
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=g1(frequencies),
                           uncertainty=uncertainty, mask=mask)
 
-    result = gaussian_fwhm(spectrum)
+    result = gaussian_fwhm(spectrum, analytic=analytic)
 
     expected = g1.stddev * gaussian_sigma_to_fwhm
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
-    assert quantity_allclose(result.uncertainty, 0.16074777*u.GHz, rtol=5e-5)
-
+    if analytic:
+        assert quantity_allclose(result.uncertainty, 0.16079604*u.GHz, rtol=5e-5)
+    else:
+        assert quantity_allclose(result.uncertainty, 0.12264682*u.GHz, rtol=5e-5)
 
 @pytest.mark.parametrize('mean', range(3, 8))
 def test_gaussian_fwhm_uncentered(mean):

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -629,7 +629,7 @@ def test_gaussian_sigma_width(analytic):
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
     if analytic:
-        assert quantity_allclose(result.uncertainty, 4.79660696e-05*u.GHz, rtol=5e-5)
+        assert quantity_allclose(result.uncertainty, 3.83737901e-05*u.GHz, rtol=5e-5)
     else:
         assert quantity_allclose(result.uncertainty, 3.59036951e-05*u.GHz, rtol=5e-5)
 
@@ -656,9 +656,9 @@ def test_gaussian_sigma_width_masked(analytic):
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
     if analytic:
-        assert quantity_allclose(result.uncertainty, 0.06578261*u.GHz, rtol=5e-5)
+        assert quantity_allclose(result.uncertainty, 0.05245744*u.GHz, rtol=5e-5)
     else:
-        assert quantity_allclose(result.uncertainty, 0.05004314*u.GHz, rtol=5e-5)
+        assert quantity_allclose(result.uncertainty, 0.04954785*u.GHz, rtol=5e-5)
 
 
 @pytest.mark.parametrize("analytic", [True, False])
@@ -718,7 +718,14 @@ def test_gaussian_sigma_width_multi_spectrum(analytic):
     flux[1] = g2(frequencies)
     flux[2] = g3(frequencies)
 
-    spectra = Spectrum1D(spectral_axis=frequencies, flux=flux)
+    # Add some noise so we don't have flux exactly = 0
+    flux += 0.001*np.random.random(flux.shape)*u.Jy - 0.0005*u.Jy
+
+    if analytic:
+        spectra = Spectrum1D(spectral_axis=frequencies, flux=flux)
+    else:
+        uncertainty = StdDevUncertainty(0.1*np.random.random(flux.shape)*u.Jy)
+        spectra = Spectrum1D(spectral_axis=frequencies, flux=flux, uncertainty=uncertainty)
 
     results = gaussian_sigma_width(spectra, analytic=analytic)
 
@@ -748,7 +755,7 @@ def test_gaussian_fwhm(analytic):
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
     if analytic:
-        assert quantity_allclose(result.uncertainty, 0.00011295*u.GHz, rtol=5e-5)
+        assert quantity_allclose(result.uncertainty, 9.03633701e-05*u.GHz, rtol=5e-5)
     else:
         assert quantity_allclose(result.uncertainty, 8.45467409e-05*u.GHz, rtol=5e-5)
 
@@ -776,9 +783,9 @@ def test_gaussian_fwhm_masked(analytic):
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
     if analytic:
-        assert quantity_allclose(result.uncertainty, 0.16079604*u.GHz, rtol=5e-5)
+        assert quantity_allclose(result.uncertainty, 0.12811291*u.GHz, rtol=5e-5)
     else:
-        assert quantity_allclose(result.uncertainty, 0.12264682*u.GHz, rtol=5e-5)
+        assert quantity_allclose(result.uncertainty, 0.12131201*u.GHz, rtol=5e-5)
 
 
 @pytest.mark.parametrize('mean', range(3, 8))

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -466,7 +466,8 @@ def test_snr_derived_masked():
     assert np.allclose(snr_derived(spectrum, [sr, sr2]), [4.01610033, 1.94906157])
 
 
-def test_centroid(simulated_spectra):
+@pytest.mark.parametrize("analytic", [True, False])
+def test_centroid(simulated_spectra, analytic):
     """
     Test the simple version of the spectral centroid.
     """
@@ -490,16 +491,19 @@ def test_centroid(simulated_spectra):
     # SNR of the whole spectrum
     #
 
-    spec_centroid = centroid(spectrum, None)
+    spec_centroid = centroid(spectrum, analytic=analytic)
 
     assert isinstance(spec_centroid, u.Quantity)
     assert np.allclose(spec_centroid.value, spec_centroid_expected.value)
     assert hasattr(spec_centroid, 'uncertainty')
     # NOTE: value has not been scientifically validated
-    assert quantity_allclose(spec_centroid.uncertainty, 3.91834165e-06*u.um, rtol=5e-5)
+    if analytic:
+        assert quantity_allclose(spec_centroid.uncertainty, 7.032035e-07*u.um, rtol=5e-5)
+    else:
+        assert quantity_allclose(spec_centroid.uncertainty, 6.916e-07*u.um, rtol=5e-3)
 
-
-def test_centroid_masked(simulated_spectra):
+@pytest.mark.parametrize("analytic", [True, False])
+def test_centroid_masked(simulated_spectra, analytic):
     """
     Test centroid with masked spectrum.
     """
@@ -519,14 +523,16 @@ def test_centroid_masked(simulated_spectra):
 
     spec_centroid_expected = np.sum(flux * wavelengths) / np.sum(flux)
 
-    spec_centroid = centroid(spectrum, None)
+    spec_centroid = centroid(spectrum, analytic=analytic)
 
     assert isinstance(spec_centroid, u.Quantity)
     assert np.allclose(spec_centroid.value, spec_centroid_expected.value)
     assert hasattr(spec_centroid, 'uncertainty')
     # NOTE: value has not been scientifically validated
-    assert quantity_allclose(spec_centroid.uncertainty, 1.1052437538307923e-05*u.um, rtol=5e-5)
-
+    if analytic:
+        assert quantity_allclose(spec_centroid.uncertainty, 1.87678219e-06*u.um, rtol=5e-5)
+    else:
+        assert quantity_allclose(spec_centroid.uncertainty, 1.92374917e-06*u.um, rtol=5e-5)
 
 def test_inverted_centroid(simulated_spectra):
     """
@@ -577,7 +583,8 @@ def test_centroid_multiple_flux(simulated_spectra):
     uncertainty = StdDevUncertainty(0.1*np.random.random(spec.flux.shape)*u.mJy)
     spec.uncertainty = uncertainty
 
-    centroid_spec = centroid(spec, None)
+    centroid_spec = centroid(spec, analytic=True)
+    print(centroid_spec.value)
 
     assert np.allclose(centroid_spec.value, np.array([5.46190995, 5.17223565, 5.37778249, 5.51595259, 5.7429066]))
     assert centroid_spec.unit == u.um
@@ -711,7 +718,7 @@ def test_gaussian_fwhm():
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
-    assert quantity_allclose(result.uncertainty, 0.00011348006579851353*u.GHz, rtol=5e-5)
+    assert quantity_allclose(result.uncertainty, 0.00011295*u.GHz, rtol=5e-5)
 
 
 def test_gaussian_fwhm_masked():
@@ -735,7 +742,7 @@ def test_gaussian_fwhm_masked():
     assert quantity_allclose(result, expected, atol=0.01*u.GHz)
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
-    assert quantity_allclose(result.uncertainty, 0.16688079501948674*u.GHz, rtol=5e-5)
+    assert quantity_allclose(result.uncertainty, 0.16074777*u.GHz, rtol=5e-5)
 
 
 @pytest.mark.parametrize('mean', range(3, 8))

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -569,7 +569,8 @@ def test_inverted_centroid_masked(simulated_spectra):
     assert np.allclose(spec_centroid_inverted.value, spec_centroid_expected.value)
 
 
-def test_centroid_multiple_flux(simulated_spectra):
+@pytest.mark.parametrize("analytic", [True, False])
+def test_centroid_multiple_flux(simulated_spectra, analytic):
     """
     Test the simple version of the spectral SNR, with multiple flux per single dispersion.
     """
@@ -585,7 +586,7 @@ def test_centroid_multiple_flux(simulated_spectra):
     uncertainty = StdDevUncertainty(0.1*np.random.random(spec.flux.shape)*u.mJy)
     spec.uncertainty = uncertainty
 
-    centroid_spec = centroid(spec, analytic=True)
+    centroid_spec = centroid(spec, analytic=analytic)
     print(centroid_spec.value)
 
     assert np.allclose(centroid_spec.value, np.array([5.46190995, 5.17223565, 5.37778249, 5.51595259, 5.7429066]))
@@ -593,7 +594,10 @@ def test_centroid_multiple_flux(simulated_spectra):
     assert hasattr(centroid_spec, 'uncertainty')
     assert len(centroid_spec.uncertainty) == 5
     # NOTE: value has not been scientifically validated
-    assert np.allclose(centroid_spec.uncertainty.value, np.array([1.14987628e-04, 1.49638658e-04, 1.02963584e-04, 1.21785134e-04, 9.47238087e-05]))
+    if analytic:
+        assert np.allclose(centroid_spec.uncertainty.value, np.array([1.14987628e-04, 1.49638658e-04, 1.02963584e-04, 1.21785134e-04, 9.47238087e-05]))
+    else:
+        assert np.allclose(centroid_spec.uncertainty.value, np.array([1.11040262e-04, 1.49617388e-04, 1.02730951e-04, 1.21124734e-04, 9.62905679e-05]))
 
 
 def test_gaussian_sigma_width():

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -652,7 +652,8 @@ def test_gaussian_sigma_width_masked(analytic):
         assert quantity_allclose(result.uncertainty, 0.05004314*u.GHz, rtol=5e-5)
 
 
-def test_gaussian_sigma_width_regions():
+@pytest.mark.parametrize("analytic", [True, False])
+def test_gaussian_sigma_width_regions(analytic):
 
     np.random.seed(42)
 
@@ -665,25 +666,26 @@ def test_gaussian_sigma_width_regions():
     spectrum = Spectrum1D(spectral_axis=frequencies, flux=compound(frequencies))
 
     region1 = SpectralRegion(15*u.GHz, 5*u.GHz)
-    result1 = gaussian_sigma_width(spectrum, regions=region1)
+    result1 = gaussian_sigma_width(spectrum, regions=region1, analytic=analytic)
 
     exp1 = g1.stddev
     assert quantity_allclose(result1, exp1, atol=0.25*exp1)
 
     region2 = SpectralRegion(3*u.GHz, 1*u.GHz)
-    result2 = gaussian_sigma_width(spectrum, regions=region2)
+    result2 = gaussian_sigma_width(spectrum, regions=region2, analytic=analytic)
 
     exp2 = g2.stddev
     assert quantity_allclose(result2, exp2, atol=0.25*exp2)
 
     region3 = SpectralRegion(100*u.GHz, 40*u.GHz)
-    result3 = gaussian_sigma_width(spectrum, regions=region3)
+    result3 = gaussian_sigma_width(spectrum, regions=region3, analytic=analytic)
 
     exp3 = g3.stddev
     assert quantity_allclose(result3, exp3, atol=0.25*exp3)
 
     # Test using a list of regions
-    result_list = gaussian_sigma_width(spectrum, regions=[region1, region2, region3])
+    result_list = gaussian_sigma_width(spectrum, regions=[region1, region2, region3],
+                                       analytic=analytic)
     for model, result in zip((g1, g2, g3), result_list):
         exp = model.stddev
         assert quantity_allclose(result, exp, atol=0.25*exp)

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -502,6 +502,7 @@ def test_centroid(simulated_spectra, analytic):
     else:
         assert quantity_allclose(spec_centroid.uncertainty, 6.916e-07*u.um, rtol=5e-3)
 
+
 @pytest.mark.parametrize("analytic", [True, False])
 def test_centroid_masked(simulated_spectra, analytic):
     """
@@ -533,6 +534,7 @@ def test_centroid_masked(simulated_spectra, analytic):
         assert quantity_allclose(spec_centroid.uncertainty, 1.87678219e-06*u.um, rtol=5e-5)
     else:
         assert quantity_allclose(spec_centroid.uncertainty, 1.92374917e-06*u.um, rtol=5e-5)
+
 
 def test_inverted_centroid(simulated_spectra):
     """
@@ -591,7 +593,7 @@ def test_centroid_multiple_flux(simulated_spectra):
     assert hasattr(centroid_spec, 'uncertainty')
     assert len(centroid_spec.uncertainty) == 5
     # NOTE: value has not been scientifically validated
-    assert np.allclose(centroid_spec.uncertainty.value, np.array([0.2812655, 0.39435469, 0.3286723, 0.31117068, 0.30481023]))
+    assert np.allclose(centroid_spec.uncertainty.value, np.array([1.14987628e-04, 1.49638658e-04, 1.02963584e-04, 1.21785134e-04, 9.47238087e-05]))
 
 
 def test_gaussian_sigma_width():
@@ -612,7 +614,7 @@ def test_gaussian_sigma_width():
     assert quantity_allclose(result, g1.stddev, atol=0.01*u.GHz)
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
-    assert quantity_allclose(result.uncertainty, 4.8190546890398186e-05*u.GHz, rtol=5e-5)
+    assert quantity_allclose(result.uncertainty, 4.79660696e-05*u.GHz, rtol=5e-5)
 
 
 def test_gaussian_sigma_width_masked():
@@ -635,7 +637,7 @@ def test_gaussian_sigma_width_masked():
     assert quantity_allclose(result, g1.stddev, atol=0.01*u.GHz)
     assert hasattr(result, 'uncertainty')
     # NOTE: value has not been scientifically validated!
-    assert quantity_allclose(result.uncertainty, 0.06852821940808544*u.GHz, rtol=5e-5)
+    assert quantity_allclose(result.uncertainty, 0.06576328*u.GHz, rtol=5e-5)
 
 
 def test_gaussian_sigma_width_regions():


### PR DESCRIPTION
We've had some reports that the uncertainties reported by `centroid`, `gaussian_sigma_width`, and `gaussian_fwhm` are suspect/wrong. This PR will update to using `astropy.uncertainty` Monte Carlo distributions to estimate the value and uncertainty for these quantities instead of the suspect analytic solutions, and give the option to use an updated analytic solution for `centroid` that @eteq re-derived. Opening this now to get eyes on my implementation, but I still need to update the gaussian measures.