### PR TITLE
added filter_non_finite flag to fit_lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 New Features
 ^^^^^^^^^^^^
 
+- Added 'filter_non_finite' flag to `fit_lines` to allow data with non-finite
+  weights to be fit after filtering. [#1078]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -515,10 +515,6 @@ def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertaintie
             warnings.warn('`filter_non_finite` can only be True when fitter is LevMarLSQFitter. Setting to False.')
             filter_non_finite = False
 
-    print('FILTER NON FINITE', filter_non_finite)
-    print(flux)
-    print(weights)
-
     fit_model = fitter(model, dispersion,
                        flux, weights=weights, filter_non_finite=filter_non_finite, **kwargs)
 


### PR DESCRIPTION
This PR adds the 'filter_non_finite' flag to specutils.fitting.fit_lines. By default, this flag is False, and it can only be True if the fitter is a `LevMarLSQFitter`. This fixes an issue when there are non-finite values in the weights array, and allows the fit to proceed with these filtered out.