### PR TITLE
Fix some comparisons that should have been using `isinstance`

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -323,9 +323,9 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         handled here.
         """
 
-        if self.flux.ndim > 1 or (type(item) == tuple and item[0] == Ellipsis):
-            if type(item) == tuple:
-                if len(item) == len(self.flux.shape) or item[0] == Ellipsis:
+        if self.flux.ndim > 1 or (isinstance(item, tuple) and item[0] is Ellipsis):
+            if isinstance(item, tuple):
+                if len(item) == len(self.flux.shape) or item[0] is Ellipsis:
                     spec_item = item[-1]
                     if not isinstance(spec_item, slice):
                         if isinstance(item, u.Quantity):

--- a/specutils/tests/test_spectral_axis.py
+++ b/specutils/tests/test_spectral_axis.py
@@ -172,7 +172,7 @@ def test_change_redshift():
 
     assert spec.redshift.unit.physical_type == 'dimensionless'
     assert_quantity_allclose(spec.redshift, u.Quantity(0))
-    assert type(spec.spectral_axis) == SpectralAxis
+    assert isinstance(spec.spectral_axis, SpectralAxis)
 
     with pytest.warns(
         AstropyDeprecationWarning,
@@ -182,13 +182,13 @@ def test_change_redshift():
 
     assert spec.redshift.unit.physical_type == 'dimensionless'
     assert_quantity_allclose(spec.redshift, u.Quantity(0.1))
-    assert type(spec.spectral_axis) == SpectralAxis
+    assert isinstance(spec.spectral_axis, SpectralAxis)
 
     spec = Spectrum1D(spectral_axis=wave, flux=flux, redshift=0.2)
 
     assert spec.redshift.unit.physical_type == 'dimensionless'
     assert_quantity_allclose(spec.redshift, u.Quantity(0.2))
-    assert type(spec.spectral_axis) == SpectralAxis
+    assert isinstance(spec.spectral_axis, SpectralAxis)
 
     with pytest.warns(
         AstropyDeprecationWarning,
@@ -198,7 +198,7 @@ def test_change_redshift():
 
     assert spec.redshift.unit.physical_type == 'dimensionless'
     assert_quantity_allclose(spec.redshift, u.Quantity(0.4))
-    assert type(spec.spectral_axis) == SpectralAxis
+    assert isinstance(spec.spectral_axis, SpectralAxis)
 
 
 def test_no_change_redshift():
@@ -208,13 +208,13 @@ def test_no_change_redshift():
 
     assert spec.redshift.unit.physical_type == 'dimensionless'
     assert_quantity_allclose(spec.redshift, u.Quantity(0))
-    assert type(spec.spectral_axis) == SpectralAxis
+    assert isinstance(spec.spectral_axis, SpectralAxis)
 
     spec.set_redshift_to(0.5)
 
     assert spec.redshift.unit.physical_type == 'dimensionless'
     assert_quantity_allclose(spec.redshift, u.Quantity(0.5))
-    assert type(spec.spectral_axis) == SpectralAxis
+    assert isinstance(spec.spectral_axis, SpectralAxis)
 
     assert_quantity_allclose(spec.wavelength, wave)
 


### PR DESCRIPTION
I'm not sure why these suddenly started getting caught by our codestyle checks, but here's the fix.