### PR TITLE
Use exact domain limits for polynomial wavelength solutions in _read_non_linear_iraf_wcs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Fixed loaders for IRAF-encoded non-linear Chebychev + Legendre wavelength
+  solutions that were imposing integer-valued domain limits. [#1199]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Fixes #1196; as described in https://github.com/astropy/specutils/issues/1196#issuecomment-2502026350 the domain limits `pmin`, `pmax` for constructing the Chebychev or Legendre series were truncated to `int` instead of allowing floating-point values as used and written by IRAF.
This will change the `spectral_axis` read in for such spectra (see tests for comparison to the old behaviour), but labelling as a bug fix as IRAF evidently reproduces this model.