### PR TITLE
Change default refraction_index method 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- ``utils.wcs_utils.refraction_index`` (and thus ``air_to_vac`` and ``vac_to_air``)
+  now defaults to ``Morton2000`` as the method instead of ``Griesen2006``. [#1169]
+
 1.16.0 (2024-08-08)
 -------------------
 

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -90,7 +90,7 @@ def refraction_index(wavelength, method='Morton2000', co2=None):
     VALID_METHODS = ['Griesen2006', 'Edlen1953', 'Edlen1966', 'Morton2000',
                      'PeckReeder1972', 'Ciddor1996']
     assert isinstance(method, str), 'method must be a string'
-    if method != 'Griesen2006' and wavelength.min() < 250 * u.nm:
+    if method != 'Griesen2006' and wavelength.min() < 200 * u.nm:
         raise ValueError("The chosen method is invalid for wavelengths below 250 nm."
                          " 'Griesen2006' is the only option for this wavelength range -"
                          " see the specutils.utils.wcs_utils.refraction_index docstring"

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -60,7 +60,7 @@ def refraction_index(wavelength, method='Morton2000', co2=None):
         'Morton2000' (default) - from Morton (2000, ApJS, 130, 403), eqn 8. Used by VALD,
             the Vienna Atomic Line Database. Very similar to Edlen (1966).
         'Griesen2006' - from Greisen et al. (2006, A&A 446, 747),
-            eqn. 65, standard used by International Unionof Geodesy and Geophysics
+            eqn. 65, standard used by International Union of Geodesy and Geophysics
         'Edlen1953' - from Edlen (1953, J. Opt. Soc. Am, 43, 339). Standard
             adopted by IAU (resolution No. C15, Commission 44, XXI GA, 1991),
             which refers to Oosterhoff (1957) that uses Edlen (1953). Also used


### PR DESCRIPTION
Closes #1162. It seems to me that we should use one of the consistent methods when possible, rather than the outlier (having no reason to believe that it's `Griesen2006` that is correct while all the other methods are wrong). This makes us consistent with the IAU, SDSS, VALD, etc.