### PR TITLE
Change new_flux_unit to with_flux unit

### DIFF
--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -80,10 +80,14 @@ class OneDSpectrumMixin():
         """
         return u.Quantity(self.data, unit=self.unit, copy=False)
 
+    @deprecated('v1.13', alternative="with_flux_unit")
     def new_flux_unit(self, unit, equivalencies=None, suppress_conversion=False):
+        return self.with_flux_unit(unit, equivalencies=equivalencies,
+                                  suppress_conversion=suppress_conversion)
+
+    def with_flux_unit(self, unit, equivalencies=None, suppress_conversion=False):
         """
-        Converts the flux data to the specified unit.  This is an in-place
-        change to the object.
+        Returns a new spectrum with a different flux unit
 
         Parameters
         ----------

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -277,12 +277,12 @@ def test_flux_unit_conversion():
 
     # Simple Unit Conversion
     s = Spectrum1D(flux=np.array([26.0, 44.5]) * u.Jy, spectral_axis=np.array([400, 500])*u.nm)
-    converted_spec = s.new_flux_unit(unit=u.uJy)
+    converted_spec = s.with_flux_unit(unit=u.uJy)
     assert ((26.0 * u.Jy).to(u.uJy) == converted_spec.flux[0])
 
     # Make sure incompatible units raise UnitConversionError
     with pytest.raises(u.UnitConversionError):
-        s.new_flux_unit(unit=u.m)
+        s.with_flux_unit(unit=u.m)
 
     # Pass custom equivalencies
     s = Spectrum1D(flux=np.array([26.0, 44.5]) * u.Jy,
@@ -290,12 +290,12 @@ def test_flux_unit_conversion():
     eq = [[u.Jy, u.m,
           lambda x: np.full_like(np.array(x), 1000.0, dtype=np.double),
           lambda x: np.full_like(np.array(x), 0.001, dtype=np.double)]]
-    converted_spec = s.new_flux_unit(unit=u.m, equivalencies=eq)
+    converted_spec = s.with_flux_unit(unit=u.m, equivalencies=eq)
     assert 1000.0 * u.m == converted_spec.flux[0]
 
     # Check if suppressing the unit conversion works
     s = Spectrum1D(flux=np.array([26.0, 44.5]) * u.Jy, spectral_axis=np.array([400, 500]) * u.nm)
-    new_spec = s.new_flux_unit("uJy", suppress_conversion=True)
+    new_spec = s.with_flux_unit("uJy", suppress_conversion=True)
     assert new_spec.flux[0] == 26.0 * u.uJy
 
 


### PR DESCRIPTION
I was cleaning up some old issues and noticed #890, this addresses that by making the function analogous to the updated `with_spectral_axis_unit` and correcting the docstring. Would have been nice to get this into 1.13.0 but thems the breaks.

Closes #890.