### PR TITLE
Improved GWCS handling in Spectrum1D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1.11.0 (unreleased)
+1.12.0 (unreleased)
 -------------------
 
 New Features

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
-
 2.0.0 (unreleased)
 ------------------
+
+New Features
+^^^^^^^^^^^^
 
 - Spectral axis can now be any axis, rather than being forced to be last. See docs
   for more details. [#1033]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,15 @@ New Features
 
 - Spectral axis can now be any axis, rather than being forced to be last. See docs
   for more details. [#1033]
-  
+
+- Spectrum1D now keeps the entire input GWCS instead of extracting only the spectral
+  information. [#1074]
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- JWST reader no longer transposes the input data cube for 3D data. [#1074]
+
 1.12.0 (unreleased)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,33 +1,9 @@
+
 2.0.0 (unreleased)
 ------------------
 
 - Spectral axis can now be any axis, rather than being forced to be last. See docs
   for more details. [#1033]
-
-1.11.0 (Unreleased)
--------------------
-
-New Features
-^^^^^^^^^^^^
-
-Bug Fixes
-^^^^^^^^^
-- Reimplementation of FluxConservingResampler. It is now faster and yields more accurate results. [#1060]
-
-Other Changes and Additions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-1.12.0 (unreleased)
--------------------
-
-New Features
-^^^^^^^^^^^^
-
-Bug Fixes
-^^^^^^^^^
-
-Other Changes and Additions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1.11.0 (2023-06-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,17 @@
 2.0.0 (unreleased)
 ------------------
 
+- Spectral axis can now be any axis, rather than being forced to be last. See docs
+  for more details. [#1033]
+
+1.11.0 (Unreleased)
+-------------------
+
 New Features
 ^^^^^^^^^^^^
 
-- Spectral axis can now be any axis, rather than being forced to be last. See docs
-  for more details. [#1033]
+Bug Fixes
+^^^^^^^^^
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,18 @@
 
 - Spectral axis can now be any axis, rather than being forced to be last. See docs
   for more details. [#1033]
+  
+1.12.0 (unreleased)
+-------------------
+
+New Features
+^^^^^^^^^^^^
+
+Bug Fixes
+^^^^^^^^^
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1.11.0 (2023-06-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,13 +7,13 @@ New Features
 - Spectral axis can now be any axis, rather than being forced to be last. See docs
   for more details. [#1033]
 
-- Spectrum1D now keeps the entire input GWCS instead of extracting only the spectral
-  information. [#1074]
+- Spectrum1D now properly handles GWCS input for wcs attribute. [#1074]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- JWST reader no longer transposes the input data cube for 3D data. [#1074]
+- JWST reader no longer transposes the input data cube for 3D data and retains
+  full GWCS information (including spatial). [#1074]
 
 1.12.0 (unreleased)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ New Features
 
 Bug Fixes
 ^^^^^^^^^
+- Reimplementation of FluxConservingResampler. It is now faster and yields more accurate results. [#1060]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ intersphinx_mapping['gwcs'] = ('https://gwcs.readthedocs.io/en/latest/', None)
 intersphinx_mapping['reproject'] = ('https://reproject.readthedocs.io/en/stable/', None)
 intersphinx_mapping['mpl_animators'] = ('https://docs.sunpy.org/projects/mpl-animators/en/stable/', None)
 
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns.append('_templates')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,6 @@ intersphinx_mapping['gwcs'] = ('https://gwcs.readthedocs.io/en/latest/', None)
 intersphinx_mapping['reproject'] = ('https://reproject.readthedocs.io/en/stable/', None)
 intersphinx_mapping['mpl_animators'] = ('https://docs.sunpy.org/projects/mpl-animators/en/stable/', None)
 
-
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns.append('_templates')

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -584,38 +584,6 @@ def _jwst_s3d_loader(filename, **kwargs):
             flux_array = hdu.data
             flux = Quantity(flux_array, unit=flux_unit)
 
-            '''
-            # I think this can all be removed now, will test
-
-            # Get the wavelength array from the GWCS object which returns a
-            # tuple of (RA, Dec, lambda).
-            # Since the spatial and spectral axes are orthogonal in s3d data,
-            # it is much faster to compute a slice down the spectral axis.
-            grid = grid_from_bounding_box(wcs.bounding_box)[:, :, 0, 0]
-            _, _, wavelength_array = wcs(*grid)
-            _, _, wavelength_unit = wcs.output_frame.unit
-
-            wavelength = Quantity(wavelength_array, unit=wavelength_unit)
-
-            # The GWCS is currently broken for some IFUs, here we work around that
-            wcs = None
-            if wavelength.shape[0] != flux.shape[-1]:
-                # Need MJD-OBS for this workaround
-                if 'MJD-OBS' not in hdu.header:
-                    for key in ('MJD-BEG', 'DATE-OBS'):  # Possible alternatives
-                        if key in hdu.header:
-                            if key.startswith('MJD'):
-                                hdu.header['MJD-OBS'] = hdu.header[key]
-                                break
-                            else:
-                                t = Time(hdu.header[key])
-                                hdu.header['MJD-OBS'] = t.mjd
-                                break
-                wcs = WCS(hdu.header)
-                # Swap to match the flux transpose
-                wcs = wcs.swapaxes(-1, 0)
-            '''
-
             # Merge primary and slit headers and dump into meta
             slit_header = hdu.header
             header = primary_header.copy()

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -8,8 +8,6 @@ from astropy.units import Quantity
 from astropy.table import Table
 from astropy.io import fits
 from astropy.nddata import StdDevUncertainty, VarianceUncertainty, InverseVariance
-from astropy.time import Time
-from astropy.wcs import WCS
 from gwcs.wcstools import grid_from_bounding_box
 
 from ...spectra import Spectrum1D, SpectrumList

--- a/specutils/io/default_loaders/tests/test_jwst_reader.py
+++ b/specutils/io/default_loaders/tests/test_jwst_reader.py
@@ -434,7 +434,7 @@ def test_jwst_s3d_single(tmp_path, cube):
 
     data = Spectrum1D.read(tmpfile, format='JWST s3d')
     assert type(data) is Spectrum1D
-    assert data.shape == (10, 10, 30)
+    assert data.shape == (30, 10, 10)
     assert data.uncertainty is not None
     assert data.mask is not None
     assert data.uncertainty.unit == 'MJy'

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -6,6 +6,7 @@ from astropy import units as u
 from astropy.utils.decorators import lazyproperty
 from astropy.utils.decorators import deprecated
 from astropy.nddata import NDUncertainty, NDIOMixin, NDArithmeticMixin
+from gwcs.wcs import WCS as GWCS
 
 from .spectral_axis import SpectralAxis
 from .spectrum_mixin import OneDSpectrumMixin
@@ -228,24 +229,34 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
                     f"of the corresponding flux axis ({flux.shape[self.spectral_axis_index]})")
 
         # If a WCS is provided, determine which axis is the spectral axis
-        if wcs is not None and hasattr(wcs, "naxis"):
-            if wcs.naxis > 1:
+        if wcs is not None:
+            naxis = None
+            if hasattr(wcs, "naxis"):
+                naxis = wcs.naxis
+            # GWCS doesn't have naxis
+            elif hasattr(wcs, "world_n_dim"):
+                naxis = wcs.world_n_dim
+
+            if naxis is not None and naxis > 1:
                 temp_axes = []
                 phys_axes = wcs.world_axis_physical_types
-                for i in range(len(phys_axes)):
-                    if phys_axes[i] is None:
-                        continue
-                    if phys_axes[i][0:2] == "em" or phys_axes[i][0:5] == "spect":
-                        temp_axes.append(i)
-                if len(temp_axes) != 1:
-                    raise ValueError("Input WCS must have exactly one axis with "
-                                     "spectral units, found {}".format(len(temp_axes)))
-                else:
-                    # Due to FITS conventions, the WCS axes are listed in opposite
-                    # order compared to the data array.
-                    self._spectral_axis_index = len(flux.shape)-temp_axes[0]-1
+                if self._spectral_axis_index is None:
+                    for i in range(len(phys_axes)):
+                        if phys_axes[i] is None:
+                            continue
+                        if phys_axes[i][0:2] == "em" or phys_axes[i][0:5] == "spect":
+                            temp_axes.append(i)
+                    if len(temp_axes) != 1:
+                        raise ValueError("Input WCS must have exactly one axis with "
+                                        "spectral units, found {}".format(len(temp_axes)))
+                    else:
+                        # Due to FITS conventions, the WCS axes are listed in opposite
+                        # order compared to the data array.
+                        self._spectral_axis_index = len(flux.shape)-temp_axes[0]-1
 
                 if move_spectral_axis is not None:
+                    if isinstance(wcs, GWCS):
+                        raise ValueError("move_spectral_axis cannot be used with GWCS")
                     if isinstance(move_spectral_axis, str):
                         if move_spectral_axis.lower() == 'first':
                             move_to_index = 0
@@ -280,6 +291,7 @@ class Spectrum1D(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
                                                             self._spectral_axis_index, move_to_index)
 
                         self._spectral_axis_index = move_to_index
+                print(f"Spectral axis index is {self._spectral_axis_index}")
 
             else:
                 if flux is not None and flux.ndim == 1:


### PR DESCRIPTION
This PR allows Spectrum1D to keep the entire GWCS when reading a file (for example a JWST cube), rather than dropping any spatial WCS information as done previously. Probably most applicable beyond just JWST cubes but that's the use case I was targeting off the bat here. This has to go in v2.0 because GWCS doesn't have a `swapaxis` method like WCS does.