### PR TITLE
Small tweaks to SDSS loaders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Bug Fixes
 
 - Fixed loaders for IRAF-encoded non-linear Chebychev + Legendre wavelength
   solutions that were imposing integer-valued domain limits. [#1199]
+- Fixed loaders for SDSS APOGEE not correctly identifying the format [#1217]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/specutils/io/default_loaders/sdss.py
+++ b/specutils/io/default_loaders/sdss.py
@@ -7,17 +7,16 @@ Loader for SDSS spectrum files: spec_, spSpec_, and spPlate_.
 """
 import re
 
-from astropy.io import fits
-from astropy.table import Table
-from astropy.wcs import WCS
-from astropy.units import Unit
-from astropy.nddata import StdDevUncertainty, InverseVariance
-
 import numpy as np
+from astropy.io import fits
+from astropy.nddata import InverseVariance, StdDevUncertainty
+from astropy.table import Table
+from astropy.units import Unit
+from astropy.wcs import WCS
 
 from ...spectra import Spectrum1D
-from ..registers import data_loader
 from ..parsing_utils import read_fileobj_or_hdulist
+from ..registers import data_loader
 
 __all__ = ['spec_identify', 'spSpec_identify', 'spPlate_identify',
            'spec_loader', 'spSpec_loader', 'spPlate_loader']
@@ -70,11 +69,13 @@ def spec_identify(origin, *args, **kwargs):
     """
     # Test if fits has extension of type BinTable and check for spec-specific keys
     with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
-        return (hdulist[0].header.get("TELESCOP") == "SDSS 2.5-M"
-                and hdulist[0].header.get("FIBERID", 0) > 0
-                and len(hdulist) > 1
-                and (isinstance(hdulist[1], fits.BinTableHDU)
-                     and hdulist[1].header.get("TTYPE3").lower() == "ivar"))
+        return (
+            hdulist[0].header.get("TELESCOP") == "SDSS 2.5-M"
+            and hdulist[0].header["VERS2D"].startswith("v5")
+            and hdulist[0].header.get("FIBERID", 0) > 0
+            and len(hdulist) > 1
+            and (isinstance(hdulist[1], fits.BinTableHDU) and hdulist[1].header.get("TTYPE3").lower() == "ivar")
+        )
 
 
 def spSpec_identify(origin, *args, **kwargs):

--- a/specutils/io/default_loaders/sdss_v.py
+++ b/specutils/io/default_loaders/sdss_v.py
@@ -3,14 +3,14 @@ import warnings
 from typing import Optional
 
 import numpy as np
-from astropy.units import Unit, Quantity, Angstrom
-from astropy.nddata import StdDevUncertainty, InverseVariance
-from astropy.io.fits import HDUList, BinTableHDU, ImageHDU
+from astropy.io.fits import BinTableHDU, HDUList, ImageHDU
+from astropy.nddata import InverseVariance, StdDevUncertainty
+from astropy.units import Angstrom, Quantity, Unit
 from astropy.utils.exceptions import AstropyUserWarning
 
 from ...spectra import Spectrum1D, SpectrumList
-from ..registers import data_loader
 from ..parsing_utils import read_fileobj_or_hdulist
+from ..registers import data_loader
 
 __all__ = [
     "load_sdss_apVisit_1D",
@@ -70,10 +70,13 @@ def spec_sdss5_identify(origin, *args, **kwargs):
         return (
             (hdulist[0].header.get("TELESCOP").lower() == "sdss 2.5-m")  # and
             # hdulist[0].header.get("OBSERVAT").lower() in ["apo", "lco"]
-            and (hdulist[1].header.get("TTYPE1").lower() == "flux") and
-            (hdulist[1].header.get("TTYPE2").lower() == "loglam") and
-            (len(hdulist) > 1) and (isinstance(hdulist[1], BinTableHDU)) and
-            (hdulist[1].header.get("TTYPE3").lower() == "ivar"))
+            and hdulist[0].header["VERS2D"].startswith("v6")
+            and (hdulist[1].header.get("TTYPE1").lower() == "flux")
+            and (hdulist[1].header.get("TTYPE2").lower() == "loglam")
+            and (len(hdulist) > 1)
+            and (isinstance(hdulist[1], BinTableHDU))
+            and (hdulist[1].header.get("TTYPE3").lower() == "ivar")
+        )
 
 
 def mwm_identify(origin, *args, **kwargs):

--- a/specutils/io/default_loaders/tests/test_apogee.py
+++ b/specutils/io/default_loaders/tests/test_apogee.py
@@ -12,7 +12,7 @@ from specutils.io.default_loaders.apogee import apStar_loader, apVisit_loader, a
     "url",
     [
         "https://data.sdss.org/sas/dr16/apogee/spectro/redux/r12/stars/apo25m/N7789/apStar-r12-2M00005414+5522241.fits",
-        "https://data.sdss.org/sas/dr17/apogee/spectro/redux/dr17/stars/lco25m/293-37-C/2M03174068-7748459/asStar-dr17-2M03174068-7748459.fits",
+        "https://data.sdss.org/sas/dr17/apogee/spectro/redux/dr17/stars/lco25m/293-37-C/asStar-dr17-2M03174068-7748459.fits",
         "https://data.sdss.org/sas/dr13/apogee/spectro/redux/r6/stars/apo25m/4291/apStar-r6-2M07440053+1053592-55960.fits",
     ],
     ids=["apstar_dr16", "asstar_dr17", "apstar_dr13"],
@@ -28,8 +28,8 @@ def test_apStar_loader(tmp_path, url):
     "url",
     [
         "https://data.sdss.org/sas/dr16/apogee/spectro/redux/r12/visit/apo25m/N7789/5094/55874/apVisit-r12-5094-55874-123.fits",
-        "https://data.sdss.org/sas/dr17/apogee/spectro/redux/dr17/visit/lco25m/293-37-C/2M03174068-7748459/asVisit-dr17-11992-59187-227.fits",
-        "https://data.sdss.org/sas/dr13/apogee/spectro/redux/r6/apo25m/44925/55702/apVisit-r6-4925-55702-003.fits",
+        "https://data.sdss.org/sas/dr17/apogee/spectro/redux/dr17/visit/lco25m/293-37-C/11992/59187/asVisit-dr17-11992-59187-227.fits",
+        "https://data.sdss.org/sas/dr13/apogee/spectro/redux/r6/apo25m/4925/55702/apVisit-r6-4925-55702-003.fits",
     ],
     ids=["apvisit_dr16", "asvisit_dr17", "apvisit_dr13"],
 )

--- a/specutils/io/default_loaders/tests/test_apogee.py
+++ b/specutils/io/default_loaders/tests/test_apogee.py
@@ -1,36 +1,54 @@
 # Third-party
-from astropy.utils.data import download_file
-from astropy.config import set_temp_cache
 import pytest
+from astropy.config import set_temp_cache
+from astropy.utils.data import download_file
 
 # Package
-from specutils.io.default_loaders.apogee import (apStar_loader, apVisit_loader,
-                                                 aspcapStar_loader)
+from specutils.io.default_loaders.apogee import apStar_loader, apVisit_loader, aspcapStar_loader
 
 
 @pytest.mark.remote_data
-def test_apStar_loader(tmp_path):
-    apstar_url = ("https://data.sdss.org/sas/dr16/apogee/spectro/redux/r12/"
-                  "stars/apo25m/N7789/apStar-r12-2M00005414+5522241.fits")
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://data.sdss.org/sas/dr16/apogee/spectro/redux/r12/stars/apo25m/N7789/apStar-r12-2M00005414+5522241.fits",
+        "https://data.sdss.org/sas/dr17/apogee/spectro/redux/dr17/stars/lco25m/293-37-C/2M03174068-7748459/asStar-dr17-2M03174068-7748459.fits",
+        "https://data.sdss.org/sas/dr13/apogee/spectro/redux/r6/stars/apo25m/4291/apStar-r6-2M07440053+1053592-55960.fits",
+    ],
+    ids=["apstar_dr16", "asstar_dr17", "apstar_dr13"],
+)
+def test_apStar_loader(tmp_path, url):
     with set_temp_cache(path=str(tmp_path)):
-        filename = download_file(apstar_url, cache=True)
+        filename = download_file(url, cache=True)
         spectrum = apStar_loader(filename)  # noqa
 
 
 @pytest.mark.remote_data
-def test_apVisit_loader(tmp_path):
-    apvisit_url = ("https://data.sdss.org/sas/dr16/apogee/spectro/redux/r12/"
-                   "visit/apo25m/N7789/5094/55874/"
-                   "apVisit-r12-5094-55874-123.fits")
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://data.sdss.org/sas/dr16/apogee/spectro/redux/r12/visit/apo25m/N7789/5094/55874/apVisit-r12-5094-55874-123.fits",
+        "https://data.sdss.org/sas/dr17/apogee/spectro/redux/dr17/visit/lco25m/293-37-C/2M03174068-7748459/asVisit-dr17-11992-59187-227.fits",
+        "https://data.sdss.org/sas/dr13/apogee/spectro/redux/r6/apo25m/44925/55702/apVisit-r6-4925-55702-003.fits",
+    ],
+    ids=["apvisit_dr16", "asvisit_dr17", "apvisit_dr13"],
+)
+def test_apVisit_loader(tmp_path, url):
     with set_temp_cache(path=str(tmp_path)):
-        filename = download_file(apvisit_url, cache=True)
+        filename = download_file(url, cache=True)
         spectrum = apVisit_loader(filename)  # noqa
 
 
 @pytest.mark.remote_data
-def test_aspcapStar_loader(tmp_path):
-    aspcap_url = ("https://data.sdss.org/sas/dr16/apogee/spectro/aspcap/r12/"
-                  "l33/apo25m/N7789/aspcapStar-r12-2M00005414+5522241.fits")
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://data.sdss.org/sas/dr16/apogee/spectro/aspcap/r12/l33/apo25m/N7789/aspcapStar-r12-2M00005414+5522241.fits",
+        "https://data.sdss.org/sas/dr17/apogee/spectro/aspcap/dr17/synspec_rev1/lco25m/293-37-C/aspcapStar-dr17-2M03174068-7748459.fits",
+    ],
+    ids=["aspcap_dr16_apo", "aspcap_dr17_lco"],
+)
+def test_aspcapStar_loader(tmp_path, url):
     with set_temp_cache(path=str(tmp_path)):
-        filename = download_file(aspcap_url, cache=True)
+        filename = download_file(url, cache=True)
         spectrum = aspcapStar_loader(filename)  # noqa

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -393,6 +393,7 @@ def spec_HDUList(n_spectra):
     hdr["FOOBAR"] = "barfoo"
     hdr["MJD5"] = 99999
     hdr["DATE-OBS"] = "1970-01-01"
+    hdr["VERS2D"] = "v6_1_2"
 
     # Init hdulist
     hdulist = fits.HDUList()


### PR DESCRIPTION
This PR makes some small tweaks to the SDSS data loaders for SDSS-IV APOGEE data.  The existing loaders were not correctly auto-identifying the spectrum format, for data from DR17 or from the southern hemisphere LCO 2.5-m.  This fixes that.  

Additionally it makes a small tweak to the SDSS-IV spec loaders for BOSS, compared to the SDSS-V loaders, to differentiate the two.  Previously `identify_spectrum_format` would return a list `["SDSS-III/IV spec", "SDSS-V spec"]` which breaks expectations for `identify_spectrum_format`.  With the tweak, SDSS spec files from SDSS-IV now correctly return the single format "SDSS-III/IV spec", whereas SDSS-V spec data returns "SDSS-V spec".  