### PR TITLE
Fix bug handling subregions in true_excise

### DIFF
--- a/specutils/manipulation/utils.py
+++ b/specutils/manipulation/utils.py
@@ -43,7 +43,7 @@ def true_exciser(spectrum, region):
 
     for subregion in region:
         # Find the indices of the spectral_axis array corresponding to the subregion
-        region_mask = (spectral_axis >= region.lower) & (spectral_axis < region.upper)
+        region_mask = (spectral_axis >= subregion.lower) & (spectral_axis < subregion.upper)
         temp_indices = np.nonzero(region_mask)[0]
         if excise_indices is None:
             excise_indices = temp_indices


### PR DESCRIPTION
Looking into #1167 led me to realize that the subregion handling in `true_excise` was actually using the upper and lower bounds from the full region rather than each subregion. This fixes that. I'll add a test tomorrow that would have caught this, since right now it looks like all tests still pass with the change.