### PR TITLE
Fix spectral_axis_index handling from #1229

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Added ``Spectrum`` class wrapper around ``Spectrum1D`` to ease transition to new
-  class name in 2.0. [#1229]
+  class name in 2.0. [#1229, #1230]
 
 - Removed redshift and radial velocity setters in ``Spectrum1D`` that have been deprecated
   since 1.8. [#1229]

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -783,5 +783,5 @@ class Spectrum(Spectrum1D):
             move_spectral_axis = kwargs.pop('move_spectral_axis', None)
             if move_spectral_axis not in ['last', -1, flux.ndim -1, None]:
                 warnings.warn("move_spectral_axis is ignored in specutils 1.x.")
-            kwargs.pop('spectral_axis_index', None)
+        kwargs.pop('spectral_axis_index', None)
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This `pop` to handle the `spectral_axis_index` keyword that isn't used in 1.x shouldn't have been in the code block handling `move_spectral_axis`.