### PR TITLE
Fix spline interpolation between different unit physical types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Bug Fixes
 
 - Fixed automatic format detection for SDSS-V ``SpectrumList`` default loaders. [#1185]
 
+- Fixed ``SplineInterpolatedResampler`` when input and output spectral axes are different
+  physical types, e.g. wavelength and velocity. [#1190]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -34,7 +37,6 @@ Bug Fixes
 
 - Fixed extracting a spectral region when one of spectrum/region is in wavelength
   and the other is in frequency units. [#1187]
-
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/specutils/manipulation/resample.py
+++ b/specutils/manipulation/resample.py
@@ -461,7 +461,7 @@ class SplineInterpolatedResampler(ResamplerBase):
         if self.extrapolation_treatment == 'zero_fill':
             fill_val = 0
 
-        orig_edges = orig_spectrum.spectral_axis.bin_edges
+        orig_edges = orig_axis_in_new.bin_edges
         off_edges = (fin_spec_axis < np.min(orig_edges)) | (np.max(orig_edges) < fin_spec_axis)
         out_flux_val[off_edges] = fill_val
         if new_unc is not None:


### PR DESCRIPTION
Fixes #1186. Part of this accidentally snuck into a commit on `main` while I was doing the last release 😬 (changing from index 0 to using min and max) but this completes the fix. @StuartLittlefair would you confirm that you get what you expected in #1186 with this fix?