### PR TITLE
Update devdeps tests to use more recent python, numpy

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -79,10 +79,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: (Allowed Failure) Python 3.11 with remote data and dev version of key dependencies
+          - name: (Allowed Failure) Python 3.12 with remote data and dev version of key dependencies
             os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-devdeps
+            python: '3.12-dev'
+            toxenv: py312-test-devdeps
             toxposargs: --remote-data=any
 
     steps:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -38,14 +38,14 @@ jobs:
             toxenv: py311-test
 
           - name: Python 3.11 (MacOS X)
-             os: macos-latest
-             python: 3.11
-             toxenv: py311-test
+            os: macos-latest
+            python: 3.11
+            toxenv: py311-test
 
           - name: Python 3.10
-             os: ubuntu-latest
-             python: 3.10
-             toxenv: py310-test
+            os: ubuntu-latest
+            python: 3.10
+            toxenv: py310-test
 
           - name: Python 3.9
             os: ubuntu-latest
@@ -53,9 +53,9 @@ jobs:
             toxenv: py39-test
 
           - name: Python 3.8 with oldest supported version of key dependencies
-             os: ubuntu-20.04
-             python: 3.8
-             toxenv: py38-test-oldestdeps
+            os: ubuntu-20.04
+            python: 3.8
+            toxenv: py38-test-oldestdeps
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -44,7 +44,7 @@ jobs:
 
           - name: Python 3.10
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-test
 
           - name: Python 3.9

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -25,27 +25,37 @@ jobs:
             python: 3.x
             toxenv: codestyle
 
-          - name: Python 3.10 with astropy data and coverage
+          - name: Python 3.11 with astropy data and coverage
             os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310-test-cov
+            python: '3.11'
+            toxenv: py311-test-cov
             toxargs: -v
             toxposargs: --remote-data=astropy
 
-          - name: Python 3.8 with oldest supported version of key dependencies
-            os: ubuntu-20.04
-            python: 3.8
-            toxenv: py38-test-oldestdeps
-
-          - name: Python 3.9 (Windows)
+          - name: Python 3.11 (Windows)
             os: windows-latest
+            python: 3.11
+            toxenv: py311-test
+
+          - name: Python 3.11 (MacOS X)
+             os: macos-latest
+             python: 3.11
+             toxenv: py311-test
+
+          - name: Python 3.10
+             os: ubuntu-latest
+             python: 3.10
+             toxenv: py310-test
+
+          - name: Python 3.9
+            os: ubuntu-latest
             python: 3.9
             toxenv: py39-test
 
-          - name: Python 3.8 (MacOS X)
-            os: macos-latest
-            python: 3.8
-            toxenv: py38-test
+          - name: Python 3.8 with oldest supported version of key dependencies
+             os: ubuntu-20.04
+             python: 3.8
+             toxenv: py38-test-oldestdeps
 
     steps:
     - name: Checkout code

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-test{,-devdeps,-oldestdeps,-predeps}{,-cov,-external}
+    py{38,39,310,311,312}-test{,-devdeps,-oldestdeps,-predeps}{,-cov,-external}
     linkcheck
     codestyle
 requires =
@@ -66,6 +66,8 @@ extras =
     !oldestdeps: jwst
 
 commands =
+    # Force numpy-dev after matplotlib downgrades it (https://github.com/matplotlib/matplotlib/issues/26847)
+    devdeps: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     pip freeze
     !cov: pytest --pyargs specutils {toxinidir}/docs {posargs}
     cov: pytest --pyargs specutils {toxinidir}/docs --cov specutils --cov-config={toxinidir}/setup.cfg {posargs}


### PR DESCRIPTION
This forces the devdeps environment to install dev numpy 2, despite matplotlib dev wanting <2. Also upgrades python in the devdeps environment to 3.12. Closes #1082 and closes #1083. Thanks to @pllim.

I'm sure there will be some test failures here, I'll also clean those up in this PR.