### PR TITLE
Address problems found in specreduce compatibility check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Other Changes and Additions
 
 - Initializing a ``Spectrum`` with only a spectral axis (not full WCS) will now
   result in a GWCS matching the dimensionality of the flux array, rather than a
-  1D spectral GWCS in all cases. [#1211]
+  1D spectral GWCS in all cases. [#1211, #1222]
 
 - Spectrum arithmetic now checks whether the spectral axes of the two operand ``Spectrum``
   objects are equal, and fails if they are not. [#1211]

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -270,10 +270,10 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
                                         axes_type=axes_type
                                         )
 
-    if array.unit == "":
+    if array.unit in ('', 'pix', 'pixel'):
         # Spectrum was initialized without a wcs or spectral axis
         spectral_frame = cf.CoordinateFrame(naxes=1,
-                                           unit=['',],
+                                           unit=[array.unit,],
                                            axes_type=['Spectral',],
                                            axes_order=(spectral_axis_index,))
     else:


### PR DESCRIPTION
https://github.com/astropy/specreduce/pull/260 exposed a couple of errors that needed addressing here. I reworked the arithmetic updates slightly to take advantage of `NDDataArray`'s mask and uncertainty handling by operating on the operand fluxes and then reinstantiating a new `Spectrum` afterwards, since we can't pass `spectral_axis_index` through the astropy arithmetic machinery. This also fixes handling for `pixel` unit spectral axes in the updated `gwcs_from_array` function to fix an error that was being raised when trying to instantiate `SpectralCoord` with `pixel` units.

Opening as draft, need to do something similar to what I did for subtraction with the other arithmetic operations.