### PR TITLE
add tabular-fits support for Spectrum1D mask

### DIFF
--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -163,6 +163,19 @@ def tabular_fits_writer(spectrum, file_name, hdu=1, update_header=False, **kwarg
             raise ValueError("Could not convert uncertainty to StdDevUncertainty due"
                              " to divide-by-zero error.")
 
+    # Add mask column if present
+    if spectrum.mask is not None:
+        # work around https://github.com/astropy/astropy/issues/11963
+        # where int8 columns are written as bool, loosing information.
+        # upcast to int16 instead.
+        if spectrum.mask.dtype == np.int8:
+            mask = spectrum.mask.astype(np.int16)
+        else:
+            mask = spectrum.mask
+
+        columns.append(mask)
+        colnames.append('mask')
+
     # For > 1D data transpose from row-major format
     for c in range(1, len(columns)):
         if columns[c].ndim > 1:

--- a/specutils/io/parsing_utils.py
+++ b/specutils/io/parsing_utils.py
@@ -282,11 +282,20 @@ def generic_spectrum_from_table(table, wcs=None, **kwargs):
     else:
         err = None
 
+    # Check for mask
+    if 'mask' in table.colnames:
+        mask = table['mask']
+        if mask.ndim > 1:
+            mask = mask.T
+    else:
+        mask = None
+
     # Create the Spectrum1D object and return it
     if wcs is not None or spectral_axis_column is not None and flux_column is not None:
         # For > 1D spectral axis transpose to row-major format and return SpectrumCollection
         spectrum = Spectrum1D(flux=flux, spectral_axis=spectral_axis,
-                              uncertainty=err, meta={'header': table.meta}, wcs=wcs)
+                              uncertainty=err, meta={'header': table.meta}, wcs=wcs,
+                              mask=mask)
 
     return spectrum
 

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -593,13 +593,14 @@ def test_tabular_fits_multid(tmp_path, ndim, spectral_axis):
     assert quantity_allclose(spec.uncertainty.quantity,
                              spectrum.uncertainty.quantity)
 
+
 @pytest.mark.parametrize("mask_type", [bool, np.uint8, np.int8, np.uint16, np.int16, '>i2'])
 def test_tabular_fits_mask(tmp_path, mask_type):
     # test mask I/O with tabular fits format
     wave = np.arange(3600, 3700) * u.AA
     nwave = len(wave)
 
-    #- 1D Case
+    # 1D Case
     flux = np.random.uniform(0,1,size=nwave) * u.Jy
     mask = np.zeros(flux.shape, dtype=mask_type)
     mask[0] = 1
@@ -627,7 +628,7 @@ def test_tabular_fits_mask(tmp_path, mask_type):
     else:
         assert sp1.mask.dtype == sp2.mask.dtype
 
-    #- 2D Case
+    # 2D Case
     nspec = 3
     flux = np.random.uniform(0,1,size=(nspec,nwave)) * u.Jy
     mask = np.zeros(flux.shape, dtype=mask_type)
@@ -654,6 +655,7 @@ def test_tabular_fits_mask(tmp_path, mask_type):
         assert sp2.mask.dtype == np.dtype('>i2')
     else:
         assert sp1.mask.dtype == sp2.mask.dtype
+
 
 def test_tabular_fits_maskheader(tmp_path):
     # Create a small data set + header with reserved FITS keywords


### PR DESCRIPTION
This PR fixes a bug in the Spectrum1D.read / write default tabular-fits format, which was dropping the .mask attribute.  It adds tests demonstrating the problem and failing before the fix, and with the fixes these tests now pass.

Detail: due to astropy/astropy#11963, by default int8 masks are written as bool thus losing information, so here I upcast int8 masks to int16 with the result that the dtype changes in the round trip but at least information isn't lost.