### PR TITLE
Add docs about migrating to 2.0 to 1.x docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,12 @@ continue to work on Python 2, it is not tested and support cannot be guaranteed
 (due to the sunsetting of Python 2 support by the Python and Astropy development
 teams).
 
+Migrating from Specutils 1.x to 2.x
+-----------------------------------
+
+For details about breaking changes coming in 2.0, please see the
+`specutils documentation <http://specutils.readthedocs.io/en/latest/>`_.
+
 License
 -------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ The most visible change is that the `~specutils.Spectrum1D` class will be rename
 to ``Spectrum`` to reduce confusion about multi-dimensional flux arrays being supported.
 The current class name will be deprecated in version 2.1; importing the old name will
 work but raise a deprecation warning until then. Version 1.20 implemented a ``Spectrum``
-class as a simple wrapper around `~specutils.Spectrum1D` so that you may update their
+class as a simple wrapper around `~specutils.Spectrum1D` so that you may update your
 code to the new class name now and avoid deprecation warnings when 2.0 releases. Note
 that the new keyword arguments ``move_spectral_axis`` and ``spectral_axis_index`` being
 introduced in 2.0 will be ignored in 1.x if used when initializing the ``Spectrum`` class.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,17 +28,21 @@ guiding document for spectroscopic development in the Astropy Project.
     development stage that some interfaces may change if user feedback and
     experience warrants it.
 
-Changes coming in version 2
-===========================
+Changes coming in version 2.0
+=============================
 
-The `~specutils.Spectrum1D` class will be renamed to ``Spectrum`` to reduce confusion
-about multi-dimensional flux arrays being supported. The current class name will be
-deprecated in version 2.1; importing the old name will work but raise a deprecation
-warning until then. Version 1.20 implemented a ``Spectrum`` class as a simple wrapper
-around `~specutils.Spectrum1D` so that users may update their code to the new
-class name now and avoid deprecation warnings when 2.0 releases. Note that the new
-keyword arguments ``move_spectral_axis`` and ``spectral_axis_index`` introduced in 2.0
-will be ignored in 1.x if used when initializing the ``Spectrum`` class.
+Specutils 2.0 has been in development for some time and is nearly ready for release.
+The major changes that will affect users are detailed here in an attempt to prepare
+users for the transition.
+
+The most visible change is that the `~specutils.Spectrum1D` class will be renamed
+to ``Spectrum`` to reduce confusion about multi-dimensional flux arrays being supported.
+The current class name will be deprecated in version 2.1; importing the old name will
+work but raise a deprecation warning until then. Version 1.20 implemented a ``Spectrum``
+class as a simple wrapper around `~specutils.Spectrum1D` so that you may update their
+code to the new class name now and avoid deprecation warnings when 2.0 releases. Note
+that the new keyword arguments ``move_spectral_axis`` and ``spectral_axis_index`` being
+introduced in 2.0 will be ignored in 1.x if used when initializing the ``Spectrum`` class.
 
 Single-dimensional flux use cases should be mostly unchanged in 2.0, with the exception
 being that spectrum arithmetic will check that the spectral axis of both operands are
@@ -59,8 +63,8 @@ based on the WCS (if provided) or the shape of the flux and spectral axis arrays
 but if the spectral axis index is unable to be automatically determined you will
 need to specify which flux array axis is the dispersion axis with the
 ``spectral_axis_index`` keyword. Note that since the ``spectral_axis`` can specify
-either bin edges or bin centers, a flux array of shape ``(10,11)`` with spectral axis
-of length 11 would be ambigious. In this case you could initialize a
+either bin edges or bin centers, a flux array of shape ``(10, 11)`` with spectral axis
+of length 10 or 11 would be ambigious. In this case you could initialize a
 ``Spectrum`` with ``bin_specification`` set to either "edges" or "centers"
 to break the degeneracy.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,56 @@ guiding document for spectroscopic development in the Astropy Project.
     development stage that some interfaces may change if user feedback and
     experience warrants it.
 
+Changes coming in version 2
+===========================
+
+The `~specutils.Spectrum1D` class will be renamed to ``Spectrum`` to reduce confusion
+about multi-dimensional flux arrays being supported. The current class name will be
+deprecated in version 2.1; importing the old name will work but raise a deprecation
+warning until then. Version 1.20 implemented a ``Spectrum`` class as a simple wrapper
+around `~specutils.Spectrum1D` so that users may update their code to the new
+class name now and avoid deprecation warnings when 2.0 releases. Note that the new
+keyword arguments ``move_spectral_axis`` and ``spectral_axis_index`` introduced in 2.0
+will be ignored in 1.x if used when initializing the ``Spectrum`` class.
+
+Single-dimensional flux use cases should be mostly unchanged in 2.0, with the exception
+being that spectrum arithmetic will check that the spectral axis of both operands are
+equal, rather than simply checking that they are the same length. Thus, you will need
+to resample onto a common spectral axis if doing arithmetic on spectra with differing
+spectral axes.
+
+Specutils version 2 implements a major change in that ``Spectrum``
+no longer forces the spectral axis to be last for multi-dimensional data. This
+was motivated by the desire for greater flexibility to allow for interoperability
+with other packages that may wish to use ``specutils`` classes as the basis for
+their own, and by the desire for consistency with the axis order that results
+from a simple ``astropy.io.fits.read`` of a file. The legacy behavior can be
+replicated by setting ``move_spectral_axis='last'`` when creating a new
+``Spectrum`` object. ``Spectrum`` will attempt to automatically
+determine which flux axis corresponds to the spectral axis during initialization
+based on the WCS (if provided) or the shape of the flux and spectral axis arrays,
+but if the spectral axis index is unable to be automatically determined you will
+need to specify which flux array axis is the dispersion axis with the
+``spectral_axis_index`` keyword. Note that since the ``spectral_axis`` can specify
+either bin edges or bin centers, a flux array of shape ``(10,11)`` with spectral axis
+of length 11 would be ambigious. In this case you could initialize a
+``Spectrum`` with ``bin_specification`` set to either "edges" or "centers"
+to break the degeneracy.
+
+An additional change for multi-dimensional spectra is that previously, initializing
+such a ``Spectrum`` with a  ``spectral_axis`` specified, but no WCS, would
+create a ``Spectrum`` instance with a one-dimensional GWCS that was essentially
+a lookup table with the spectral axis values. In 2.0 this case will result in a GWCS with
+dimensionality matching that of the flux array to facilitate use with downstream packages
+that expect WCS dimensionality to match that of the data. The resulting spatial axes
+transforms are simple pixel to pixel identity operations, since no actual spatial
+coordinate information is available.
+
+In addition to the changes to the generated GWCS, handling of input GWCS will also be
+improved. This mostly manifests in the full GWCS (including spatial information) being
+retained in the resulting ``Spectrum`` objects when reading, e.g., JWST spectral
+cubes.
+
 Getting started with :ref:`specutils <specutils>`
 =================================================
 


### PR DESCRIPTION
Mostly copied from v2.0-dev with an additional note about the behavior of 2.0 keywords in 1.x.