### PR TITLE
Assert spectral axis in Spectrum1D is sorted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- When creating a Spectrum1D object, it is not enforced that the spectral axis is sorted and either
+- When creating a Spectrum1D object, it is enforced that the spectral axis is sorted and either
   strictly increasing or decreasing. [#1061]
 
 1.10.0 (2023-04-05)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- When creating a Spectrum1D object, it is not enforced that the spectral axis is sorted and either
+  strictly increasing or decreasing. [#1061]
+
 1.10.0 (2023-04-05)
 -------------------
 

--- a/specutils/io/default_loaders/tests/test_jwst_reader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_reader.py
@@ -24,7 +24,12 @@ else:
 
 def create_spectrum_hdu(data_len, srctype=None, ver=1, name='EXTRACT1D'):
     """Mock a JWST x1d BinTableHDU"""
+    np.random.seed(20)
     data = np.random.random((data_len, 5))
+
+    # make sure spectral axis is sorted
+    data = data[data[:, 0].argsort()]
+
     table = Table(data=data, names=['WAVELENGTH', 'FLUX', 'ERROR', 'SURF_BRIGHT',
         'SB_ERROR'])
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -296,6 +296,11 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
                 doppler_rest=rest_value,
                 doppler_convention=velocity_convention)
 
+        # make sure that spectral axis is strictly increasing or decreasing,
+        # raise an error if not.
+        if not self._check_strictly_increasing_decreasing():
+            raise ValueError('Spectral axis must be strictly increasing or decreasing.')
+
         if hasattr(self, 'uncertainty') and self.uncertainty is not None:
             if not flux.shape == self.uncertainty.array.shape:
                 raise ValueError(
@@ -583,6 +588,10 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
     @property
     def shape(self):
         return self.flux.shape
+
+    @property
+    def spectral_axis_direction(self):
+        return self._spectral_axis_direction
 
     @property
     def redshift(self):

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -288,6 +288,25 @@ class OneDSpectrumMixin():
 
         raise u.UnitConversionError(f"WCS units incompatible: {unit} and {orig_unit}.")
 
+    def _check_strictly_increasing_decreasing(self):
+        """
+        Check that the self._spectral_axis is strictly increasing or decreasing
+        and raise an error if its not.
+
+        """
+
+        spec_axis = self._spectral_axis
+
+        sorted_increasing = np.all(spec_axis[1:] >= spec_axis[:-1])
+        if sorted_increasing:  # check increasing first, probably most common case
+            self._spectral_axis_direction = 'increasing'
+            return True
+        sorted_decreasing = np.all(spec_axis[1:] <= spec_axis[:-1])
+        if sorted_decreasing:
+            self._spectral_axis_direction = 'decreasing'
+            return True
+        return False
+
 
 class InplaceModificationMixin:
     # Example methods follow to demonstrate how methods can be written to be

--- a/specutils/tests/test_resample.py
+++ b/specutils/tests/test_resample.py
@@ -175,7 +175,7 @@ def test_expanded_grid_interp_spline():
 def test_resample_edges(edgetype, lastvalue, all_resamplers):
     input_spectrum = Spectrum1D(spectral_axis=[2, 4, 12, 16, 20] * u.micron,
                                 flux=[1, 3, 7, 6, 20] * u.mJy)
-    resamp_grid = [1, 3, 7, 6, 20, 100] * u.micron
+    resamp_grid = [1, 3, 7, 16, 20, 100] * u.micron
 
     resampler = all_resamplers(edgetype)
     resampled = resampler(input_spectrum, resamp_grid)

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -507,3 +507,31 @@ def test_collapse_flux():
     median_spec = spec.mean(axis = 0)
     assert isinstance(median_spec, Spectrum1D)
     assert np.all(median_spec.flux == [2, 8, 9] * u.Jy)
+
+
+def test_unsorted_spectral_axis_fails():
+    """
+    Test that creating a Spectrum1D fails if spectral axis isn't strictly
+    ascending or descending.
+    """
+    wave = [2, 1, 3] * u.nm
+    flux = [5, 5, 5] * u.Jy
+
+    with pytest.raises(ValueError, match='Spectral axis must be strictly increasing or decreasing.'):
+        Spectrum1D(spectral_axis=wave, flux=flux)
+
+
+def test_spectral_axis_direction():
+    """
+    Test that the spec1d.spectral_axis_direction attribute correctly reflects
+    if the spectral axis in Spectrum1D is increasing or decreasing.
+    """
+    flux = [5, 5, 5] * u.Jy
+
+    wave = [1, 2, 3] * u.nm
+    spec1d = Spectrum1D(spectral_axis=wave, flux=flux)
+    assert spec1d.spectral_axis_direction == 'increasing'
+
+    wave = [3, 2, 1] * u.nm
+    spec1d = Spectrum1D(spectral_axis=wave, flux=flux)
+    assert spec1d.spectral_axis_direction == 'decreasing'


### PR DESCRIPTION
This PR adds a constraint when initializing a Spectrum1D object that the spectral axis is either strictly ascending or descending, and raises an error if that condition is not met. A new attribute indicating which order the spectral axis is in (``spec1d.spectral_axis_order``) is added. This will be used, for example, by Specreduce wavelength calibration to make sure the spectral axis is ascending. I also changed some of the tests accordingly. 

I decided to do this on Spectrum1D rather than SpectralAxis - I thought that doing it there might be too restrictive? I'm not sure.