### PR TITLE
Replace LevMarLSQFitter with TRFLSQFitter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Replaced ``LevMarLSQFitter`` with ``TRFLSQFitter`` as the former is no longer
+  recommended by ``astropy``. [#1180]
+
 1.17.0 (2024-10-04)
 -------------------
 

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -199,7 +199,7 @@ each parameter, but that is optional.
 
 The `~specutils.fitting.fit_lines` function takes as input the spectrum to be fit
 and the set of models with initial guesses, and by default uses the
-`~astropy.modeling.fitting.LevMarLSQFitter` to perform the fit. You may override
+`~astropy.modeling.fitting.TRFLSQFitter` to perform the fit. You may override
 this by providing a different fitter to the ``fitter`` input parameter.  Note
 that the default fitter will populate the ``stds`` attribute of the returned
 models with estimates of the standard deviation uncertainty in the fit parameters,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,7 +97,7 @@ may have downloaded from some archive, or reduced from your own observations.
     >>> from specutils import SpectralRegion
     >>> from specutils.analysis import equivalent_width
     >>> equivalent_width(cont_norm_spec, regions=SpectralRegion(6562 * u.AA, 6575 * u.AA)) # doctest: +REMOTE_DATA +FLOAT_CMP
-    <Quantity -14.7396 Angstrom>
+    <Quantity -14.82013888 Angstrom>
 
 
 While there are other tools and spectral representations detailed more below,

--- a/docs/manipulation.rst
+++ b/docs/manipulation.rst
@@ -403,8 +403,8 @@ A model fitted over the region can also be used to replace the spectrum flux val
     >>> region = SpectralRegion(3.5*u.AA, 7.1*u.AA)
     >>> result = model_replace(input_spectrum, region, model=fitted_model)
     >>> result  # doctest: +FLOAT_CMP
-    <Spectrum1D(flux=<Quantity [1.        , 1.1       , 0.9       , 4.40801804, 9.58271877,
-               5.61238054, 0.88556096, 1.        , 1.2       , 1.1       ] mJy> (shape=(10,), mean=2.67887 mJy); spectral_axis=<SpectralAxis [ 1.  2.  3. ...  8.  9. 10.] Angstrom> (length=10))>
+    <Spectrum1D(flux=<Quantity [1.        , 1.1       , 0.9       , 4.40803188, 9.58269826,
+               5.61240079, 0.88557902, 1.        , 1.2       , 1.1       ] mJy> (shape=(10,), mean=2.67887 mJy); spectral_axis=<SpectralAxis [ 1.  2.  3. ...  8.  9. 10.] Angstrom> (length=10))>
 
 Reference/API
 -------------

--- a/specutils/fitting/continuum.py
+++ b/specutils/fitting/continuum.py
@@ -1,6 +1,6 @@
 import astropy.units as u
 from astropy.modeling.polynomial import Chebyshev1D
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 
 from ..fitting import fit_lines
 from ..manipulation.smoothing import median_smooth
@@ -11,7 +11,7 @@ __all__ = ['fit_continuum', 'fit_generic_continuum']
 
 
 def fit_generic_continuum(spectrum, median_window=3, model=Chebyshev1D(3),
-                          fitter=LevMarLSQFitter(),
+                          fitter=TRFLSQFitter(),
                           exclude_regions=None, weights=None):
     """
     Basic fitting of the continuum of an input spectrum. The input
@@ -29,7 +29,7 @@ def fit_generic_continuum(spectrum, median_window=3, model=Chebyshev1D(3),
         `~scipy.signal.medfilt` for more information.
     fitter : `~astropy.fitting._FitterMeta`
         The astropy fitter to use for fitting the model.
-        Default: `~astropy.modeling.fitting.LevMarLSQFitter`
+        Default: `~astropy.modeling.fitting.TRFLSQFitter`
     exclude_regions : list of 2-tuples
         List of regions to exclude in the fitting. Passed through
         to the fitmodels routine.
@@ -56,7 +56,7 @@ def fit_generic_continuum(spectrum, median_window=3, model=Chebyshev1D(3),
                          exclude_regions=exclude_regions, weights=weights)
 
 
-def fit_continuum(spectrum, model=Chebyshev1D(3), fitter=LevMarLSQFitter(),
+def fit_continuum(spectrum, model=Chebyshev1D(3), fitter=TRFLSQFitter(),
                   exclude_regions=None, exclude_region_upper_bounds=False,
                   window=None, weights=None):
     """
@@ -71,7 +71,7 @@ def fit_continuum(spectrum, model=Chebyshev1D(3), fitter=LevMarLSQFitter(),
         The list of models that contain the initial guess.
     fitter : `~astropy.fitting._FitterMeta`
         The astropy fitter to use for fitting the model.
-        Default: `~astropy.modeling.fitting.LevMarLSQFitter`
+        Default: `~astropy.modeling.fitting.TRFLSQFitter`
     exclude_regions : list of 2-tuples
         List of regions to exclude in the fitting. Passed through
         to the fitmodels routine.

--- a/specutils/fitting/fitmodels.py
+++ b/specutils/fitting/fitmodels.py
@@ -258,7 +258,7 @@ def _generate_line_list_table(spectrum, emission_inds, absorption_inds):
     return qtable
 
 
-def fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertainties=True),
+def fit_lines(spectrum, model, fitter=fitting.TRFLSQFitter(calc_uncertainties=True),
               exclude_regions=None, exclude_region_upper_bounds=False, weights=None,
               window=None, get_fit_info=False, **kwargs):
     """
@@ -382,7 +382,7 @@ def fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertainties
     return fitted_models
 
 
-def _fit_lines(spectrum, model, fitter=fitting.LevMarLSQFitter(calc_uncertainties=True),
+def _fit_lines(spectrum, model, fitter=fitting.TRFLSQFitter(calc_uncertainties=True),
                exclude_regions=None, exclude_region_upper_bounds=False, weights=None,
                window=None, get_fit_info=False, ignore_units=False, **kwargs):
     """

--- a/specutils/tests/test_model_replace.py
+++ b/specutils/tests/test_model_replace.py
@@ -126,8 +126,8 @@ def test_from_fitted_model():
     assert result.uncertainty is None
     assert result.flux.unit == input_spectrum.flux.unit
 
-    expected_flux = np.array([1., 1.1, 0.9, 4.40801804, 9.58271877,
-                              5.61238054, 0.88556096, 1., 1.2, 1.1]) * u.mJy
+    expected_flux = np.array([1, 1.1, 0.9, 4.408032, 9.582698,
+                              5.612401, 0.885579, 1, 1.2, 1.1]) * u.mJy
 
     assert_quantity_allclose(result.flux, expected_flux)
     assert_quantity_allclose(result.spectral_axis, input_spectrum.spectral_axis)


### PR DESCRIPTION
Related PRs:

* https://github.com/astropy/astropy/pull/16983
* https://github.com/astropy/photutils/pull/1899
* https://github.com/spacetelescope/jdaviz/pull/3202

`TRFLSQFitter` also has `calc_uncertainties` and should respect bounds.

Fix https://github.com/astropy/specutils/issues/1172