### PR TITLE
MNT: Replace ubuntu-20.04 with ubuntu-22.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "mambaforge-4.10"
   jobs:


### PR DESCRIPTION
As recommended by actions/runner-images#11101 , this PR replaces the deprecated ubuntu-20.04 runner with a newer version. This also replaces RTD workflow, if applicable, to future-proof the build in case it follows suit.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

[:ghost:](https://github.com/pllim/playpen/issues/63)