### PR TITLE
new implementation of FluxConservingResampler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Bug Fixes
 
 - Fix SNR calculations with both masks and regions. [#1044]
 
+- Reimplementation of FluxConservingResampler to fix incorrect flux and
+  uncertainties and increase speed. [#1058]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -53,6 +56,7 @@ Other Changes and Additions
 
 - JWST X1D reader will no longer raise a ``UnitWarning`` for surface brightness
   error. [#1050]
+
 
 1.9.1 (2022-11-22)
 ------------------

--- a/specutils/manipulation/resample.py
+++ b/specutils/manipulation/resample.py
@@ -44,6 +44,7 @@ class ResamplerBase(ABC):
 
 
 class FluxConservingResampler(ResamplerBase):
+
     """
     This resampling algorithm conserves overall integrated flux (as opposed to
     flux density).
@@ -73,59 +74,164 @@ class FluxConservingResampler(ResamplerBase):
     >>> resample_grid = [1, 5, 9, 13, 14, 17, 21, 22, 23]  *u.nm
     >>> fluxc_resample = FluxConservingResampler()
     >>> fluxc_resample(input_spectra, resample_grid)  # doctest: +FLOAT_CMP
-    <Spectrum1D(flux=<Quantity [        nan,  3.        ,  6.13043478,  7.        ,  6.33333333,
-               10.        , 20.        ,         nan,         nan] mJy>, spectral_axis=<SpectralAxis [ 1.,  5.,  9., 13., 14., 17., 21., 22., 23.] nm>)>
-
+    <Spectrum1D(flux=<Quantity [  nan,  3.  ,  6.  ,  7.  ,  6.25, 10.  , 20.  ,   nan,   nan] mJy>, spectral_axis=<SpectralAxis [ 1.,  5.,  9., 13., 14., 17., 21., 22., 23.] nm>)>
     """
 
-    def _resample_matrix(self, orig_spec_axis, fin_spec_axis):
+    @staticmethod
+    def _check_if_overlap(a1, a2, b1, b2):
+        # check if 2 bins bounded by ``bin1_bounds``=(a1, a2) and
+        # ``bin2_bounds``=(b1, b2) have any intersection
+        if (b1 >= a2) or (b2 <= a1):
+            return False
+        return True
+
+    @staticmethod
+    def _get_overlap_area(a1, a2, b1, b2):
+        # get intersection area of 2 bins bounded by
+        # ``bin1_bounds``=(a1, b1) and ``bin2_bounds``=(a2, b2)
+        # assuming its already known they overlap
+        if b1 >= a1:
+            if b2 > a2:
+                return a2 - b1
+            return b2 - b1
+        if b2 > a2:
+            return min(b2, a2) - max(b1, a1)
+        return b2 - a1
+
+    def _fluxc_resample(self, input_bin_centers, output_bin_centers,
+                        input_bin_fluxes, errs):
         """
-        Create a re-sampling matrix to be used in re-sampling spectra in a way
-        that conserves flux. This code was heavily influenced by Nick Earl's
-        resample rough draft: nmearl@0ff6ef1.
+        Resample ``input_bin_fluxes`` and (optionally) ``errs`` from
+        ``input_bin_centers`` to ``output_bin_centers``.
 
         Parameters
         ----------
-        orig_spec_axis : SpectralAxis
-            The original spectral axis array.
-        fin_spec_axis : SpectralAxis
-            The desired spectral axis array.
+        input_bin_centers : `~specutils.SpectralAxis`
+            `~specutils.SpectralAxis` object, with input bin centers.
+        output_bin_centers : `~specutils.SpectralAxis`
+            `~specutils.SpectralAxis` object, with input bin centers.
+        input_bin_fluxes : Quantity
+            Quantity array of flux values.
+        errs : `~astropy.nddata.Variance` object, or None
+            Variance array of errors corresponding to input bin fluxes. If None,
+            error resampling is not performed.
 
         Returns
         -------
-        resample_mat : ndarray
-            An [[N_{fin_spec_axis}, M_{orig_spec_axis}]] matrix.
+       (output_fluxes, output_errs)
+            A tuple containing plain numpy arrays of the resampled fluxes and
+            errors (if available).
         """
-        # Lower bin and upper bin edges
-        orig_edges = orig_spec_axis.bin_edges
-        fin_edges = fin_spec_axis.bin_edges
 
-        # I could get rid of these alias variables,
-        # but it does add readability
-        orig_low = orig_edges[:-1]
-        fin_low = fin_edges[:-1]
-        orig_upp = orig_edges[1:]
-        fin_upp = fin_edges[1:]
+        fill_val = np.nan  # bin_edges=nan_fill case
+        if self.extrapolation_treatment == 'zero_fill':
+            fill_val = 0
 
-        # Here's the real work in figuring out the bin overlaps
-        # i.e., contribution of each original bin to the resampled bin
-        l_inf = np.where(orig_low > fin_low[:, np.newaxis],
-                         orig_low, fin_low[:, np.newaxis])
-        l_sup = np.where(orig_upp < fin_upp[:, np.newaxis],
-                         orig_upp, fin_upp[:, np.newaxis])
+        # get bin edges from centers
+        input_bin_edges = input_bin_centers.bin_edges.value
+        output_bin_edges = output_bin_centers.bin_edges.value
 
-        resamp_mat = (l_sup - l_inf).clip(0)
-        resamp_mat = resamp_mat * (orig_upp - orig_low)
+        # convert to regular arrays
+        input_bin_centers = input_bin_centers.value
+        output_bin_centers = output_bin_centers.value
+        input_bin_fluxes = input_bin_fluxes.value
 
-        # set bins that don't overlap 100% with original bins
-        # to zero by checking edges, and applying generated mask
-        left_clip = np.where(fin_edges[:-1] - orig_edges[0] < 0, 0, 1)
-        right_clip = np.where(orig_edges[-1] - fin_edges[1:] < 0, 0, 1)
-        keep_overlapping_matrix = left_clip * right_clip
+        # create array of output fluxes and errors to be returned
+        output_fluxes = np.zeros(shape=len(output_bin_centers))
+        output_errs = None
+        if errs is not None:
+            output_errs = np.zeros(shape=len(output_bin_centers))
 
-        resamp_mat *= keep_overlapping_matrix[:, np.newaxis]
+        # running sums for ouput flux, err calculations
+        num = 0
+        num_err = 0
+        denom = 0
 
-        return resamp_mat.value
+        # index of min. overlapping bin. - ignore bins before this in each iter
+        exclude_before_last_iter = 0
+
+        # first, figure out what output bins cover wavelengths outside the span of
+        # input bins. these bins should have fluxes set to nan (or whatever the
+        # fill val is.) and can be skipped
+        min_idx = 0
+        max_idx = None
+
+        low_out_of_range = np.where(output_bin_edges < input_bin_edges[0])[0]
+        if len(low_out_of_range) > 0:  # if any bins below wavelength range
+            min_idx = low_out_of_range[-1] + 1
+            output_fluxes[:min_idx] = fill_val
+            if errs is not None:
+                output_errs[:min_idx] = fill_val
+
+        high_out_of_range = np.where(output_bin_edges > input_bin_edges[-1])[0]
+        if len(high_out_of_range) > 0:
+            max_idx = high_out_of_range[0] - 1
+            output_fluxes[max_idx:] = fill_val
+            if errs is not None:
+                output_errs[max_idx:] = fill_val
+
+        # iterate over each output bin in wavelength range of input bins
+        for i, output_bin in enumerate(output_bin_centers[min_idx:max_idx]):
+
+            i = i + min_idx  # index in orig, unclipped array
+            bin_start, bin_stop = output_bin_edges[i], output_bin_edges[i+1]
+
+            # now iterate over each input bin to see which ones overlap
+            # but do this in such a way that we don't check bins unnecessarily.
+            exclude_before = exclude_before_last_iter
+            for j, input_bin in enumerate(input_bin_centers[exclude_before_last_iter:]):
+
+                j = j + exclude_before  # index in orig, unclipped
+
+                input_bin_start, input_bin_stop = input_bin_edges[j], input_bin_edges[j+1]
+                input_bin_width = input_bin_stop - input_bin_start
+
+                if input_bin_start >= bin_stop:  # stop when bins go out of range
+                    break
+
+                # if the start or the stop of the bin is in range, it overlaps
+                overlaps = self._check_if_overlap(*(bin_start, bin_stop),
+                                                  *(input_bin_start, input_bin_stop))
+
+                if overlaps is True:
+
+                    # if this input bin overlaps and terminates within this output
+                    # bin, then it can be skipped for the next output bin (i)
+                    if input_bin_stop <= bin_stop:
+                        exclude_before_last_iter = j
+
+                    # what fraction of input bin is contained in output bin?
+                    overlap_width = self._get_overlap_area(*(bin_start, bin_stop),
+                                                           *(input_bin_start,
+                                                             input_bin_stop))
+                    overlap_fraction = (overlap_width / input_bin_width)
+
+                    # numerator contribution from this i, j
+                    num += (input_bin_fluxes[j] * overlap_fraction * input_bin_width)
+                    if errs is not None:
+                        num_err += (overlap_fraction*overlap_fraction) *\
+                                   (input_bin_width*input_bin_width) *\
+                                   (errs[j]*errs[j])
+
+                    # denom. contribution from this i, j
+                    denom += input_bin_width * overlap_fraction
+
+                else:  # bin doesn't overlap
+                    continue
+
+            output_fluxes[i] = num / denom
+
+            if errs is not None:
+                output_errs[i] = num_err / (denom * denom)
+                num_err = 0  # reset running sum of P_ij^2*w_i^2*err_i^2
+
+            num = 0  # reset running sum of P_ij*w_i*f_i
+            denom = 0  # reset running sum of P_ij*w_i
+
+        if errs is not None:
+            output_errs = InverseVariance(np.reciprocal(np.sqrt(output_errs)))
+
+        return (output_fluxes, output_errs)
 
     def resample1d(self, orig_spectrum, fin_spec_axis):
         """
@@ -143,12 +249,10 @@ class FluxConservingResampler(ResamplerBase):
 
         Returns
         -------
-        resample_spectrum : `~specutils.Spectrum1D`
+        resampled_spectrum : `~specutils.Spectrum1D`
             An output spectrum containing the resampled `~specutils.Spectrum1D`
         """
 
-        # Check if units on original spectrum and new wavelength (if defined)
-        # match
         if isinstance(fin_spec_axis, Quantity):
             if orig_spectrum.spectral_axis.unit != fin_spec_axis.unit:
                 raise ValueError("Original spectrum spectral axis grid and new"
@@ -157,64 +261,45 @@ class FluxConservingResampler(ResamplerBase):
         if not isinstance(fin_spec_axis, SpectralAxis):
             fin_spec_axis = SpectralAxis(fin_spec_axis)
 
-        # todo: Would be good to return uncertainty in type it was provided?
-        # todo: add in weighting options
-
         # Get provided uncertainty into variance
         if orig_spectrum.uncertainty is not None:
             pixel_uncer = orig_spectrum.uncertainty.represent_as(VarianceUncertainty).array
         else:
             pixel_uncer = None
 
+        # convert unit
         orig_axis_in_fin = orig_spectrum.spectral_axis.to(fin_spec_axis.unit)
-        resample_grid = self._resample_matrix(orig_axis_in_fin, fin_spec_axis)
 
-        # Now for some broadcasting magic to handle multi dimensional flux inputs
-        # Essentially this part is inserting length one dimensions as fillers
-        # For example, if we have a (5,6,10) input flux, and an output grid
-        # of 3, flux will be broadcast to (5,6,1,10) and resample_grid will
-        # Be broadcast to (1,1,3,10).  The sum then reduces down the 10, the
-        # original dispersion grid, leaving 3, the new dispersion grid, as
-        # the last index.
-        new_flux_shape = list(orig_spectrum.flux.shape)
-        new_flux_shape.insert(-1, 1)
-        in_flux = orig_spectrum.flux.reshape(new_flux_shape)
+        # handle 2d flux inputs
+        if orig_spectrum.flux.ndim == 2:
+            # make output matrix
+            output_fluxes = np.zeros(shape=(orig_spectrum.flux.shape[0],
+                                            fin_spec_axis.shape[0]))
+            output_errs = np.zeros(shape=(orig_spectrum.flux.shape[0],
+                                          fin_spec_axis.shape[0]))
+            for r, row in enumerate(orig_spectrum.flux):
+                new_f, new_e = self._fluxc_resample(input_bin_centers=orig_axis_in_fin,
+                                                    output_bin_centers=fin_spec_axis,
+                                                    input_bin_fluxes=row,
+                                                    errs=pixel_uncer[r])
+                output_fluxes[r] = new_f
+                output_errs[r] = new_e.array
 
-        ones = [1] * len(orig_spectrum.flux.shape[:-1])
-        new_shape_resample_grid = ones + list(resample_grid.shape)
-        resample_grid = resample_grid.reshape(new_shape_resample_grid)
+            new_errs = InverseVariance(output_errs)
 
-        # Calculate final flux
-        out_flux = np.sum(in_flux * resample_grid, axis=-1) / np.sum(
-            resample_grid, axis=-1)
-
-        # Calculate output uncertainty
-        if pixel_uncer is not None:
-            pixel_uncer = pixel_uncer.reshape(new_flux_shape)
-
-            out_variance = np.sum(pixel_uncer * resample_grid**2, axis=-1) / np.sum(
-                resample_grid, axis=-1)**2
-            out_uncertainty = InverseVariance(np.reciprocal(out_variance))
         else:
-            out_uncertainty = None
+            # calculate new fluxes and errors
+            output_fluxes, new_errs = self._fluxc_resample(input_bin_centers=orig_axis_in_fin,
+                                                           output_bin_centers=fin_spec_axis,
+                                                           input_bin_fluxes=orig_spectrum.flux,
+                                                           errs=pixel_uncer)
 
-        # nan-filling happens by default - replace with zeros if requested:
-        if self.extrapolation_treatment == 'zero_fill':
-            origedges = orig_spectrum.spectral_axis.bin_edges
-            off_edges = (fin_spec_axis < origedges[0]) | (origedges[-1] < fin_spec_axis)
-            out_flux[off_edges] = 0
-            if out_uncertainty is not None:
-                out_uncertainty.array[off_edges] = 0
+        output_fluxes = output_fluxes << orig_spectrum.flux.unit
+        fin_spec_axis = np.array(fin_spec_axis) << orig_spectrum.spectral_axis.unit
 
-        # todo: for now, use the units from the pre-resampled
-        # spectra, although if a unit is defined for fin_spec_axis and it doesn't
-        # match the input spectrum it won't work right, will have to think
-        # more about how to handle that... could convert before and after
-        # calculation, which is probably easiest. Matrix math algorithm is
-        # geometry based, so won't work to just let quantity math handle it.
-        resampled_spectrum = Spectrum1D(flux=out_flux,
-                                        spectral_axis=np.array(fin_spec_axis) * orig_spectrum.spectral_axis.unit,
-                                        uncertainty=out_uncertainty)
+        resampled_spectrum = Spectrum1D(flux=output_fluxes,
+                                        spectral_axis=fin_spec_axis,
+                                        uncertainty=new_errs)
 
         return resampled_spectrum
 
@@ -348,15 +433,16 @@ class SplineInterpolatedResampler(ResamplerBase):
         """
         orig_axis_in_new = orig_spectrum.spectral_axis.to(fin_spec_axis.unit)
         flux_spline = CubicSpline(orig_axis_in_new.value, orig_spectrum.flux.value,
-                                   extrapolate=self.extrapolation_treatment != 'nan_fill')
+                                  extrapolate=self.extrapolation_treatment != 'nan_fill')
         out_flux_val = flux_spline(fin_spec_axis.value)
 
         new_unc = None
         if orig_spectrum.uncertainty is not None:
             unc_spline = CubicSpline(orig_axis_in_new.value, orig_spectrum.uncertainty.array,
-                                       extrapolate=self.extrapolation_treatment != 'nan_fill')
+                                     extrapolate=self.extrapolation_treatment != 'nan_fill')
             out_unc_val = unc_spline(fin_spec_axis.value)
-            new_unc = orig_spectrum.uncertainty.__class__(array=out_unc_val, unit=orig_spectrum.unit)
+            new_unc = orig_spectrum.uncertainty.__class__(array=out_unc_val,
+                                                          unit=orig_spectrum.unit)
 
         if self.extrapolation_treatment == 'zero_fill':
             origedges = orig_spectrum.spectral_axis.bin_edges

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -84,7 +84,7 @@ def test_line_flux_masked():
 
     # With flux conserving resampler
     result = line_flux(spectrum_masked, mask_interpolation=FluxConservingResampler)
-    assert quantity_allclose(result.value, 720.61116, atol=0.001)
+    assert quantity_allclose(result.value, 720.52992, atol=0.001)
 
 
 def test_equivalent_width():

--- a/specutils/tests/test_resample.py
+++ b/specutils/tests/test_resample.py
@@ -48,7 +48,8 @@ def test_expanded_grid_fluxconserving():
     results = inst(input_spectra, resamp_grid)
 
     assert_quantity_allclose(results.flux,
-                            np.array([np.nan, 3., 6.13043478, 7., 6.33333333, 10., 20., np.nan, np.nan])*u.mJy)
+                             np.array([np.nan, 3., 6., 7., 6.25, 10., 20.,
+                                       np.nan, np.nan])*u.mJy)
 
 
 def test_stddev_uncert_propogation():
@@ -64,7 +65,7 @@ def test_stddev_uncert_propogation():
     results = inst(input_spectra, [25, 35, 50, 55]*u.AA)
 
     assert np.allclose(results.uncertainty.array,
-                       np.array([55.17241379, 73.52941176, 27.94759825, 55.17241379]))
+                       np.array([31.59810022, 38.89549208, 21.30305717, 31.59810022]))
 
 
 def delta_wl(saxis):
@@ -116,20 +117,20 @@ def test_multi_dim_spectrum1D():
     flux_2d = np.array([np.ones(10) * 5, np.ones(10) * 6, np.ones(10) * 7])
 
     input_spectra = Spectrum1D(spectral_axis=np.arange(5000, 5010) * u.AA,
-                      flux=flux_2d * u.Jy,
-                      uncertainty=StdDevUncertainty(flux_2d / 10))
+                               flux=flux_2d * u.Jy,
+                               uncertainty=StdDevUncertainty(flux_2d / 10))
 
     inst = FluxConservingResampler()
     results = inst(input_spectra, [5001, 5003, 5005, 5007] * u.AA)
 
     assert_quantity_allclose(results.flux,
-                            np.array([[5., 5., 5., 5.],
-                                      [6., 6., 6., 6.],
-                                      [7., 7., 7., 7.]]) * u.Jy)
+                             np.array([[5., 5., 5., 5.],
+                                       [6., 6., 6., 6.],
+                                       [7., 7., 7., 7.]]) * u.Jy)
     assert np.allclose(results.uncertainty.array,
-                       np.array([[10.66666667, 10.66666667, 10.66666667, 10.66666667],
-                                 [ 7.40740741, 7.40740741, 7.40740741, 7.40740741],
-                                 [ 5.44217687, 5.44217687, 5.44217687, 5.44217687]]))
+                       np.array([[6.53197265, 6.53197265, 6.53197265, 6.53197265],
+                                 [4.53609212, 4.53609212, 4.53609212, 4.53609212],
+                                 [3.33263911, 3.33263911, 3.33263911, 3.33263911]]))
 
 
 def test_expanded_grid_interp_linear():
@@ -146,7 +147,8 @@ def test_expanded_grid_interp_linear():
     results = inst(input_spectra, resamp_grid)
 
     assert_quantity_allclose(results.flux,
-                            np.array([np.nan, 3.5, 5.5, 6.75, 6.5, 9.5, np.nan, np.nan, np.nan])*u.mJy)
+                             np.array([np.nan, 3.5, 5.5, 6.75, 6.5, 9.5, np.nan,
+                                       np.nan, np.nan])*u.mJy)
 
 
 def test_expanded_grid_interp_spline():
@@ -163,8 +165,9 @@ def test_expanded_grid_interp_spline():
     results = inst(input_spectra, resamp_grid)
 
     assert_quantity_allclose(results.flux,
-                            np.array([np.nan, 3.98808594, 6.94042969, 6.45869141,
-                                      5.89921875, 7.29736328, np.nan, np.nan, np.nan])*u.mJy)
+                             np.array([np.nan, 3.98808594, 6.94042969, 6.45869141,
+                                       5.89921875, 7.29736328, np.nan, np.nan,
+                                       np.nan])*u.mJy)
 
 
 @pytest.mark.parametrize("edgetype,lastvalue",
@@ -183,7 +186,7 @@ def test_resample_edges(edgetype, lastvalue, all_resamplers):
 
 
 def test_resample_different_units(all_resamplers):
-    input_spectrum = Spectrum1D(spectral_axis=[5000, 6000 ,7000] * u.AA,
+    input_spectrum = Spectrum1D(spectral_axis=[5000, 6000, 7000] * u.AA,
                                 flux=[1, 2, 3] * u.mJy)
     resampler = all_resamplers("nan_fill")
     if all_resamplers == FluxConservingResampler:
@@ -199,8 +202,8 @@ def test_resample_different_units(all_resamplers):
 
 
 def test_resample_uncs(all_resamplers):
-    sdunc = StdDevUncertainty([0.1,0.2, 0.3]*u.mJy)
-    input_spectrum = Spectrum1D(spectral_axis=[5000, 6000 ,7000] * u.AA,
+    sdunc = StdDevUncertainty([0.1, 0.2, 0.3]*u.mJy)
+    input_spectrum = Spectrum1D(spectral_axis=[5000, 6000, 7000] * u.AA,
                                 flux=[1, 2, 3] * u.mJy,
                                 uncertainty=sdunc)
 


### PR DESCRIPTION
(Resolves issue #817, #1059)

This is a new version of FluxConservingResampler that addresses the issue described in #817. 

To summarize the changes made, the initial approach constructed a matrix of values that represented something about the fraction of overap between input wavelength bin i and output wavelength j. Most of the elements of this matrix will be zero, since only i_j values that have any overlap will be non-zero, so it is inefficient to use matrix operations here. 

In this new approach, it loops over each output bin, and then each input bin but excluding input bins determined in the previous iteration to have terminated in that output bin, and stoping when the front edge of the input bun exceeds the end of that output bin, therefore comparing the minimum number of bins required and calculating the output flux and errors in these bins.

As shown here, the speed increase for the new version is quite good:
<img width="737" alt="Screen Shot 2023-05-15 at 11 07 36 PM" src="https://github.com/astropy/specutils/assets/20444899/2d8e0765-9614-4cd3-bfb0-dcb871fbe240">

In the process of writing this, I noticed a subtle difference in flux and uncertainty outputs in certain cases when you have uneven sized output bins (it actually might be more general than this, and occur in cases of partial overlap). I opened an issue for this which has the justification and verification that the new results are correct (https://github.com/astropy/specutils/issues/1059). This PR solves that issue as well. Because of this, some of the truth values of the unit tests have changed.

EDIT: Fix #817, #1059