### PR TITLE
Fix SDSS-I/II spSpec units

### DIFF
--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -30,7 +30,10 @@ def _sdss_wcs_to_log_wcs(old_wcs):
     claims to be linear, but is logarithmic in base-10.
     The wavelength is given by:
     λ = 10^(w0 + w1 * i)
-    with i being the pixel index starting from 0.
+    with i being the pixel index starting from 0. This formula is documented at
+    https://classic.sdss.org/dr7/products/spectra/read_spSpec.php and appears to
+    be the same across all SDSS-I and SDSS-II data releases (replace dr7 with
+    dr<x> in the above URL).
 
     The FITS standard uses a natural log with a sightly different formulation,
     see WCS Paper 3 (which discusses spectral WCS).
@@ -146,6 +149,11 @@ def spec_loader(file_obj, **kwargs):
 def spSpec_loader(file_obj, **kwargs):
     """
     Loader for SDSS-I/II spSpec files.
+
+    The content of these files is documented at
+    https://classic.sdss.org/dr7/dm/flatFiles/spSpec.php, with instructions for
+    reading them at
+    https://classic.sdss.org/dr7/products/spectra/read_spSpec.php.
 
     Parameters
     ----------

--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -41,7 +41,7 @@ def _sdss_wcs_to_log_wcs(old_wcs):
     w1 = old_wcs.wcs.cd[0,0]
     crval = 10 ** w0
     cdelt = crval * w1 * np.log(10)
-    cunit = old_wcs.wcs.cunit[0] or Unit('Angstrom')
+    cunit = Unit('Angstrom')
     ctype = "WAVE-LOG"
 
     w = WCS(naxis=1)

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -208,6 +208,7 @@ def test_sdss_spspec(tmp_path):
         spec = Spectrum1D.read(response, format="SDSS-I/II spSpec")
         assert isinstance(spec, Spectrum1D)
         assert spec.flux.size > 0
+        assert (spec.wavelength[0] / u.AA).value == pytest.approx(3799.268615)
 
     file_path = str(tmp_path / sp_pattern)
     with urllib.request.urlopen(url) as response:


### PR DESCRIPTION
It looks like something changed (I've not yet worked out what) in how astropy/wcslib handled absent `CUNITa`, and now the loader is incorrectly using metres instead of using angstroms. As the WCS was already incorrectly encoded, we probably can't trust `CUNITa` anyway, so force angstroms.

This also adds a test to confirm that the unit does not change again.