### PR TITLE
Use the APE 14 specified API in some of the tests

### DIFF
--- a/docs/spectral_regions.rst
+++ b/docs/spectral_regions.rst
@@ -327,6 +327,11 @@ to create a new `~specutils.SpectralRegion` using the ``read`` class method:
 
     >>> spec_reg = SpectralRegion.read("spectral_region.ecsv")
 
+.. testcleanup::
+
+    >>> import os
+    >>> os.remove("spectral_region.ecsv")
+
 The `~astropy.table.QTable` created to write out the `~specutils.SpectralRegion` to file can also be accessed
 directly with the ``as_table`` method, and a `~specutils.SpectralRegion` can be created directly from a `~astropy.table.QTable`
 with the appropriate columns (minimally ``lower_bound`` and ``upper_bound``) using the ``from_qtable`` class method.

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -191,10 +191,11 @@ def test_from_list_list():
         assert_quantity_allclose(reg, (spec_reg[i].lower, spec_reg[i].upper))
 
 
-def test_read_write():
+def test_read_write(tmp_path):
+    path = tmp_path / "test_sr.ecsv"
     sr = SpectralRegion([(0.45*u.um, 0.6*u.um), (0.8*u.um, 0.9*u.um)])
-    sr.write("test_sr.ecsv")
-    sr2 = SpectralRegion.read("test_sr.ecsv")
+    sr.write(str(path))
+    sr2 = SpectralRegion.read(path)
     assert list(sr2.as_table().columns) == ["lower_bound", "upper_bound"]
 
     sr3 = SpectralRegion.from_qtable(sr2.as_table())

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -318,7 +318,7 @@ def test_wcs_transformations():
     spec = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm,
                       flux=np.ones(49) * u.Jy)
 
-    pix_axis = spec.wcs.world_to_pixel(np.arange(20, 30) * u.nm)
+    pix_axis = spec.wcs.world_to_pixel_values(np.arange(20, 30) * u.nm)
     disp_axis = spec.wcs.pixel_to_world(np.arange(20, 30))
 
     assert isinstance(pix_axis, np.ndarray)
@@ -326,7 +326,7 @@ def test_wcs_transformations():
 
     # Test transform with different unit
     with u.set_enabled_equivalencies(u.spectral()):
-        spec.wcs.world_to_pixel(np.arange(20, 30) * u.GHz)
+        spec.wcs.world_to_pixel_values(np.arange(20, 30) * u.GHz)
 
     # Test with a FITS WCS
     my_wcs = fitswcs.WCS(header={'CDELT1': 1, 'CRVAL1': 6562.8, 'CUNIT1': 'Angstrom',

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -318,7 +318,9 @@ def test_wcs_transformations():
     spec = Spectrum1D(spectral_axis=np.arange(1, 50) * u.nm,
                       flux=np.ones(49) * u.Jy)
 
-    pix_axis = spec.wcs.world_to_pixel_values(np.arange(20, 30) * u.nm)
+    # After spacetelescope/gwcs#457 is merged and released, this can be changed to
+    # pix_axis = spec.wcs.world_to_pixel_values(np.arange(20, 30) * u.nm)
+    pix_axis = spec.wcs.world_to_pixel(SpectralCoord(np.arange(20, 30) * u.nm))
     disp_axis = spec.wcs.pixel_to_world(np.arange(20, 30))
 
     assert isinstance(pix_axis, np.ndarray)
@@ -326,7 +328,9 @@ def test_wcs_transformations():
 
     # Test transform with different unit
     with u.set_enabled_equivalencies(u.spectral()):
-        spec.wcs.world_to_pixel_values(np.arange(20, 30) * u.GHz)
+        # After spacetelescope/gwcs#457 is merged and released, this can be changed to
+        # spec.wcs.world_to_pixel_values(np.arange(20, 30) * u.GHz)
+        spec.wcs.world_to_pixel(SpectralCoord(np.arange(20, 30) * u.GHz))
 
     # Test with a FITS WCS
     my_wcs = fitswcs.WCS(header={'CDELT1': 1, 'CRVAL1': 6562.8, 'CUNIT1': 'Angstrom',


### PR DESCRIPTION
spacetelescope/gwcs#457 corrects an oversight in the APE 14 related API, where "low-level" inputs were accepted by the "high-level" api. This PR simply swaps the usage in specutils from using the "high-level" with "low-level" inputs to using the proper "low-level" API.

Also, I updated the tests so that files generated by the tests get cleaned up by pytest.