### PR TITLE
Fix moment 0 calculation for spectral axis that isn't last, update spatial moment

### DIFF
--- a/specutils/analysis/moment.py
+++ b/specutils/analysis/moment.py
@@ -51,6 +51,9 @@ def _compute_moment(spectrum, regions=None, order=0, axis='spectral'):
     """
     This is a helper function for the above `moment()` method.
     """
+    if order is None or order < 0:
+        return None
+
     if axis == "spectral":
         if isinstance(spectrum, SpectrumCollection):
             axes = [spec.spectral_axis_index for spec in spectrum]
@@ -71,23 +74,29 @@ def _compute_moment(spectrum, regions=None, order=0, axis='spectral'):
     # Ignore masks for now. This should be fully addressed when
     # specutils gets revamped to handle multi-dimensional masks.
     flux = calc_spectrum.flux
+
     spectral_axis = calc_spectrum.spectral_axis
+    # If axis is not the spectral axis, we simply use pixel values for dx and dispersion
+    if (axis != spectrum.spectral_axis_index and
+            not (axis == -1 and spectrum.spectral_axis_index == spectrum.flux.ndim-1)):
+        dx = np.ones(flux.shape[axis])
+        dispersion = np.arange(flux.shape[axis]) + 1
+    else:
+        dx = np.abs(np.diff(spectral_axis.bin_edges))
+        dispersion = spectral_axis
 
-    if order is None or order < 0:
-        return None
+    # We now have to account for the desired axis being anywhere, not always last
+    if len(flux.shape) > len(spectral_axis.shape):
+        for i in range(flux.ndim):
+            if i != axis:
+                dx = np.expand_dims(dx, i)
+                dx = np.repeat(dx, flux.shape[i], i)
+                dispersion = np.expand_dims(dispersion, i)
+                dispersion = np.repeat(dispersion, flux.shape[i], i)
 
-    dx = np.abs(np.diff(spectral_axis.bin_edges))
     m0 = np.sum(flux * dx, axis=axis)
     if order == 0:
         return m0
-
-    dispersion = spectral_axis
-    # We now have to account for the spectral axis being anywhere, not always last
-    if len(flux.shape) > len(spectral_axis.shape):
-        for i in range(flux.ndim):
-            if i != calc_spectrum.spectral_axis_index:
-                dispersion = np.expand_dims(dispersion, i)
-                dispersion = np.repeat(dispersion, flux.shape[i], i)
 
     if order == 1:
         return np.sum(flux * dispersion * dx, axis=axis) / m0

--- a/specutils/tests/test_analysis.py
+++ b/specutils/tests/test_analysis.py
@@ -1116,12 +1116,12 @@ def test_moment_cube():
     assert moment_1_last.unit.is_equivalent(moment_1.unit)
     assert quantity_allclose(moment_1, moment_1_last, rtol=1.E-5)
 
-    # spatial 1st order - returns the dispersion
+    # spatial 1st order
     moment_1 = moment(spectrum, order=1, axis=1)
 
     assert moment_1.shape == (9, 10000)
-    assert moment_1.unit.is_equivalent(u.GHz)
-    assert quantity_allclose(moment_1, frequencies, rtol=1.E-5)
+    assert moment_1.unit.is_equivalent(u.dimensionless_unscaled)
+    assert quantity_allclose(moment_1, np.ones((9, 10000))*5.5, rtol=1.E-5)
 
     # higher order
     moment_2 = moment(spectrum, order=2)
@@ -1162,11 +1162,11 @@ def test_moment_cube_order_2():
     moment_2 = moment(spectrum, order=2, axis=1)
 
     assert moment_2.shape == (10, 10000)
-    assert moment_2.unit.is_equivalent(u.GHz**2)
+    assert moment_2.unit.is_equivalent(u.dimensionless_unscaled)
     # check assorted values.
-    assert quantity_allclose(moment_2[0][0], 8.078e-28*u.GHz**2, rtol=0.01)
-    assert quantity_allclose(moment_2[1][0], 8.078e-28*u.GHz**2, rtol=0.01)
-    assert quantity_allclose(moment_2[0][3], 2.019e-28*u.GHz**2, rtol=0.01)
+    assert quantity_allclose(moment_2[0][0], 8.25, rtol=0.01)
+    assert quantity_allclose(moment_2[1][0], 8.25, rtol=0.01)
+    assert quantity_allclose(moment_2[0][3], 8.25, rtol=0.01)
 
 
 def test_moment_cube_order_1_to_6():


### PR DESCRIPTION
Non-spectral axis moments now use pixel values, previously they incorrectly still used the spectral axis for `dx` and `dispersion` and then simply did the final sums over the specified axis. It still may be reasonable to just get rid of non-spectral moments as discussed in https://github.com/astropy/specutils/issues/930.