### PR TITLE
Fix for gwcs inverse transform with a bounding_box

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     numpy>=1.24
     scipy>=1.3
     astropy>=5.1
-    gwcs>=0.18
+    gwcs @ git+https://github.com/nden/gwcs.git@inverse-bbox
     asdf-astropy>=0.3
     asdf>=2.14.4
     ndcube>=2.0

--- a/specutils/tests/test_spectrum1d.py
+++ b/specutils/tests/test_spectrum1d.py
@@ -330,7 +330,7 @@ def test_wcs_transformations():
     with u.set_enabled_equivalencies(u.spectral()):
         # After spacetelescope/gwcs#457 is merged and released, this can be changed to
         # spec.wcs.world_to_pixel_values(np.arange(20, 30) * u.GHz)
-        spec.wcs.world_to_pixel(SpectralCoord(np.arange(20, 30) * u.GHz))
+        spec.wcs.world_to_pixel(SpectralCoord(np.arange(6.9e6, 1e7) * u.GHz))
 
     # Test with a FITS WCS
     my_wcs = fitswcs.WCS(header={'CDELT1': 1, 'CRVAL1': 6562.8, 'CUNIT1': 'Angstrom',


### PR DESCRIPTION
This PR fixes a test where the input passed to the inverse transform is out of bounds. It should be merged after gwcs#498.
More specifically the footprint defined by the test WCS is [1, 49]*u.nm. 
The input passed is in GHz and well outside this footprint. As a result the Tabular model in the WCS errors with "out of bounds" . This PR adjust the input values to be within the footprint.
As a side note, I found it is best to define Tabular model with `bounds_error=False, fill_value=np.nan`. In this case an error is not raised and the value returned when out of bounds is NaN which is more in line with the WCS philosophy.