### PR TITLE
BUG: adjust copy semantics for compatibility with numpy 2

### DIFF
--- a/specutils/utils/quantity_model.py
+++ b/specutils/utils/quantity_model.py
@@ -1,6 +1,9 @@
+import numpy as np
 from astropy import units as u
 
 __all__ = ['QuantityModel']
+
+_NUMPY_COPY_IF_NEEDED = False if np.__version__.startswith("1.") else None
 
 
 class QuantityModel:
@@ -72,4 +75,4 @@ class QuantityModel:
     def __call__(self, x, *args, **kwargs):
         unitlessx = x.to(self.input_units).value
         result = self.unitless_model(unitlessx, *args, **kwargs)
-        return u.Quantity(result, self.return_units, copy=False)
+        return u.Quantity(result, self.return_units, copy=_NUMPY_COPY_IF_NEEDED)


### PR DESCRIPTION
See https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword

This fixes a test failure that I saw locally, though oddly enough it doesn't seem to have shown in CI yet
Reprod:
```
pytest specutils/tests/test_utils.py::test_quantity_model
```