### PR TITLE
Refactor gwcs_from_array to provide ND GWCS in ND flux case

### DIFF
--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -832,14 +832,16 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
     def _other_as_correct_class(self, other):
         # NDArithmetic mixin will try to turn other into a Spectrum, which will fail
         # sometimes because of not specifiying the spectral axis index
-        flux = u.Quantity(other, unit=self.unit)
-        if flux.ndim > 1 and flux.shape == self.shape:
-            return Spectrum(flux=flux, spectral_axis=self.spectral_axis,
+        if not isinstance(other, u.Quantity):
+            other = u.Quantity(other, unit=self.unit)
+        if other.ndim > 1 and other.shape == self.shape:
+            print("Making other operator a Spectrum")
+            return Spectrum(flux=other, spectral_axis=self.spectral_axis,
                             spectral_axis_index=self.spectral_axis_index)
-        return flux
+        return other
 
     def __add__(self, other):
-        if not isinstance(other, (NDCube, u.Quantity)):
+        if not isinstance(other, (Spectrum)):
             try:
                 other = self._other_as_correct_class(other)
             except TypeError:
@@ -848,7 +850,7 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         return self._return_with_redshift(self.add(other))
 
     def __sub__(self, other):
-        if not isinstance(other, NDCube):
+        if not isinstance(other, Spectrum):
             try:
                 other = self._other_as_correct_class(other)
             except TypeError:
@@ -857,19 +859,19 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         return self._return_with_redshift(self.subtract(other))
 
     def __mul__(self, other):
-        if not isinstance(other, NDCube):
+        if not isinstance(other, Spectrum):
             other = self._other_as_correct_class(other)
 
         return self._return_with_redshift(self.multiply(other))
 
     def __div__(self, other):
-        if not isinstance(other, NDCube):
+        if not isinstance(other, Spectrum):
             other = self._other_as_correct_class(other)
 
         return self._return_with_redshift(self.divide(other))
 
     def __truediv__(self, other):
-        if not isinstance(other, NDCube):
+        if not isinstance(other, Spectrum):
             other = self._other_as_correct_class(other)
 
         return self._return_with_redshift(self.divide(other))

--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -845,7 +845,7 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
             except TypeError:
                 return NotImplemented
 
-        return self._return_with_redshift(self.add(other, spectral_axis_index=self.spectral_axis_index))  # noqa
+        return self._return_with_redshift(self.add(other))
 
     def __sub__(self, other):
         if not isinstance(other, NDCube):
@@ -854,25 +854,25 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
             except TypeError:
                 return NotImplemented
 
-        return self._return_with_redshift(self.subtract(other, spectral_axis_index=self.spectral_axis_index))  # noqa
+        return self._return_with_redshift(self.subtract(other))
 
     def __mul__(self, other):
         if not isinstance(other, NDCube):
             other = self._other_as_correct_class(other)
 
-        return self._return_with_redshift(self.multiply(other, spectral_axis_index=self.spectral_axis_index))  # noqa
+        return self._return_with_redshift(self.multiply(other))
 
     def __div__(self, other):
         if not isinstance(other, NDCube):
             other = self._other_as_correct_class(other)
 
-        return self._return_with_redshift(self.divide(other, spectral_axis_index=self.spectral_axis_index))  # noqa
+        return self._return_with_redshift(self.divide(other))
 
     def __truediv__(self, other):
         if not isinstance(other, NDCube):
             other = self._other_as_correct_class(other)
 
-        return self._return_with_redshift(self.divide(other, spectral_axis_index=self.spectral_axis_index))  # noqa
+        return self._return_with_redshift(self.divide(other))
 
     __radd__ = __add__
 

--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -837,8 +837,8 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         if not isinstance(other, u.Quantity):
             other = u.Quantity(other, unit=self.unit)
         if other.shape == self.shape:
-                return Spectrum(flux=other, spectral_axis=self.spectral_axis,
-                                spectral_axis_index=self.spectral_axis_index)
+            return Spectrum(flux=other, spectral_axis=self.spectral_axis,
+                            spectral_axis_index=self.spectral_axis_index)
 
         return other
 

--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -654,7 +654,9 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         elif isinstance(axis, tuple) and self.spectral_axis_index in axis:
             return collapsed_flux
         else:
-            return Spectrum(collapsed_flux, wcs=self.wcs)
+            # Pass the spectral axis rather than WCS in this case, so we don't have to
+            # figure out which part of a multidimensional WCS is the spectral part.
+            return Spectrum(collapsed_flux, spectral_axis=self.spectral_axis)
 
     def mean(self, **kwargs):
         return self.collapse("mean", **kwargs)

--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -834,10 +834,10 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         # sometimes because of not specifiying the spectral axis index
         if not isinstance(other, u.Quantity):
             other = u.Quantity(other, unit=self.unit)
-        if other.ndim > 1 and other.shape == self.shape:
-            print("Making other operator a Spectrum")
-            return Spectrum(flux=other, spectral_axis=self.spectral_axis,
-                            spectral_axis_index=self.spectral_axis_index)
+        if other.shape == self.shape:
+                return Spectrum(flux=other, spectral_axis=self.spectral_axis,
+                                spectral_axis_index=self.spectral_axis_index)
+
         return other
 
     def __add__(self, other):

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -114,7 +114,7 @@ class SpectrumCollection(NDIOMixin):
 
         return Spectrum(flux=flux, spectral_axis=spectral_axis,
                           uncertainty=uncertainty, wcs=wcs, mask=mask,
-                          meta=meta, spectral_axis_index=self._spectral_axis_index)
+                          meta=meta)
 
     @classmethod
     def from_spectra(cls, spectra):

--- a/specutils/spectra/spectrum_collection.py
+++ b/specutils/spectra/spectrum_collection.py
@@ -53,7 +53,7 @@ class SpectrumCollection(NDIOMixin):
         each spectrum in the collection.
     """
     def __init__(self, flux, spectral_axis=None, wcs=None, uncertainty=None,
-                 mask=None, meta=None):
+                 mask=None, meta=None, spectral_axis_index=None):
         # Check for quantity
         if not isinstance(flux, u.Quantity):
             raise u.UnitsError("Flux must be a `Quantity`.")
@@ -89,6 +89,7 @@ class SpectrumCollection(NDIOMixin):
 
         self._flux = flux
         self._spectral_axis = spectral_axis
+        self._spectral_axis_index = spectral_axis_index
         self._wcs = wcs
         self._uncertainty = uncertainty
         self._mask = mask
@@ -113,7 +114,7 @@ class SpectrumCollection(NDIOMixin):
 
         return Spectrum(flux=flux, spectral_axis=spectral_axis,
                           uncertainty=uncertainty, wcs=wcs, mask=mask,
-                          meta=meta)
+                          meta=meta, spectral_axis_index=self._spectral_axis_index)
 
     @classmethod
     def from_spectra(cls, spectra):
@@ -153,6 +154,8 @@ class SpectrumCollection(NDIOMixin):
                             observer=sa[0].observer,
                             target=sa[0].target)
 
+        spectral_axis_index = spectra[0].spectral_axis_index
+
         # Check that either all spectra have associated uncertainties, or that
         # none of them do. If only some do, log an error and ignore the
         # uncertainties.
@@ -183,7 +186,8 @@ class SpectrumCollection(NDIOMixin):
         meta = [spec.meta for spec in spectra]
 
         return cls(flux=flux, spectral_axis=spectral_axis,
-                   uncertainty=uncertainty, wcs=wcs, mask=mask, meta=meta)
+                   uncertainty=uncertainty, wcs=wcs, mask=mask, meta=meta,
+                   spectral_axis_index=spectral_axis_index)
 
     @property
     def flux(self):
@@ -194,6 +198,10 @@ class SpectrumCollection(NDIOMixin):
     def spectral_axis(self):
         """The spectral axes as a `~astropy.units.Quantity`."""
         return self._spectral_axis
+
+    @property
+    def spectral_axis_index(self):
+        return self._spectral_axis_index
 
     @property
     def frequency(self):

--- a/specutils/tests/test_arithmetic.py
+++ b/specutils/tests/test_arithmetic.py
@@ -1,6 +1,7 @@
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 import numpy as np
+import pytest
 
 from ..spectra.spectrum import Spectrum
 
@@ -89,8 +90,9 @@ def test_multiplication_basic_spectra(simulated_spectra):
 
 def test_add_diff_spectral_axis(simulated_spectra):
 
-    # Calculate using the spectrum/nddata code
-    spec3 = simulated_spectra.s1_um_mJy_e1 + simulated_spectra.s1_AA_mJy_e3  # noqa
+    # We now raise an error if the spectra aren't on the same spectral axis
+    with pytest.raises(ValueError, match="Spectral axis of both operands must match"):
+        spec3 = simulated_spectra.s1_um_mJy_e1 + simulated_spectra.s1_AA_mJy_e3  # noqa
 
 
 def test_masks(simulated_spectra):

--- a/specutils/tests/test_manipulation.py
+++ b/specutils/tests/test_manipulation.py
@@ -129,7 +129,7 @@ def test_snr_threshold():
     np.random.seed(42)
     flux = u.Quantity(np.random.sample((5, 10)), unit='Jy')
     spectral_axis = u.Quantity(np.arange(50).reshape((5, 10)), unit='AA')
-    wcs = np.array([gwcs_from_array(x) for x in spectral_axis])
+    wcs = np.array([gwcs_from_array(x, [10,]) for x in spectral_axis])
     uncertainty = StdDevUncertainty(np.random.sample((5, 10)), unit='Jy')
     mask = np.ones((5, 10)).astype(bool)
     meta = [{'test': 5, 'info': [1, 2, 3]} for i in range(5)]

--- a/specutils/tests/test_slicing.py
+++ b/specutils/tests/test_slicing.py
@@ -23,8 +23,12 @@ def test_spectral_axes():
 
     sliced_spec2 = spec2[0]
 
+    print(sliced_spec2.shape)
+    print(spec2.shape)
+
     assert isinstance(sliced_spec2, Spectrum)
-    assert_allclose(sliced_spec2.wcs.pixel_to_world(np.arange(10)), spec2.wcs.pixel_to_world(np.arange(10)))
+    assert_allclose(sliced_spec2.wcs.pixel_to_world(np.arange(10)),
+                    spec2.wcs.pixel_to_world([0,]*10, np.arange(10))[1])
     assert sliced_spec2.flux.shape[0] == 49
 
 
@@ -107,4 +111,4 @@ def test_slicing_multidim():
     assert spec1.mask.shape == (10,)
 
     assert quantity_allclose(spec3.spectral_axis, spec.spectral_axis[4:7])
-    assert quantity_allclose(spec3.wcs.pixel_to_world([0,1,2]), spec3.spectral_axis[0:3])
+    assert quantity_allclose(spec3.wcs.pixel_to_world([0, 0, 0], [0,1,2])[1], spec3.spectral_axis[0:3])

--- a/specutils/tests/test_spectrum_collection.py
+++ b/specutils/tests/test_spectrum_collection.py
@@ -15,14 +15,15 @@ from ..utils.wcs_utils import gwcs_from_array
 def spectrum_collection():
     flux = u.Quantity(np.random.sample((5, 10)), unit='Jy')
     spectral_axis = u.Quantity(np.arange(50).reshape((5, 10)) + 1, unit='AA')
-    wcs = np.array([gwcs_from_array(x, flux.shape) for x in spectral_axis])
+    wcs = np.array([gwcs_from_array(x, flux.shape, spectral_axis_index=1) for x in spectral_axis])
     uncertainty = StdDevUncertainty(np.random.sample((5, 10)), unit='Jy')
     mask = np.ones((5, 10)).astype(bool)
     meta = [{'test': 5, 'info': [1, 2, 3]} for i in range(5)]
 
     spec_coll = SpectrumCollection(
         flux=flux, spectral_axis=spectral_axis, wcs=wcs,
-        uncertainty=uncertainty, mask=mask, meta=meta)
+        uncertainty=uncertainty, mask=mask, meta=meta,
+        spectral_axis_index=1)
 
     return spec_coll
 
@@ -59,7 +60,7 @@ def test_collection_without_optional_arguments():
     flux = u.Quantity(np.random.sample((5, 10)), unit='Jy')
     spectral_axis = u.Quantity(np.arange(50).reshape((5, 10)) + 1, unit='AA')
     uncertainty = StdDevUncertainty(np.random.sample((5, 10)), unit='Jy')
-    wcs = np.array([gwcs_from_array(x, flux.shape) for x in spectral_axis])
+    wcs = np.array([gwcs_from_array(x, flux.shape, spectral_axis_index=1) for x in spectral_axis])
     mask = np.ones((5, 10)).astype(bool)
     meta = [{'test': 5, 'info': [1, 2, 3]} for i in range(5)]
 

--- a/specutils/tests/test_spectrum_collection.py
+++ b/specutils/tests/test_spectrum_collection.py
@@ -15,7 +15,7 @@ from ..utils.wcs_utils import gwcs_from_array
 def spectrum_collection():
     flux = u.Quantity(np.random.sample((5, 10)), unit='Jy')
     spectral_axis = u.Quantity(np.arange(50).reshape((5, 10)) + 1, unit='AA')
-    wcs = np.array([gwcs_from_array(x) for x in spectral_axis])
+    wcs = np.array([gwcs_from_array(x, flux.shape) for x in spectral_axis])
     uncertainty = StdDevUncertainty(np.random.sample((5, 10)), unit='Jy')
     mask = np.ones((5, 10)).astype(bool)
     meta = [{'test': 5, 'info': [1, 2, 3]} for i in range(5)]
@@ -59,7 +59,7 @@ def test_collection_without_optional_arguments():
     flux = u.Quantity(np.random.sample((5, 10)), unit='Jy')
     spectral_axis = u.Quantity(np.arange(50).reshape((5, 10)) + 1, unit='AA')
     uncertainty = StdDevUncertainty(np.random.sample((5, 10)), unit='Jy')
-    wcs = np.array([gwcs_from_array(x) for x in spectral_axis])
+    wcs = np.array([gwcs_from_array(x, flux.shape) for x in spectral_axis])
     mask = np.ones((5, 10)).astype(bool)
     meta = [{'test': 5, 'info': [1, 2, 3]} for i in range(5)]
 

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -293,10 +293,17 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
     if naxes == 1:
         forward_transform = SpectralTabular1D(np.arange(len(array)), lookup_table=array)
     else:
-        mapped_axes = axes_order.append(spectral_axis_index)
+        axes_order.append(spectral_axis_index)
+        mapped_axes = axes_order
+        out_mapping = np.ones(len(mapped_axes)).astype(int)
+        for i in range(len(mapped_axes)):
+            out_mapping[mapped_axes[i]] = i
+
+        print(out_mapping)
+
         forward_transform = (Mapping(mapped_axes) |
                              Identity(naxes - 1) & SpectralTabular1D(np.arange(len(array)), lookup_table=array) |
-                             Mapping())
+                             Mapping(out_mapping))
 
     # If our spectral axis is in descending order, we have to flip the lookup
     # table to be ascending in order for world_to_pixel to work.

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -39,12 +39,6 @@ class SpectralGWCS(GWCS):
         """
         return copy.deepcopy(self)
 
-    def pixel_to_world(self, *args, **kwargs):
-        if self.original_unit == '':
-            return u.Quantity(super().pixel_to_world_values(*args, **kwargs))
-        return super().pixel_to_world(*args, **kwargs).to(
-            self.original_unit, equivalencies=u.spectral())
-
 
 def refraction_index(wavelength, method='Morton2000', co2=None):
     """
@@ -264,7 +258,7 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
     axes_type[spectral_axis_index] = "SPECTRAL"
 
     detector_frame = cf.CoordinateFrame(naxes=naxes,
-                                        unit=[u.pix,] * naxes,
+                                        unit=['',] * naxes,
                                         axes_order=axes_order,
                                         axes_type=axes_type
                                         )
@@ -274,7 +268,7 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
     if naxes > 1:
         axes_order.remove(spectral_axis_index)
         spatial_frame = cf.CoordinateFrame(naxes=naxes - 1,
-                                           unit=[u.pix,] * (naxes -1),
+                                           unit=['',] * (naxes -1),
                                            axes_type=['Spatial',] * (naxes - 1),
                                            axes_order=axes_order)
         output_frame = cf.CompositeFrame(frames=[spatial_frame, spectral_frame])

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -293,8 +293,6 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
         for i in range(len(mapped_axes)):
             out_mapping[mapped_axes[i]] = i
 
-        print(out_mapping)
-
         forward_transform = (Mapping(mapped_axes) |
                              Identity(naxes - 1) & SpectralTabular1D(np.arange(len(array)), lookup_table=array) |
                              Mapping(out_mapping))

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -252,6 +252,8 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
 
     if naxes > 1 and spectral_axis_index is None:
         raise ValueError("spectral_axis_index must be set for multidimensional flux arrays")
+    elif naxes == 1:
+        spectral_axis_index=0
 
     axes_order = list(np.arange(naxes))
     axes_type = ['SPATIAL',] * naxes


### PR DESCRIPTION
Currently, `gwcs_from_array` always gives a 1D purely spectral GWCS, even in the case where the flux array is multi-dimensional. This PR updates that function to return an ND GWCS, so that the dimensionality of a `Spectrum`'s GWCS always matches that of the flux array, even if the spatial dimensions are simply returning the pixel values. This will simplify and solve a lot of problems down stream in e.g. `glue-astronomy` and `jdaviz`.

There were a lot of changes here that were needed to accommodate this change, but I think it's all improvements. I have one final failing test that I need to debug, so I'm opening this as a draft while I resolve that.