### PR TITLE
feat: add correlation mode to template_correlation

### DIFF
--- a/specutils/analysis/correlation.py
+++ b/specutils/analysis/correlation.py
@@ -52,7 +52,7 @@ def template_correlate(observed_spectrum, template_spectrum, lag_units=_KMS,
         a sensible resampling).
     method: str
         If you choose "FFT", the correlation will be done through the use
-        of convolution and will be calculated faster (for small spectral 
+        of convolution and will be calculated faster (for small spectral
         resolutions it is often correct), otherwise the correlation is determined
         directly from sums (the "direct" method in `~scipy.signal.correlate`).
 
@@ -91,11 +91,11 @@ def template_correlate(observed_spectrum, template_spectrum, lag_units=_KMS,
 
     # Correlate
     if method.lower() == "fft":
-        corr = correlate(observed_log_spectrum.flux.value, 
+        corr = correlate(observed_log_spectrum.flux.value,
                          (template_log_spectrum.flux.value * normalization),
                          method="fft")
     else:
-        corr = correlate(observed_log_spectrum.flux.value, 
+        corr = correlate(observed_log_spectrum.flux.value,
                          (template_log_spectrum.flux.value * normalization),
                          method="direct")
 

--- a/specutils/analysis/correlation.py
+++ b/specutils/analysis/correlation.py
@@ -50,11 +50,11 @@ def template_correlate(observed_spectrum, template_spectrum, lag_units=_KMS,
         ``template_logwl_resample(spectrum, template, delta_log_wavelength=.1)``.
         If False, *no* resampling is performed (and the user is responsible for
         a sensible resampling).
-    mode: str
-        If you choose FFT method, the correlation will be done through the use
+    method: str
+        If you choose "FFT", the correlation will be done through the use
         of convolution and will be calculated faster (for small spectral 
-        resolutions it is often correct). In other cases, the direct method
-        from the numpy will be used.
+        resolutions it is often correct), otherwise the correlation is determined
+        directly from sums (the "direct" method in `~scipy.signal.correlate`).
 
     Returns
     -------
@@ -90,7 +90,7 @@ def template_correlate(observed_spectrum, template_spectrum, lag_units=_KMS,
         normalization = 1.
 
     # Correlate
-    if method == "fft":
+    if method.lower() == "fft":
         corr = correlate(observed_log_spectrum.flux.value, 
                          (template_log_spectrum.flux.value * normalization),
                          method="fft")

--- a/specutils/analysis/correlation.py
+++ b/specutils/analysis/correlation.py
@@ -4,6 +4,7 @@ from astropy import constants as const
 from astropy.nddata import StdDevUncertainty
 from astropy.units import Quantity
 from scipy.signal.windows import tukey
+from scipy.signal import correlate
 
 from ..manipulation import LinearInterpolatedResampler
 from .. import Spectrum1D
@@ -14,7 +15,7 @@ _KMS = u.Unit('km/s')  # for use below without having to create a composite unit
 
 
 def template_correlate(observed_spectrum, template_spectrum, lag_units=_KMS,
-                       apodization_window=0.5, resample=True):
+                       apodization_window=0.5, resample=True, method="direct"):
     """
     Compute cross-correlation of the observed and template spectra.
 
@@ -49,6 +50,11 @@ def template_correlate(observed_spectrum, template_spectrum, lag_units=_KMS,
         ``template_logwl_resample(spectrum, template, delta_log_wavelength=.1)``.
         If False, *no* resampling is performed (and the user is responsible for
         a sensible resampling).
+    mode: str
+        If you choose FFT method, the correlation will be done through the use
+        of convolution and will be calculated faster (for small spectral 
+        resolutions it is often correct). In other cases, the direct method
+        from the numpy will be used.
 
     Returns
     -------
@@ -84,9 +90,14 @@ def template_correlate(observed_spectrum, template_spectrum, lag_units=_KMS,
         normalization = 1.
 
     # Correlate
-    corr = np.correlate(observed_log_spectrum.flux.value,
-                        (template_log_spectrum.flux.value * normalization),
-                        mode='full')
+    if method == "fft":
+        corr = correlate(observed_log_spectrum.flux.value, 
+                         (template_log_spectrum.flux.value * normalization),
+                         method="fft")
+    else:
+        corr = correlate(observed_log_spectrum.flux.value, 
+                         (template_log_spectrum.flux.value * normalization),
+                         method="direct")
 
     # Compute lag
     # wave_l is the wavelength array equally spaced in log space.


### PR DESCRIPTION
Added the ability to select a correlation method. The direct method is often slower; on weaker computers, calculating the spectrum offset can take hours. The "direct" flag in the scipy correlation source code refers to direct correlation using numpy. Forward compatibility is enabled by default.