### PR TITLE
Preserve fits primary header when writing out spectrum1d without wcs

### DIFF
--- a/specutils/io/default_loaders/mef_tabular_fits.py
+++ b/specutils/io/default_loaders/mef_tabular_fits.py
@@ -7,85 +7,90 @@ from astropy.io import fits
 import numpy as np
 from astropy.table import Table
 
-def mef_tabular_fits_writer(spectrum, file_name, hdu=0, update_header=False, **kwargs):
+def mef_tabular_fits_writer(spectrum, file_name='my_func_output.fits', hdu=0, update_header=False, **kwargs):
 
-	# no matter what the dimensionality of 'flux', there will always be a primary header and
-	# a single BinTableHDU extension. the `hdu` arg controls where `meta.header` is dumped.
-	hdulist = [fits.PrimaryHDU(), None]
+    # no matter what the dimensionality of 'flux', there will always be a primary header and
+    # a single BinTableHDU extension. the `hdu` arg controls where `meta.header` is dumped.
+    hdulist = [fits.PrimaryHDU(), None]
+    pri_header_initial = hdulist[0].header
 
-	if hdu > 1:
-	    raise ValueError('`hdu`, which controls which extension `meta.header` is written to, must either be 0 or 1')
-	    
-		# we expect anything that should be written out to the file header to be in `meta.header`
-		# This should be a `fits.header.Header` object, so convert to if meta.header is a dictionary
-		header = spectrum.meta.get('header', fits.header.Header())  # if no meta.header, create empty `fits.header.Header`
-		if not isinstance(header, fits.header.Header):
-		    if isinstance(header, dict):
-		        header = fits.header.Header(header)
-		    else:
-		        raise ValueError('`Spectrum1d.meta.header must be `fits.header.Header` or dictionary.')
+    if hdu > 1:
+        raise ValueError('`hdu`, which controls which extension `meta.header` is written to, must either be 0 or 1')
+        
+    # we expect anything that should be written out to the file header to be in `meta.header`
+    # This should be a `fits.header.Header` object, so convert to if meta.header is a dictionary
+    header = spectrum.meta.get('header', fits.header.Header())  # if no meta.header, create empty `fits.header.Header`
 
-		if update_header:
-		    hdr_types = (str, int, float, complex, bool,
-		                 np.floating, np.integer, np.complexfloating, np.bool_)
-		    header.update([keyword for keyword in spectrum.meta.items() if
-		                   isinstance(keyword[1], hdr_types)])
+    if hdu == 0:
+        header.update(pri_header_initial)  # update with initial values created from primary header
 
-		# Strip header of FITS reserved keywords
-		for keyword in ['NAXIS', 'NAXIS1', 'NAXIS2']:
-		    header.remove(keyword, ignore_missing=True)
+    if not isinstance(header, fits.header.Header):
+        if isinstance(header, dict):
+            header = fits.header.Header(header)
+        else:
+            raise ValueError('`Spectrum1d.meta.header must be `fits.header.Header` or dictionary.')
 
-		# Add dispersion array and unit
-		wtype = kwargs.pop('wtype', spectrum.spectral_axis.dtype)
-		wunit = u.Unit(kwargs.pop('wunit', spectrum.spectral_axis.unit))
+        if update_header:
+            hdr_types = (str, int, float, complex, bool,
+                         np.floating, np.integer, np.complexfloating, np.bool_)
+            header.update([keyword for keyword in spectrum.meta.items() if
+                           isinstance(keyword[1], hdr_types)])
 
-		disp = spectrum.spectral_axis.to(wunit, equivalencies=u.spectral())
+        # Strip header of FITS reserved keywords
+        for keyword in ['NAXIS', 'NAXIS1', 'NAXIS2']:
+            header.remove(keyword, ignore_missing=True)
 
-		# Mapping of spectral_axis types to header TTYPE1 (no "torque/work" types!)
-		dispname = str(wunit.physical_type)
-		if dispname == "length":
-		    dispname = "wavelength"
-		elif "energy" in dispname:
-		    dispname = "energy"
+        # Add dispersion array and unit
+        wtype = kwargs.pop('wtype', spectrum.spectral_axis.dtype)
+        wunit = u.Unit(kwargs.pop('wunit', spectrum.spectral_axis.unit))
 
-		# Add flux array and unit
-		ftype = kwargs.pop('ftype', spectrum.flux.dtype)
-		funit = u.Unit(kwargs.pop('funit', spectrum.flux.unit))
-		flux = spectrum.flux.to(funit, equivalencies=u.spectral_density(disp))
+        disp = spectrum.spectral_axis.to(wunit, equivalencies=u.spectral())
 
-		columns = [disp.astype(wtype), flux.astype(ftype)]
-		colnames = [dispname, "flux"]
+        # Mapping of spectral_axis types to header TTYPE1 (no "torque/work" types!)
+        dispname = str(wunit.physical_type)
+        if dispname == "length":
+            dispname = "wavelength"
+        elif "energy" in dispname:
+            dispname = "energy"
 
-		# Include uncertainty - units to be inferred from spectrum.flux
-		if spectrum.uncertainty is not None:
-		    try:
-		        unc = (
-		            spectrum
-		            .uncertainty
-		            .represent_as(StdDevUncertainty)
-		            .quantity
-		            .to(funit, equivalencies=u.spectral_density(disp))
-		        )
-		        columns.append(unc.astype(ftype))
-		        colnames.append("uncertainty")
-		    except RuntimeWarning:
-		        raise ValueError("Could not convert uncertainty to StdDevUncertainty due"
-		                         " to divide-by-zero error.")
+        # Add flux array and unit
+        ftype = kwargs.pop('ftype', spectrum.flux.dtype)
+        funit = u.Unit(kwargs.pop('funit', spectrum.flux.unit))
+        flux = spectrum.flux.to(funit, equivalencies=u.spectral_density(disp))
 
-		# For > 1D data transpose from row-major format
-		for c in range(1, len(columns)):
-		    if columns[c].ndim > 1:
-		        columns[c] = columns[c].T
+        columns = [disp.astype(wtype), flux.astype(ftype)]
+        colnames = [dispname, "flux"]
 
-		tab = Table(columns, names=colnames, meta=header)
-		hdulist[1] = fits.BinTableHDU(tab)
+        # Include uncertainty - units to be inferred from spectrum.flux
+        if spectrum.uncertainty is not None:
+            try:
+                unc = (
+                    spectrum
+                    .uncertainty
+                    .represent_as(StdDevUncertainty)
+                    .quantity
+                    .to(funit, equivalencies=u.spectral_density(disp))
+                )
+                columns.append(unc.astype(ftype))
+                colnames.append("uncertainty")
+            except RuntimeWarning:
+                raise ValueError("Could not convert uncertainty to StdDevUncertainty due"
+                                 " to divide-by-zero error.")
 
-		# now figure out where meta.header (and if specified, addl meta keys) should go
-		if hdu==0:
-		    hdulist[0].header = header
-		else:  # must otherwise be 1, we already checked this
-		    hdulist[1].header = header
+        # For > 1D data transpose from row-major format
+        for c in range(1, len(columns)):
+            if columns[c].ndim > 1:
+                columns[c] = columns[c].T
 
-		hdulist = fits.HDUList(hdulist)
+        tab = Table(columns, names=colnames, meta=header)
+        hdulist[1] = fits.BinTableHDU(tab)
 
-		hdulist.writeto(file_name)
+        # now figure out where meta.header (and if specified, addl meta keys) should go
+        if hdu==0:
+            hdulist[0].header = header
+        else:  # must otherwise be 1, we already checked this
+            hdulist[1].header = header
+
+        hdulist = fits.HDUList(hdulist)
+
+        hdulist.writeto(file_name)

--- a/specutils/io/default_loaders/mef_tabular_fits.py
+++ b/specutils/io/default_loaders/mef_tabular_fits.py
@@ -30,67 +30,68 @@ def mef_tabular_fits_writer(spectrum, file_name='my_func_output.fits', hdu=0, up
         else:
             raise ValueError('`Spectrum1d.meta.header must be `fits.header.Header` or dictionary.')
 
-        if update_header:
-            hdr_types = (str, int, float, complex, bool,
-                         np.floating, np.integer, np.complexfloating, np.bool_)
-            header.update([keyword for keyword in spectrum.meta.items() if
-                           isinstance(keyword[1], hdr_types)])
+    if update_header:
+        hdr_types = (str, int, float, complex, bool,
+                     np.floating, np.integer, np.complexfloating, np.bool_)
+        header.update([keyword for keyword in spectrum.meta.items() if
+                       isinstance(keyword[1], hdr_types)])
 
-        # Strip header of FITS reserved keywords
-        for keyword in ['NAXIS', 'NAXIS1', 'NAXIS2']:
-            header.remove(keyword, ignore_missing=True)
+    # Strip header of FITS reserved keywords
+    for keyword in ['NAXIS', 'NAXIS1', 'NAXIS2']:
+        header.remove(keyword, ignore_missing=True)
 
-        # Add dispersion array and unit
-        wtype = kwargs.pop('wtype', spectrum.spectral_axis.dtype)
-        wunit = u.Unit(kwargs.pop('wunit', spectrum.spectral_axis.unit))
+    # Add dispersion array and unit
+    wtype = kwargs.pop('wtype', spectrum.spectral_axis.dtype)
+    wunit = u.Unit(kwargs.pop('wunit', spectrum.spectral_axis.unit))
 
-        disp = spectrum.spectral_axis.to(wunit, equivalencies=u.spectral())
+    disp = spectrum.spectral_axis.to(wunit, equivalencies=u.spectral())
 
-        # Mapping of spectral_axis types to header TTYPE1 (no "torque/work" types!)
-        dispname = str(wunit.physical_type)
-        if dispname == "length":
-            dispname = "wavelength"
-        elif "energy" in dispname:
-            dispname = "energy"
+    # Mapping of spectral_axis types to header TTYPE1 (no "torque/work" types!)
+    dispname = str(wunit.physical_type)
+    if dispname == "length":
+        dispname = "wavelength"
+    elif "energy" in dispname:
+        dispname = "energy"
 
-        # Add flux array and unit
-        ftype = kwargs.pop('ftype', spectrum.flux.dtype)
-        funit = u.Unit(kwargs.pop('funit', spectrum.flux.unit))
-        flux = spectrum.flux.to(funit, equivalencies=u.spectral_density(disp))
+    # Add flux array and unit
+    ftype = kwargs.pop('ftype', spectrum.flux.dtype)
+    funit = u.Unit(kwargs.pop('funit', spectrum.flux.unit))
+    flux = spectrum.flux.to(funit, equivalencies=u.spectral_density(disp))
 
-        columns = [disp.astype(wtype), flux.astype(ftype)]
-        colnames = [dispname, "flux"]
+    columns = [disp.astype(wtype), flux.astype(ftype)]
+    colnames = [dispname, "flux"]
 
-        # Include uncertainty - units to be inferred from spectrum.flux
-        if spectrum.uncertainty is not None:
-            try:
-                unc = (
-                    spectrum
-                    .uncertainty
-                    .represent_as(StdDevUncertainty)
-                    .quantity
-                    .to(funit, equivalencies=u.spectral_density(disp))
-                )
-                columns.append(unc.astype(ftype))
-                colnames.append("uncertainty")
-            except RuntimeWarning:
-                raise ValueError("Could not convert uncertainty to StdDevUncertainty due"
-                                 " to divide-by-zero error.")
+    # Include uncertainty - units to be inferred from spectrum.flux
+    if spectrum.uncertainty is not None:
+        try:
+            unc = (
+                spectrum
+                .uncertainty
+                .represent_as(StdDevUncertainty)
+                .quantity
+                .to(funit, equivalencies=u.spectral_density(disp))
+            )
+            columns.append(unc.astype(ftype))
+            colnames.append("uncertainty")
+        except RuntimeWarning:
+            raise ValueError("Could not convert uncertainty to StdDevUncertainty due"
+                             " to divide-by-zero error.")
 
-        # For > 1D data transpose from row-major format
-        for c in range(1, len(columns)):
-            if columns[c].ndim > 1:
-                columns[c] = columns[c].T
+    # For > 1D data transpose from row-major format
+    for c in range(1, len(columns)):
+        if columns[c].ndim > 1:
+            columns[c] = columns[c].T
 
-        tab = Table(columns, names=colnames, meta=header)
-        hdulist[1] = fits.BinTableHDU(tab)
+    tab = Table(columns, names=colnames)
+    hdulist[1] = fits.BinTableHDU(tab)
 
-        # now figure out where meta.header (and if specified, addl meta keys) should go
-        if hdu==0:
-            hdulist[0].header = header
-        else:  # must otherwise be 1, we already checked this
-            hdulist[1].header = header
+    # now figure out where meta.header (and if specified, addl meta keys) should go
+    if hdu==0:
+        print('here')
+        hdulist[0].header.update(header)
+    else:  # must otherwise be 1, we already checked this
+        hdulist[1].header.update(header)
 
-        hdulist = fits.HDUList(hdulist)
+    hdulist = fits.HDUList(hdulist)
 
-        hdulist.writeto(file_name)
+    hdulist.writeto(file_name, overwrite=True)

--- a/specutils/io/default_loaders/mef_tabular_fits.py
+++ b/specutils/io/default_loaders/mef_tabular_fits.py
@@ -87,3 +87,5 @@ def mef_tabular_fits_writer(spectrum, file_name, hdu=0, update_header=False, **k
 		    hdulist[1].header = header
 
 		hdulist = fits.HDUList(hdulist)
+
+		hdulist.writeto(file_name)

--- a/specutils/io/default_loaders/mef_tabular_fits.py
+++ b/specutils/io/default_loaders/mef_tabular_fits.py
@@ -1,0 +1,89 @@
+# a hack around tabular-fits that supports putting header info in the primary hdu
+
+from astropy.wcs import WCS
+from specutils import Spectrum1D
+import astropy.units as u
+from astropy.io import fits
+import numpy as np
+from astropy.table import Table
+
+def mef_tabular_fits_writer(spectrum, file_name, hdu=0, update_header=False, **kwargs):
+
+	# no matter what the dimensionality of 'flux', there will always be a primary header and
+	# a single BinTableHDU extension. the `hdu` arg controls where `meta.header` is dumped.
+	hdulist = [fits.PrimaryHDU(), None]
+
+	if hdu > 1:
+	    raise ValueError('`hdu`, which controls which extension `meta.header` is written to, must either be 0 or 1')
+	    
+		# we expect anything that should be written out to the file header to be in `meta.header`
+		# This should be a `fits.header.Header` object, so convert to if meta.header is a dictionary
+		header = spectrum.meta.get('header', fits.header.Header())  # if no meta.header, create empty `fits.header.Header`
+		if not isinstance(header, fits.header.Header):
+		    if isinstance(header, dict):
+		        header = fits.header.Header(header)
+		    else:
+		        raise ValueError('`Spectrum1d.meta.header must be `fits.header.Header` or dictionary.')
+
+		if update_header:
+		    hdr_types = (str, int, float, complex, bool,
+		                 np.floating, np.integer, np.complexfloating, np.bool_)
+		    header.update([keyword for keyword in spectrum.meta.items() if
+		                   isinstance(keyword[1], hdr_types)])
+
+		# Strip header of FITS reserved keywords
+		for keyword in ['NAXIS', 'NAXIS1', 'NAXIS2']:
+		    header.remove(keyword, ignore_missing=True)
+
+		# Add dispersion array and unit
+		wtype = kwargs.pop('wtype', spectrum.spectral_axis.dtype)
+		wunit = u.Unit(kwargs.pop('wunit', spectrum.spectral_axis.unit))
+
+		disp = spectrum.spectral_axis.to(wunit, equivalencies=u.spectral())
+
+		# Mapping of spectral_axis types to header TTYPE1 (no "torque/work" types!)
+		dispname = str(wunit.physical_type)
+		if dispname == "length":
+		    dispname = "wavelength"
+		elif "energy" in dispname:
+		    dispname = "energy"
+
+		# Add flux array and unit
+		ftype = kwargs.pop('ftype', spectrum.flux.dtype)
+		funit = u.Unit(kwargs.pop('funit', spectrum.flux.unit))
+		flux = spectrum.flux.to(funit, equivalencies=u.spectral_density(disp))
+
+		columns = [disp.astype(wtype), flux.astype(ftype)]
+		colnames = [dispname, "flux"]
+
+		# Include uncertainty - units to be inferred from spectrum.flux
+		if spectrum.uncertainty is not None:
+		    try:
+		        unc = (
+		            spectrum
+		            .uncertainty
+		            .represent_as(StdDevUncertainty)
+		            .quantity
+		            .to(funit, equivalencies=u.spectral_density(disp))
+		        )
+		        columns.append(unc.astype(ftype))
+		        colnames.append("uncertainty")
+		    except RuntimeWarning:
+		        raise ValueError("Could not convert uncertainty to StdDevUncertainty due"
+		                         " to divide-by-zero error.")
+
+		# For > 1D data transpose from row-major format
+		for c in range(1, len(columns)):
+		    if columns[c].ndim > 1:
+		        columns[c] = columns[c].T
+
+		tab = Table(columns, names=colnames, meta=header)
+		hdulist[1] = fits.BinTableHDU(tab)
+
+		# now figure out where meta.header (and if specified, addl meta keys) should go
+		if hdu==0:
+		    hdulist[0].header = header
+		else:  # must otherwise be 1, we already checked this
+		    hdulist[1].header = header
+
+		hdulist = fits.HDUList(hdulist)

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -116,7 +116,6 @@ def tabular_fits_writer(spectrum, file_name, hdu=1, update_header=False, **kwarg
         raise ValueError(f'FITS does not support BINTABLE extension in HDU {hdu}.')
 
     header = spectrum.meta.get('header', fits.header.Header()).copy()
-    print('header', header)
 
     if update_header:
         hdr_types = (str, int, float, complex, bool,

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -116,6 +116,7 @@ def tabular_fits_writer(spectrum, file_name, hdu=1, update_header=False, **kwarg
         raise ValueError(f'FITS does not support BINTABLE extension in HDU {hdu}.')
 
     header = spectrum.meta.get('header', fits.header.Header()).copy()
+    print('header', header)
 
     if update_header:
         hdr_types = (str, int, float, complex, bool,


### PR DESCRIPTION
(this is a suuuuper draft pr, just opening to track work done at Spectro 2023 hack day with @kelle)

The current issue (that we have been trying to wrap our heads around in #1096, #905, and has become clearer to us as we've explored this) is that tabular-fits writer, which converts Spectrum1D into a table and uses Table.write to save to file, does not support writing out to the PrimaryHDU. The alternative writer available for `Spectrum1D`, `wcs1d-fits', sort of does what we want (which is, a primary HDU with a header and a BinTableHDU in the 1st extension with spectrum info) but requires a valid wcs to work (since the initial HDUList is created from this WCS)

The goal of this PR is to bypass the tabular-fits writer to enable writing out meta.header info to the primary HDU when there is NO wcs.