### PR TITLE
Update tox.ini to handle spaces in paths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,9 +70,9 @@ commands =
     # Force numpy-dev after matplotlib downgrades it (https://github.com/matplotlib/matplotlib/issues/26847)
     devdeps: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     pip freeze
-    !cov: pytest --pyargs specutils {toxinidir}/docs {posargs}
-    cov: pytest --pyargs specutils {toxinidir}/docs --cov specutils --cov-config={toxinidir}/setup.cfg {posargs}
-    cov: coverage xml -o {toxinidir}/coverage.xml
+    !cov: pytest --pyargs specutils '{toxinidir}/docs' {posargs}
+    cov: pytest --pyargs specutils '{toxinidir}/docs' --cov specutils --cov-config='{toxinidir}/setup.cfg' {posargs}
+    cov: coverage xml -o '{toxinidir}/coverage.xml'
 
 pip_pre =
     predeps: true


### PR DESCRIPTION
Tox doesn't handle spaces in paths well.  Adding single quotes around the path variables in the `tox.ini` fixes this.