### PR TITLE
Compatibility with unreleased ASDF stack for JWST s2d data

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,17 +1,8 @@
-import pkg_resources
-
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
     ASTROPY_HEADER = True
 except ImportError:
     ASTROPY_HEADER = False
-
-entry_points = []
-for entry_point in pkg_resources.iter_entry_points('pytest11'):
-    entry_points.append(entry_point.name)
-
-if "asdf_schema_tester" not in entry_points:
-    pytest_plugins = ['asdf.tests.schema_tester']
 
 
 # Repeat this from specutils/conftest.py so tox picks it up.

--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -445,7 +445,7 @@ def _jwst_s2d_loader(filename, **kwargs):
     slits = None
 
     # Get a list of GWCS objects from the slits
-    with asdf_in_fits.open(filename) as af:
+    with fits.open(filename, memmap=False) as hdulist, asdf_in_fits.open(hdulist) as af:
         # Slits can be listed under "slits", "products" or "exposures"
         if "products" in af.tree:
             slits = "products"
@@ -460,8 +460,6 @@ def _jwst_s2d_loader(filename, **kwargs):
         # Create list of the GWCS objects, one for each slit
         if slits is not None:
             wcslist = [slit["meta"]["wcs"] for slit in af.tree[slits]]
-
-    with fits.open(filename, memmap=False) as hdulist:
 
         primary_header = hdulist["PRIMARY"].header
 
@@ -567,10 +565,8 @@ def _jwst_s3d_loader(filename, **kwargs):
     spectra = []
 
     # Get a list of GWCS objects from the slits
-    with asdf_in_fits.open(filename) as af:
+    with fits.open(filename, memmap=False) as hdulist, asdf_in_fits.open(hdulist) as af:
         wcslist = [af.tree["meta"]["wcs"]]
-
-    with fits.open(filename, memmap=False) as hdulist:
 
         primary_header = hdulist["PRIMARY"].header
 


### PR DESCRIPTION
This will hopefully address https://github.com/spacetelescope/jdaviz/issues/2446 . Minimally reproducible example that crashes without this patch using unreleased ASDF stack:

```python
from astropy.utils.data import download_file
from specutils import Spectrum1D
fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits', cache=True)
sp = Spectrum1D.read(fn)
```

[🐱](https://jira.stsci.edu/browse/JDAT-3786)