### PR TITLE
Update MANGA urls in tests

### DIFF
--- a/docs/identify.rst
+++ b/docs/identify.rst
@@ -21,7 +21,7 @@ For eample, to identify a SDSS MaNGA data cube file:
     >>> from astropy.utils.data import download_file
     >>> from specutils.io.registers import identify_spectrum_format
     >>>
-    >>> url = 'https://dr15.sdss.org/sas/dr15/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
+    >>> url = 'https://dr17.sdss.org/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
     >>> dd = download_file(url)  # doctest: +REMOTE_DATA
     >>> identify_spectrum_format(dd)  # doctest: +REMOTE_DATA
     'MaNGA cube'

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -143,7 +143,7 @@ def test_hst_stis(remote_data_path):
 
 @pytest.mark.remote_data
 def test_manga_cube():
-    url = 'https://dr15.sdss.org/sas/dr15/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
+    url = 'https://dr17.sdss.org/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
     spec = Spectrum1D.read(url, format='MaNGA cube')
 
     assert isinstance(spec, Spectrum1D)
@@ -154,7 +154,7 @@ def test_manga_cube():
 
 @pytest.mark.remote_data
 def test_manga_rss():
-    url = 'https://dr15.sdss.org/sas/dr15/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGRSS.fits.gz'
+    url = 'https://dr17.sdss.org/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGRSS.fits.gz'
     spec = Spectrum1D.read(url, format='MaNGA rss')
 
     assert isinstance(spec, Spectrum1D)


### PR DESCRIPTION
Update urls from data release 15 to data release 17 so that remote data tests pass again.