### PR TITLE
Truncate in template_comparison by default rather than nan_fill

### DIFF
--- a/specutils/analysis/template_comparison.py
+++ b/specutils/analysis/template_comparison.py
@@ -268,6 +268,7 @@ def template_redshift(observed_spectrum, template_spectrum, redshift,
     """
     chi2_min = None
     final_redshift = None
+    final_spectrum = None
     chi2_list = []
 
     redshift = np.array(redshift).reshape((np.array(redshift).size,))
@@ -294,5 +295,9 @@ def template_redshift(observed_spectrum, template_spectrum, redshift,
             chi2_min = chi2
             final_redshift = rs
             final_spectrum = redshifted_spectrum
+
+    if final_spectrum is None:
+        warnings.warn("Template spectrum and observed spectrum have no overlap after"
+                      "applying specified redshift(s) to template.")
 
     return final_spectrum, final_redshift, normalized_spectral_template, chi2_min, chi2_list

--- a/specutils/manipulation/resample.py
+++ b/specutils/manipulation/resample.py
@@ -57,7 +57,7 @@ class FluxConservingResampler(ResamplerBase):
     extrapolation_treatment : str
         What to do when resampling off the edge of the spectrum.  Can be
         ``'nan_fill'`` to have points beyond the edges by set to NaN,
-        ``'zero_fill'`` to set thoe points to zero, or ``'truncate'`` to
+        ``'zero_fill'`` to set those points to zero, or ``'truncate'`` to
         truncate any non-overlapping bins of the spectrum.
 
     Examples
@@ -126,7 +126,7 @@ class FluxConservingResampler(ResamplerBase):
 
         low_out_of_range = np.where(output_bin_edges < input_bin_edges[0])[0]
         if len(low_out_of_range) > 0:  # if any bins below wavelength range
-            min_idx = low_out_of_range[-1] + 1
+            min_idx = low_out_of_range[-1]  # This doesn't need +1 because bin_edges has len+1 compared to output_fluxes
             output_fluxes[:min_idx] = fill_val
             if errs is not None:
                 output_errs[:min_idx] = fill_val
@@ -374,7 +374,7 @@ class LinearInterpolatedResampler(ResamplerBase):
                                                           unit=orig_spectrum.unit)
 
         if self.extrapolation_treatment == 'truncate':
-            fin_spec_axis = fin_spec_axis[np.where(v)]
+            fin_spec_axis = fin_spec_axis[np.where(~np.isnan(out_flux))]
             new_unc = new_unc[np.where(~np.isnan(out_flux))]
             out_flux = out_flux[np.where(~np.isnan(out_flux))]
 

--- a/specutils/manipulation/resample.py
+++ b/specutils/manipulation/resample.py
@@ -104,12 +104,9 @@ class FluxConservingResampler(ResamplerBase):
             errors (if available).
         """
 
-        if self.extrapolation_treatment == 'nan_fill':
-            fill_val = np.nan  # bin_edges=nan_fill case
-        elif self.extrapolation_treatment == 'zero_fill':
+        fill_val = np.nan  # bin_edges=nan_fill case
+        if self.extrapolation_treatment == 'zero_fill':
             fill_val = 0
-        else:
-            fill_val = None
 
         # get bin edges from centers
         input_bin_edges = input_bin_centers.bin_edges.value
@@ -295,9 +292,9 @@ class FluxConservingResampler(ResamplerBase):
         fin_spec_axis = np.array(fin_spec_axis) << orig_spectrum.spectral_axis.unit
 
         if self.extrapolation_treatment == 'truncate':
-            fin_spec_axis = fin_spec_axis[np.where(output_fluxes != None)]
-            new_errs = new_errs[np.where(output_fluxes != None)]
-            output_fluxes = output_fluxes[np.where(output_fluxes != None)]
+            fin_spec_axis = fin_spec_axis[np.where(~np.isnan(output_fluxes))]
+            new_errs = new_errs[np.where(~np.isnan(output_fluxes))]
+            output_fluxes = output_fluxes[np.where(~np.isnan(output_fluxes))]
 
         resampled_spectrum = Spectrum1D(flux=output_fluxes,
                                         spectral_axis=fin_spec_axis,
@@ -358,12 +355,9 @@ class LinearInterpolatedResampler(ResamplerBase):
             An output spectrum containing the resampled `~specutils.Spectrum1D`
         """
 
-        if self.extrapolation_treatment == 'nan_fill':
-            fill_val = np.nan  # bin_edges=nan_fill case
-        elif self.extrapolation_treatment == 'zero_fill':
+        fill_val = np.nan  # bin_edges=nan_fill case
+        if self.extrapolation_treatment == 'zero_fill':
             fill_val = 0
-        else:
-            fill_val = None
 
         orig_axis_in_fin = orig_spectrum.spectral_axis.to(fin_spec_axis.unit)
 
@@ -380,9 +374,9 @@ class LinearInterpolatedResampler(ResamplerBase):
                                                           unit=orig_spectrum.unit)
 
         if self.extrapolation_treatment == 'truncate':
-            fin_spec_axis = fin_spec_axis[np.where(out_flux != None)]
-            new_unc = new_unc[np.where(out_flux != None)]
-            out_flux = out_flux[np.where(out_flux != None)]
+            fin_spec_axis = fin_spec_axis[np.where(v)]
+            new_unc = new_unc[np.where(~np.isnan(out_flux))]
+            out_flux = out_flux[np.where(~np.isnan(out_flux))]
 
         return Spectrum1D(spectral_axis=fin_spec_axis,
                           flux=out_flux,
@@ -455,11 +449,9 @@ class SplineInterpolatedResampler(ResamplerBase):
             out_unc_val = unc_spline(fin_spec_axis.value)
             new_unc = orig_spectrum.uncertainty.__class__(array=out_unc_val, unit=orig_spectrum.unit)
 
-        if self.extrapolation_treatment != 'nan_fill':
-            if self.extrapolation_treatment == 'zero_fill':
-                fill_val = 0
-            else:
-                fill_val = None
+        fill_val = np.nan
+        if self.extrapolation_treatment == 'zero_fill':
+            fill_val = 0
 
             origedges = orig_spectrum.spectral_axis.bin_edges
             off_edges = (fin_spec_axis < origedges[0]) | (origedges[-1] < fin_spec_axis)
@@ -468,9 +460,9 @@ class SplineInterpolatedResampler(ResamplerBase):
                 new_unc.array[off_edges] = fill_val
 
         if self.extrapolation_treatment == 'truncate':
-            fin_spec_axis = fin_spec_axis[np.where(out_flux_val != None)]
-            new_unc = new_unc[np.where(out_flux_val != None)]
-            out_flux_val = out_flux_val[np.where(out_flux_val != None)]
+            fin_spec_axis = fin_spec_axis[np.where(~np.isnan(out_flux_val))]
+            new_unc = new_unc[np.where(~np.isnan(out_flux_val))]
+            out_flux_val = out_flux_val[np.where(~np.isnan(out_flux_val))]
 
         return Spectrum1D(spectral_axis=fin_spec_axis,
                           flux=out_flux_val*orig_spectrum.flux.unit,

--- a/specutils/tests/test_template_comparison.py
+++ b/specutils/tests/test_template_comparison.py
@@ -29,16 +29,11 @@ def test_template_match_no_overlap():
                        uncertainty=StdDevUncertainty(np.random.sample(50), unit='Jy'))
 
     # Get result from template_match
-    tm_result = template_comparison.template_match(spec, spec1)
-    assert tm_result[3] == 0.0
+    with pytest.warns(UserWarning, match="Template spectrum has no overlap with observed spectrum"):
+        tm_result = template_comparison.template_match(spec, spec1)
+    assert np.isnan(tm_result[3])
 
-    # Create new spectrum for comparison
-    spec_result = Spectrum1D(spectral_axis=spec_axis,
-                             flux=spec1.flux * template_comparison._normalize_for_template_matching(spec, spec1))
-    try:
-        assert quantity_allclose(tm_result[0].flux, spec_result.flux, atol=0.01*u.Jy)
-    except AssertionError:
-        pytest.xfail('TODO: investigate why this is failing')
+    assert tm_result[0] is None
 
 
 def test_template_match_minimal_overlap():

--- a/specutils/tests/test_template_comparison.py
+++ b/specutils/tests/test_template_comparison.py
@@ -18,7 +18,7 @@ def test_template_match_no_overlap():
 
     # Create test spectra
     spec_axis = np.linspace(0, 50, 50) * u.AA
-    spec_axis_no_overlap = np.linspace(51, 102, 50) * u.AA
+    spec_axis_no_overlap = np.linspace(52, 103, 50) * u.AA
 
     spec = Spectrum1D(spectral_axis=spec_axis,
                       flux=np.random.randn(50) * u.Jy,
@@ -31,6 +31,7 @@ def test_template_match_no_overlap():
     # Get result from template_match
     with pytest.warns(UserWarning, match="Template spectrum has no overlap with observed spectrum"):
         tm_result = template_comparison.template_match(spec, spec1)
+
     assert np.isnan(tm_result[3])
 
     assert tm_result[0] is None
@@ -51,24 +52,19 @@ def test_template_match_minimal_overlap():
     spec_axis_min_overlap[0] = 51.0 * u.AA
 
     spec = Spectrum1D(spectral_axis=spec_axis,
-                      flux=np.random.randn(50) * u.Jy,
+                      flux=abs(np.random.randn(50)) * u.Jy,
                       uncertainty=StdDevUncertainty(np.random.sample(50), unit='Jy'))
 
     spec1 = Spectrum1D(spectral_axis=spec_axis_min_overlap,
-                       flux=np.random.randn(50) * u.Jy,
+                       flux=abs(np.random.randn(50)) * u.Jy,
                        uncertainty=StdDevUncertainty(np.random.sample(50), unit='Jy'))
 
     # Get result from template_match
     tm_result = template_comparison.template_match(spec, spec1)
-    assert tm_result[3] == 0.0
+    np.testing.assert_almost_equal(tm_result[3], 0)
 
-    # Create new spectrum for comparison
-    spec_result = Spectrum1D(spectral_axis=spec_axis,
-                             flux=spec1.flux * template_comparison._normalize_for_template_matching(spec, spec1))
-    try:
-        assert quantity_allclose(tm_result[0].flux, spec_result.flux, atol=0.01*u.Jy)
-    except AssertionError:
-        pytest.xfail('TODO: investigate why all elements in tm_result[0] are NaN even with overlap')
+    assert len(tm_result[0].flux) == 1
+    assert quantity_allclose(tm_result[0].flux, 1.763*u.Jy, atol=0.01*u.Jy)
 
 
 def test_template_match_spectrum():
@@ -327,7 +323,7 @@ def test_template_redshift_with_multiple_template_spectra_in_match():
     # TODO: Determine cause of and fix failing assert
     # np.testing.assert_almost_equal(tm_result[1], redshift)
 
-    np.testing.assert_almost_equal(tm_result[3], 1172.135458895792)
+    np.testing.assert_almost_equal(tm_result[3], 1172.1446112796834)
 
     # When a spectrum collection is matched with a redshift
     # grid, a list-of-lists is returned with the trial chi2


### PR DESCRIPTION
Implements the suggestion given in #653. One thing I changed here, which I'm not sure of, is that the returned template is now resampled onto the observed spectrum's spectral axis, in addition to being normalized as previous. Opening as draft since I still need to update the docs, and I'll probably need to add a bit more test coverage.