### PR TITLE
Fix `with_spectral_unit`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Bug Fixes
 - ``template_correlate`` no longer errors when used on a ``Spectrum1D`` that lacks an
   ``uncertainty`` array. [#1118]
 
+- ``with_spectral_unit`` has been changed to ``with_spectral_axis_unit`` and actually works
+  now. [#1119]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -64,7 +67,7 @@ New Features
 
 - ``wcs1d-fits`` loader now reads and writes celestial components of
   of multi-dimensional WCS, and handles ``mask`` and ``uncertainty``
-  attributes. [#1009] 
+  attributes. [#1009]
 
 - Added support for reading from files with flux in counts. [#1018]
 
@@ -183,7 +186,7 @@ Bug Fixes
   ``Spectrum1D`` without WCS nor spectral axis and the spatial-spatial dimension
   is smaller than spectral dimension. [#926]
 
-- Fixed WCS not accurately reflecting the updated spectral axis after slicing a 
+- Fixed WCS not accurately reflecting the updated spectral axis after slicing a
   ``Spectrum1D``. [#918]
 
 Other Changes and Additions
@@ -212,8 +215,8 @@ New Features
 - Convolution-based smoothing will now apply a 1D kernel to multi-dimensional fluxes
   by convolving along the spectral axis only, rather than raising an error. [#885]
 
-- ``template_comparison`` now handles ``astropy.nddata.Variance`` and 
-  ``astropy.nddata.InverseVariance`` uncertainties instead of assuming 
+- ``template_comparison`` now handles ``astropy.nddata.Variance`` and
+  ``astropy.nddata.InverseVariance`` uncertainties instead of assuming
   the uncertainty is standard deviation. [#899]
 
 Bug Fixes
@@ -253,7 +256,7 @@ New Features
 
 - Allow overriding existing astropy registry elements. [#861]
 
-- ``Spectrum1D`` will now swap the spectral axis with the last axis on initialization 
+- ``Spectrum1D`` will now swap the spectral axis with the last axis on initialization
   if it can be identified from the WCS and is not last, rather than erroring. [#654, #822]
 
 Bug Fixes

--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -21,7 +21,7 @@ def moment(spectrum, regions=None, order=0, axis=-1):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object over which the width will be calculated.
 
-    regions: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    regions: `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
         Region within the spectrum to calculate the gaussian sigma width. If
         regions is `None`, computation is performed over entire spectrum.
 

--- a/specutils/analysis/uncertainty.py
+++ b/specutils/analysis/uncertainty.py
@@ -22,7 +22,7 @@ def snr(spectrum, region=None):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object overwhich the equivalent width will be calculated.
 
-    region: `~specutils.utils.SpectralRegion` or list of `~specutils.utils.SpectralRegion`
+    region: `~specutils.SpectralRegion` or list of `~specutils.SpectralRegion`
         Region within the spectrum to calculate the SNR.
 
     Returns
@@ -67,7 +67,7 @@ def _snr_single_region(spectrum, region=None):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object overwhich the equivalent width will be calculated.
 
-    region: `~specutils.utils.SpectralRegion`
+    region: `~specutils.SpectralRegion`
         Region within the spectrum to calculate the SNR.
 
     Returns
@@ -109,7 +109,7 @@ def snr_derived(spectrum, region=None):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object overwhich the equivalent width will be calculated.
 
-    region: `~specutils.utils.SpectralRegion`
+    region: `~specutils.SpectralRegion`
         Region within the spectrum to calculate the SNR.
 
     Returns
@@ -155,7 +155,7 @@ def _snr_derived(spectrum, region=None):
     spectrum : `~specutils.spectra.spectrum1d.Spectrum1D`
         The spectrum object overwhich the equivalent width will be calculated.
 
-    region: `~specutils.utils.SpectralRegion`
+    region: `~specutils.SpectralRegion`
         Region within the spectrum to calculate the SNR.
 
     Returns

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -229,7 +229,7 @@ class OneDSpectrumMixin():
             meta['original_unit'] = orig_unit
 
         if 'original_wcs' not in self.meta:
-            meta['original_wcs'] = self.wcs.copy()
+            meta['original_wcs'] = self.wcs.deepcopy()
 
         new_spectral_axis = self.spectral_axis.to(unit, doppler_convention=velocity_convention,
                                                   doppler_rest=rest_value)

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -193,8 +193,9 @@ class OneDSpectrumMixin():
         """
         Returns a new spectrum with a different spectral axis unit. Note that this creates a new
         object using the converted spectral axis and thus drops the original WCS, if it existed,
-        replacing it with a :class:`~specutils.utils.wcs_utils.SpectralGWCS`. The original WCS
-        will be stored in the ``original_wcs`` entry of the new object's ``meta`` dictionary.
+        replacing it with a lookup-table :class:`~gwcs.wcs.WCS` based on the new spectral axis. The
+        original WCS will be stored in the ``original_wcs`` entry of the new object's ``meta``
+        dictionary.
 
         Parameters
         ----------

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -192,9 +192,9 @@ class OneDSpectrumMixin():
                            rest_value=None):
         """
         Returns a new spectrum with a different spectral axis unit. Note that this creates a new
-        object using the converted spectral axis and thus drops the original WCS, if it existed.
-        The original WCS will be stored in the ``original_wcs`` entry of the new object's ``meta``
-        dictionary.
+        object using the converted spectral axis and thus drops the original WCS, if it existed,
+        replacing it with a :class:`~specutils.utils.wcs_utils.SpectralGWCS`. The original WCS
+        will be stored in the ``original_wcs`` entry of the new object's ``meta`` dictionary.
 
         Parameters
         ----------

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -5,8 +5,6 @@ import astropy.units.equivalencies as eq
 from astropy import units as u
 from astropy.utils.decorators import deprecated
 
-from specutils.utils.wcs_utils import gwcs_from_array, SpectralGWCS
-
 DOPPLER_CONVENTIONS = {}
 DOPPLER_CONVENTIONS['radio'] = u.doppler_radio
 DOPPLER_CONVENTIONS['optical'] = u.doppler_optical

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -224,9 +224,9 @@ class OneDSpectrumMixin():
         # Store the original unit information and WCS for posterity
         meta = self._meta.copy()
 
-        if 'original_unit' not in self._meta:
+        if 'original_spectral_axis_unit' not in self._meta:
             orig_unit = self.wcs.unit[0] if hasattr(self.wcs, 'unit') else self.spectral_axis.unit
-            meta['original_unit'] = orig_unit
+            meta['original_spectral_axis_unit'] = orig_unit
 
         if 'original_wcs' not in self.meta:
             meta['original_wcs'] = self.wcs.deepcopy()

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -184,7 +184,13 @@ class OneDSpectrumMixin():
 
         return new_data
 
+    @deprecated('v1.13', alternative="with_spectral_axis_unit")
     def with_spectral_unit(self, unit, velocity_convention=None,
+                           rest_value=None):
+        self.with_spectral_axis_unit(unit, velocity_convention=velocity_convention,
+                                     rest_value=rest_value)
+
+    def with_spectral_axis_unit(self, unit, velocity_convention=None,
                            rest_value=None):
         """
         Returns a new spectrum with a different spectral axis unit.

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -222,7 +222,7 @@ class OneDSpectrumMixin():
                                                  rest_value)
 
         # Store the original unit information and WCS for posterity
-        meta = self._meta.copy()
+        meta = deepcopy(self._meta)
 
         if 'original_spectral_axis_unit' not in self._meta:
             orig_unit = self.wcs.unit[0] if hasattr(self.wcs, 'unit') else self.spectral_axis.unit

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -162,6 +162,19 @@ def test_spectral_axis_conversions():
     assert new_spec.meta["original_wcs"].world_axis_units[0] == "nm"
     assert new_spec.meta["original_spectral_axis_unit"] == "nm"
 
+    wcs_dict = {"CTYPE1": "WAVE", "CRVAL1": 3.622e3, "CDELT1": 8e-2,
+                "CRPIX1": 0, "CUNIT1": "Angstrom"}
+    wcs_spec = Spectrum1D(flux=np.random.randn(49) * u.Jy, wcs=WCS(wcs_dict),
+                          meta={'header': wcs_dict.copy()})
+    new_spec = wcs_spec.with_spectral_axis_unit(u.km/u.s, rest_value=125*u.um,
+                                       velocity_convention="relativistic")
+    new_spec.meta['original_wcs'].wcs.crval = [3.777e-7]
+    new_spec.meta['header']['CRVAL1'] = 3777.0
+
+    assert wcs_spec.wcs.wcs.crval[0] == 3.622e-7
+    assert wcs_spec.meta['header']['CRVAL1'] == 3622.
+
+
 
 def test_spectral_slice():
     spec = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -150,10 +150,13 @@ def test_spectral_axis_conversions():
     with pytest.raises(ValueError):
         spec.velocity
 
-    spec = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm,
+    spec = Spectrum1D(spectral_axis=np.arange(100, 150) * u.nm,
                       flux=np.random.randn(49) * u.Jy)
 
-    new_spec = spec.with_spectral_unit(u.GHz)  # noqa
+    new_spec = spec.with_spectral_unit(u.km/u.s, rest_value=125*u.um,
+                                       velocity_convention="relativistic")
+
+    assert new_spec.spectral_axis.unit == u.km/u.s
 
 
 def test_spectral_slice():

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -160,6 +160,7 @@ def test_spectral_axis_conversions():
     assert new_spec.wcs.world_axis_units[0] == "km.s**-1"
     # Make sure meta stored the old WCS correctly
     assert new_spec.meta["original_wcs"].world_axis_units[0] == "nm"
+    assert new_spec.meta["original_spectral_axis_unit"] == "nm"
 
 
 def test_spectral_slice():

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -153,7 +153,7 @@ def test_spectral_axis_conversions():
     spec = Spectrum1D(spectral_axis=np.arange(100, 150) * u.nm,
                       flux=np.random.randn(49) * u.Jy)
 
-    new_spec = spec.with_spectral_unit(u.km/u.s, rest_value=125*u.um,
+    new_spec = spec.with_spectral_axis_unit(u.km/u.s, rest_value=125*u.um,
                                        velocity_convention="relativistic")
 
     assert new_spec.spectral_axis.unit == u.km/u.s

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -157,6 +157,9 @@ def test_spectral_axis_conversions():
                                        velocity_convention="relativistic")
 
     assert new_spec.spectral_axis.unit == u.km/u.s
+    assert new_spec.wcs.world_axis_units[0] == "km.s**-1"
+    # Make sure meta stored the old WCS correctly
+    assert new_spec.meta["original_wcs"].world_axis_units[0] == "nm"
 
 
 def test_spectral_slice():

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -175,7 +175,6 @@ def test_spectral_axis_conversions():
     assert wcs_spec.meta['header']['CRVAL1'] == 3622.
 
 
-
 def test_spectral_slice():
     spec = Spectrum1D(spectral_axis=np.linspace(100, 1000, 10) * u.nm,
                       flux=np.random.random(10) * u.Jy)

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -10,7 +10,7 @@ from gwcs import coordinate_frames as cf
 
 class SpectralGWCS(GWCS):
     def __init__(self, *args, **kwargs):
-        self.original_unit = kwargs.pop("original_unit")
+        self.original_unit = kwargs.pop("original_unit", "")
         super().__init__(*args, **kwargs)
 
     def pixel_to_world(self, *args, **kwargs):

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -8,6 +8,18 @@ from gwcs import WCS as GWCS
 from gwcs import coordinate_frames as cf
 
 
+class SpectralGWCS(GWCS):
+    def __init__(self, *args, **kwargs):
+        self.original_unit = kwargs.pop("original_unit")
+        super().__init__(*args, **kwargs)
+
+    def pixel_to_world(self, *args, **kwargs):
+        if self.original_unit == '':
+            return u.Quantity(super().pixel_to_world_values(*args, **kwargs))
+        return super().pixel_to_world(*args, **kwargs).to(
+            self.original_unit, equivalencies=u.spectral())
+
+
 def refraction_index(wavelength, method='Griesen2006', co2=None):
     """
     Calculates the index of refraction of dry air at standard temperature
@@ -210,14 +222,8 @@ def gwcs_from_array(array):
         forward_transform.inverse = SpectralTabular1D(
                 array[::-1], lookup_table=np.arange(len(array))[::-1])
 
-    class SpectralGWCS(GWCS):
-        def pixel_to_world(self, *args, **kwargs):
-            if orig_array.unit == '':
-                return u.Quantity(super().pixel_to_world_values(*args, **kwargs))
-            return super().pixel_to_world(*args, **kwargs).to(
-                orig_array.unit, equivalencies=u.spectral())
-
-    tabular_gwcs = SpectralGWCS(forward_transform=forward_transform,
+    tabular_gwcs = SpectralGWCS(original_unit = orig_array.unit,
+                                forward_transform=forward_transform,
                                 input_frame=coord_frame,
                                 output_frame=spec_frame)
 

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -9,6 +9,10 @@ from gwcs import coordinate_frames as cf
 
 
 class SpectralGWCS(GWCS):
+    """
+    This is a placeholder lookup-table GWCS created when a :class:`~specutils.Spectrum1D` is
+    instantiated with a ``spectral_axis`` and no WCS.
+    """
     def __init__(self, *args, **kwargs):
         self.original_unit = kwargs.pop("original_unit", "")
         super().__init__(*args, **kwargs)

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -13,6 +13,28 @@ class SpectralGWCS(GWCS):
         self.original_unit = kwargs.pop("original_unit", "")
         super().__init__(*args, **kwargs)
 
+    def copy(self):
+        """
+        Return a shallow copy of the object.
+
+        Convenience method so user doesn't have to import the
+        :mod:`copy` stdlib module.
+
+        .. warning::
+            Use `deepcopy` instead of `copy` unless you know why you need a
+            shallow copy.
+        """
+        return copy.copy(self)
+
+    def deepcopy(self):
+        """
+        Return a deep copy of the object.
+
+        Convenience method so user doesn't have to import the
+        :mod:`copy` stdlib module.
+        """
+        return copy.deepcopy(self)
+
     def pixel_to_world(self, *args, **kwargs):
         if self.original_unit == '':
             return u.Quantity(super().pixel_to_world_values(*args, **kwargs))


### PR DESCRIPTION
This has been needed for a long time - intended to fix #995 , #889 , #676. My current changes fix the behavior for a `Spectrum1D` initialized with a `spectral_axis`, but I think it needs a little more work to also fix it for one initialized with a `wcs`. Note that this also moves the `SpectralGWCS` out of `gwcs_from_array` so that it's actually accessible to check instances, since there are times we may want to do something different if that's the WCS type.