### PR TITLE
Fix empty returned list of template chi2 values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Bug Fixes
 - Fixed loaders for IRAF-encoded non-linear Chebychev + Legendre wavelength
   solutions that were imposing integer-valued domain limits. [#1199]
 - Fixed loaders for SDSS APOGEE not correctly identifying the format [#1217]
+- Fixed template comparison returning empty list of chi2 values in some cases. [#1228]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/specutils/analysis/template_comparison.py
+++ b/specutils/analysis/template_comparison.py
@@ -223,6 +223,7 @@ def template_match(observed_spectrum, spectral_templates, redshift=None,
         else:
             normalized_spectral_template, chi2 = _chi_square_for_templates(
                 observed_spectrum, spectrum, resample_method, extrapolation_treatment)
+            chi2_list.append(chi2)
 
         if chi2_min is None or chi2 < chi2_min:
             chi2_min = chi2

--- a/specutils/tests/test_template_comparison.py
+++ b/specutils/tests/test_template_comparison.py
@@ -154,6 +154,7 @@ def test_template_match_list():
     # make sure that multiple template spectra will create a list of
     # chi2 values, one per template.
     assert len(tm_result) == 5
+    assert len(tm_result[4]) == 2
 
 
 @pytest.mark.filterwarnings('ignore:Not all spectra have associated masks')


### PR DESCRIPTION
Closes #1227

Thanks @skendrew for filing a bug ticket for this, looks like it was just an oversight in the code not appending to the list in one case. Despite the comment in the test saying it was checking for this, it actually wasn't, so I added a check in the test as well.