### PR TITLE
TST: Pin casa-formats-io in oldest-deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ deps =
     # These are pinned to avoid upgrading numpy.
     oldestdeps: matplotlib==3.6.*
     oldestdeps: dask==2023.2.0
+    oldestdeps: casa-formats-io==0.2.1
 
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0


### PR DESCRIPTION
Pin casa-formats-io in oldest-deps job because it is upgrading numpy but we do not want that to happen.

Fix #1091