### PR TITLE
Small tweaks to 2.0 after debugging with Jdaviz

### DIFF
--- a/specutils/manipulation/smoothing.py
+++ b/specutils/manipulation/smoothing.py
@@ -63,7 +63,8 @@ def convolution_smooth(spectrum, kernel):
         kernel_ndim = kernel.array.ndim
 
     if flux.ndim > 1 and kernel_ndim == 1:
-        expand_axes = tuple(np.arange(flux.ndim-1))
+        expand_axes = list(np.arange(flux.ndim))
+        expand_axes.remove(spectrum.spectral_axis_index)
         kernel = np.expand_dims(kernel, expand_axes)
 
     # Smooth based on the input kernel

--- a/specutils/manipulation/smoothing.py
+++ b/specutils/manipulation/smoothing.py
@@ -113,10 +113,7 @@ def convolution_smooth(spectrum, kernel):
                 AstropyUserWarning)
 
     # Return a new object with the smoothed flux.
-    return spectrum._copy(flux=u.Quantity(smoothed_flux, spectrum.unit),
-                          spectral_axis=u.Quantity(spectrum.spectral_axis,
-                                                   spectrum.spectral_axis.unit),
-                          uncertainty=uncertainty)
+    return spectrum._copy(flux=u.Quantity(smoothed_flux, spectrum.unit), uncertainty=uncertainty)
 
 
 def box_smooth(spectrum, width):
@@ -278,6 +275,4 @@ def median_smooth(spectrum, width):
     smoothed_flux = medfilt(flux, width)
 
     # Return a new object with the smoothed flux.
-    return spectrum._copy(flux=u.Quantity(smoothed_flux, spectrum.unit),
-                          spectral_axis=u.Quantity(spectrum.spectral_axis,
-                                                   spectrum.spectral_axis.unit))
+    return spectrum._copy(flux=u.Quantity(smoothed_flux, spectrum.unit))

--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -245,8 +245,8 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
                         if phys_axes[i] is None:
                             continue
                         if (phys_axes[i][0:2] == "em" or phys_axes[i][0:5] == "spect" or
-                            phys_axes[i][7:12] == "Spect"):
-                                temp_axes.append(i)
+                                phys_axes[i][7:12] == "Spect"):
+                            temp_axes.append(i)
                     if len(temp_axes) != 1:
                         raise ValueError("Input WCS must have exactly one axis with "
                                         "spectral units, found {}".format(len(temp_axes)))

--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -244,8 +244,9 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
                     for i in range(len(phys_axes)):
                         if phys_axes[i] is None:
                             continue
-                        if phys_axes[i][0:2] == "em" or phys_axes[i][0:5] == "spect":
-                            temp_axes.append(i)
+                        if (phys_axes[i][0:2] == "em" or phys_axes[i][0:5] == "spect" or
+                            phys_axes[i][7:12] == "Spect"):
+                                temp_axes.append(i)
                     if len(temp_axes) != 1:
                         raise ValueError("Input WCS must have exactly one axis with "
                                         "spectral units, found {}".format(len(temp_axes)))
@@ -347,7 +348,7 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
                     raise ValueError("Must specify spectral_axis_index if no WCS or spectral"
                                      " axis is input.")
             size = flux.shape[self.spectral_axis_index] if not flux.isscalar else 1
-            wcs = gwcs_from_array(np.arange(size) * u.Unit(""),
+            wcs = gwcs_from_array(np.arange(size) * u.Unit("pixel"),
                                   flux.shape,
                                   spectral_axis_index=self.spectral_axis_index
                                   )
@@ -891,8 +892,7 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
 
     def __truediv__(self, other):
         other = self._check_input(other)
-
-        return self._return_with_redshift(self.divide(other))
+        return self._do_flux_arithmetic(other, "divide")
 
     __radd__ = __add__
 

--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -572,6 +572,7 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
         alt_kwargs.update(kwargs)
         if 'spectral_axis' in kwargs and 'wcs' not in kwargs:
             # We assume in this case that the user wants to override with a new spectral axis
+            alt_kwargs['meta']['original_wcs'] = alt_kwargs['wcs']
             alt_kwargs['wcs'] = None
 
         return self.__class__(**alt_kwargs)

--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -83,7 +83,7 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
     """
     def __init__(self, flux=None, spectral_axis=None, spectral_axis_index=None,
                  wcs=None, velocity_convention=None, rest_value=None,
-                 redshift=None, radial_velocity=None, bin_specification=None,
+                 redshift=None, radial_velocity=None, bin_specification="centers",
                  move_spectral_axis=None, **kwargs):
 
         # If the flux (data) argument is already a Spectrum (as it would
@@ -570,6 +570,9 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
             spectral_axis_index=deepcopy(self.spectral_axis_index))
 
         alt_kwargs.update(kwargs)
+        if 'spectral_axis' in kwargs and 'wcs' not in kwargs:
+            # We assume in this case that the user wants to override with a new spectral axis
+            alt_kwargs['wcs'] = None
 
         return self.__class__(**alt_kwargs)
 

--- a/specutils/spectra/spectrum.py
+++ b/specutils/spectra/spectrum.py
@@ -83,7 +83,7 @@ class Spectrum(OneDSpectrumMixin, NDCube, NDIOMixin, NDArithmeticMixin):
     """
     def __init__(self, flux=None, spectral_axis=None, spectral_axis_index=None,
                  wcs=None, velocity_convention=None, rest_value=None,
-                 redshift=None, radial_velocity=None, bin_specification="centers",
+                 redshift=None, radial_velocity=None, bin_specification=None,
                  move_spectral_axis=None, **kwargs):
 
         # If the flux (data) argument is already a Spectrum (as it would


### PR DESCRIPTION
This PR addresses a few bugs that cropped up when testing with the downstream Jdaviz package. This introduces what I think is a reasonable assumption that if `spectral_axis` and not `wcs` is passed to the `_copy` method, we shouldn't enforce the original WCS (which likely conflicts with the new spectral axis). We instead keep a copy of the original WCS in the `meta` dictionary. This might not really come up anywhere, since the places we were calling `_copy` internally in smoothing didn't really need the `spectral_axis` manually passed anyway, and downstream packages probably shouldn't be using the private copy method.