### PR TITLE
Update test envs now that python 3.12 is released

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -25,20 +25,25 @@ jobs:
             python: 3.x
             toxenv: codestyle
 
-          - name: Python 3.11 with astropy data and coverage
+          - name: Python 3.12 with astropy data and coverage
             os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-cov
+            python: 3.12
+            toxenv: py312-test-cov
             toxargs: -v
             toxposargs: --remote-data=astropy
 
-          - name: Python 3.11 (Windows)
+          - name: Python 3.12 (Windows)
             os: windows-latest
-            python: 3.11
-            toxenv: py311-test
+            python: 3.12
+            toxenv: py312-test
 
-          - name: Python 3.11 (MacOS X)
+          - name: Python 3.12 (MacOS X)
             os: macos-latest
+            python: 3.12
+            toxenv: py312-test
+
+          - name: Python 3.11
+            os: ubuntu-laters
             python: 3.11
             toxenv: py311-test
 

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -27,24 +27,24 @@ jobs:
 
           - name: Python 3.12 with astropy data and coverage
             os: ubuntu-latest
-            python: 3.12
+            python: '3.12'
             toxenv: py312-test-cov
             toxargs: -v
             toxposargs: --remote-data=astropy
 
           - name: Python 3.12 (Windows)
             os: windows-latest
-            python: 3.12
+            python: '3.12'
             toxenv: py312-test
 
           - name: Python 3.12 (MacOS X)
             os: macos-latest
-            python: 3.12
+            python: '3.12'
             toxenv: py312-test
 
           - name: Python 3.11
             os: ubuntu-laters
-            python: 3.11
+            python: '3.11'
             toxenv: py311-test
 
           - name: Python 3.10

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ isolated_build = true
 setenv =
     MPLBACKEND=agg
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    py312: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,9 @@ deps =
     devdeps: git+https://github.com/astropy/asdf-astropy.git
     devdeps: git+https://github.com/spacetelescope/stdatamodels.git
 
+    # Currently need dev astropy with python 3.12
+    py312: git+https://github.com/astropy/astropy.git#egg=astropy
+
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ deps =
     devdeps: git+https://github.com/spacetelescope/stdatamodels.git
 
     # Currently need dev astropy with python 3.12
-    py312: astropy>=0.0.dev0
+    py312-test: git+https://github.com/spacetelescope/gwcs.git#egg=astropy
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ deps =
     devdeps: git+https://github.com/spacetelescope/stdatamodels.git
 
     # Currently need dev astropy with python 3.12
-    py312: git+https://github.com/astropy/astropy.git#egg=astropy
+    py312: astropy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ deps =
     devdeps: git+https://github.com/spacetelescope/stdatamodels.git
 
     # Currently need dev astropy with python 3.12
-    py312-test: git+https://github.com/spacetelescope/gwcs.git#egg=astropy
+    py312: astropy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
Updates our OS tests to all use python 3.12 and adds a test to keep checking against 3.11.