### PR TITLE
Improvements to the HST/STIS data loaders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Fixed loaders for HST/STIS.  Added an "HST/STIS multi" reader for use with
+  ``SpectrumCollection`` to read multi-extension and/or multi-order echelle datasets.
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/specutils/io/default_loaders/hst_stis.py
+++ b/specutils/io/default_loaders/hst_stis.py
@@ -1,28 +1,54 @@
-from astropy.units import Unit
+from copy import deepcopy
+import numpy as np
+import astropy.units as u
 from astropy.nddata import StdDevUncertainty
 
-from ...spectra import Spectrum1D
+from ...spectra import Spectrum1D, SpectrumCollection
 from ..registers import data_loader
 from ..parsing_utils import read_fileobj_or_hdulist
 
-__all__ = ['stis_identify', 'stis_spectrum_loader']
+__all__ = ['identify_stis_1storder_and_singleread',
+           'identify_stis_multiorder_or_multiread',
+           'stis_single_spectrum_loader',
+           'stis_multi_spectrum_loader',]
+
+SDQFLAGS_DEFAULT = 31743  # = 0b11110111111111
+SCALAR_COLUMNS = ['SPORDER', 'NELEM', 'A2CENTER', 'EXTRSIZE', 'MAXSRCH', 'BK1SIZE',
+                  'BK2SIZE', 'BK1OFFST', 'BK2OFFST', 'OFFSET',]
+FLUX_UNIT = u.erg / (u.s * u.cm**2 * u.Angstrom)
+DISP_UNIT = u.Angstrom
 
 
-def stis_identify(origin, *args, **kwargs):
-    """Check whether given file contains HST/STIS spectral data."""
+def identify_stis_1storder_and_singleread(origin, *args, **kwargs):
+    """Check whether given file contains first-order HST/STIS 1D spectral data from a
+    single read (ext).
+    """
     with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
-        return (hdulist[0].header['TELESCOP'] == 'HST' and hdulist[0].header['INSTRUME'] == 'STIS')
+        return (hdulist[0].header.get('TELESCOP', '') == 'HST') and \
+               (hdulist[0].header.get('INSTRUME', '') == 'STIS') and \
+               (hdulist[0].header.get('X1DCORR', '') == 'COMPLETE') and \
+               (hdulist[0].header.get('NEXTEND', -1) == 1) and \
+               (len(hdulist[1].data) == 1)
 
-    return False
+
+def identify_stis_multiorder_or_multiread(origin, *args, **kwargs):
+    """Check whether given file contains HST/STIS 1D spectral data from multiple
+    echelle orders and/or multiple reads (exts).
+    """
+    with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
+        return (hdulist[0].header.get('TELESCOP', '') == 'HST') and \
+               (hdulist[0].header.get('INSTRUME', '') == 'STIS') and \
+               (hdulist[0].header.get('X1DCORR', '') == 'COMPLETE') and \
+               ((hdulist[0].header.get('NEXTEND', -1) > 1) or (len(hdulist[1].data) > 1))
 
 
 @data_loader(
-    label="HST/STIS", identifier=stis_identify,
+    label="HST/STIS", identifier=identify_stis_1storder_and_singleread,
     extensions=['FITS', 'FIT', 'fits', 'fit'], priority=10,
+    dtype=Spectrum1D,
 )
-def stis_spectrum_loader(file_obj, **kwargs):
-    """
-    Load STIS spectral data from the MAST archive into a spectrum object.
+def stis_single_spectrum_loader(file_obj, **kwargs):
+    """Load STIS spectral data from the MAST archive into a spectrum object.
 
     Parameters
     ----------
@@ -30,28 +56,120 @@ def stis_spectrum_loader(file_obj, **kwargs):
           FITS file name, object (provided from name by Astropy I/O Registry),
           or HDUList (as resulting from astropy.io.fits.open()).
 
+    sdqflags: int or None
+          Serious data quality flag bit-wise mask to apply.
+          If None, use the default value found in the SCI ext headers.
+
     Returns
     -------
     data: Spectrum1D
         The spectrum that is represented by the data in this table.
+
+    Note
+    ----
+    See here for the definitions of the STIS data quality (DQ) bits:
+    https://hst-docs.stsci.edu/stisdhb/chapter-2-stis-data-structure/2-5-error-and-data-quality-array#id-2.5ErrorandDataQualityArray-2.5.2DataQualityFlagging
     """
+    sdqflags = kwargs.pop('sdqflags', None)
 
     with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
-        header = hdulist[0].header
-        meta = {'header': header}
+        if len(hdulist) <= 1:
+            raise ValueError('HST/STIS file is mising the SCI data extension.')
+        if len(hdulist) > 2:
+            raise RuntimeError('HST/STIS file is multi-extension.  '
+                               'Use SpectrumCollection.read() instead.')
+        if len(hdulist[1].data) > 1:
+            raise RuntimeError('HST/STIS file has multiple orders (echelle data).  '
+                               'Use SpectrumCollection.read() instead.')
 
-        unit = Unit("erg/cm**2 Angstrom s")
-        disp_unit = Unit('Angstrom')
-        data = hdulist[1].data['FLUX'].flatten() * unit
-        dispersion = hdulist[1].data['wavelength'].flatten() * disp_unit
-        uncertainty = StdDevUncertainty(hdulist[1].data["ERROR"].flatten() * unit)
+        # Extract the single spectrum returned from the list (a Spectrum1D object):
+        return _construct_Spectrum1D_list(hdulist, sdqflags=sdqflags)[0]
 
-    sort_idx = dispersion.argsort()
-    dispersion = dispersion[sort_idx]
-    data = data[sort_idx]
-    uncertainty = uncertainty[sort_idx]
 
-    return Spectrum1D(flux=data,
-                      spectral_axis=dispersion,
-                      uncertainty=uncertainty,
-                      meta=meta)
+@data_loader(
+    label="HST/STIS multi", identifier=identify_stis_multiorder_or_multiread,
+    extensions=['FITS', 'FIT', 'fits', 'fit'], priority=10,
+    dtype=SpectrumCollection,
+)
+def stis_multi_spectrum_loader(file_obj, **kwargs):
+    """Load STIS spectral data from the MAST archive into a spectrum object.
+
+    Parameters
+    ----------
+    file_obj: str, file-like, or HDUList
+          FITS file name, object (provided from name by Astropy I/O Registry),
+          or HDUList (as resulting from astropy.io.fits.open()).
+
+    sdqflags: int or None
+          Serious data quality flag bit-wise mask to apply.
+          If None, use the default value found in the SCI ext headers.
+
+    Returns
+    -------
+    data: SpectrumCollection
+        The spectra that are represented by the data in this table.
+
+    Note
+    ----
+    See here for the definitions of the STIS data quality (DQ) bits:
+    https://hst-docs.stsci.edu/stisdhb/chapter-2-stis-data-structure/2-5-error-and-data-quality-array#id-2.5ErrorandDataQualityArray-2.5.2DataQualityFlagging
+    """
+    sdqflags = kwargs.pop('sdqflags', None)
+
+    with read_fileobj_or_hdulist(file_obj, **kwargs) as hdulist:
+        if len(hdulist) <= 1:
+            raise ValueError('HST/STIS file is mising the SCI data extension.')
+        if (len(hdulist) == 2) and (len(hdulist[1].data) == 1):
+            raise RuntimeError('HST/STIS file is single-read and first-order.  '
+                               'Use Spectrum1D.read() instead.')
+
+        multi_spec = _construct_Spectrum1D_list(hdulist, sdqflags=sdqflags)
+
+    return SpectrumCollection.from_spectra(multi_spec)
+
+
+def _construct_Spectrum1D_list(hdulist, sdqflags=None):
+    """Construct a list of Spectrum1D objects from an HST/STIS FITS HDUList.
+    """
+    meta = {'header_primary': hdulist[0].header}
+
+    # Loop over all reads and orders within the dataset and accumulate Spectrum1Ds:
+    multi_spec = []
+    for ext in range(1, len(hdulist)):
+        if sdqflags is None:
+            sdqflags = hdulist[ext].header.get('SDQFLAGS', SDQFLAGS_DEFAULT)
+        meta['ext'] = ext
+        meta['header_sci'] = hdulist[ext].header
+        for order in hdulist[ext].data:
+            for scalar_column in SCALAR_COLUMNS:
+                meta[scalar_column.lower()] = _nptype_to_pythontype(order[scalar_column])
+            meta['sdqflags_applied'] = sdqflags
+            multi_spec.append(_read_stis_order(order, meta=deepcopy(meta), sdqflags=sdqflags))
+
+    return multi_spec
+
+
+def _read_stis_order(order, meta=None, sdqflags=SDQFLAGS_DEFAULT):
+    """Construct a Spectrum1D object from a single STIS order (first-order or a
+    single echelle order).  Mask using SDQFLAGS.  Apply units.
+    """
+    return Spectrum1D(
+        flux=order['FLUX'] * FLUX_UNIT,
+        spectral_axis=order['WAVELENGTH'] * DISP_UNIT,
+        uncertainty=StdDevUncertainty(order['ERROR'] * FLUX_UNIT),
+        mask=(order['DQ'] & sdqflags) != 0,  # False where data are good
+        meta=meta)
+
+
+def _nptype_to_pythontype(x):
+    """Truncate extra precision in decimal representation of Numpy 32-bit types when
+    converting to Python-native 64-bit types.
+    """
+    if isinstance(x, np.float64):
+        return float(x)
+    elif isinstance(x, np.float32):
+        return float(np.format_float_positional(x, precision=7, unique=True, trim='k'))
+    elif isinstance(x, np.integer):
+        return int(x)
+    else:
+        return float(x)

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -125,10 +125,9 @@ def test_hst_cos(remote_data_path):
     assert spec.flux.size > 0
 
 
-@remote_access([{'id': '1481192', 'filename': 'STIS_FUV.fits'},
-                {'id': '1481185', 'filename': 'STIS_NUV.fits'},
-                {'id': '1481183', 'filename': 'STIS_CCD.fits'}])
-def test_hst_stis(remote_data_path):
+@remote_access([{'id': '15320389', 'filename': 'oewgl2040_x1d.fits'},
+                {'id': '15320389', 'filename': 'ofb002010_sx1.fits'}])
+def test_hst_stis_1d(remote_data_path):
     spec = Spectrum1D.read(remote_data_path)
 
     assert isinstance(spec, Spectrum1D)
@@ -138,6 +137,22 @@ def test_hst_stis(remote_data_path):
     with fits.open(remote_data_path) as hdulist:
         spec = Spectrum1D.read(hdulist, format="HST/STIS")
     assert isinstance(spec, Spectrum1D)
+    assert spec.flux.size > 0
+
+
+@remote_access([{'id': '15320389', 'filename': 'oewge4040_x1d.fits'},
+                {'id': '15320389', 'filename': 'oeqi13020_x1d.fits'},
+                {'id': '15320389', 'filename': 'oeqw10040_x1d.fits'}])
+def test_hst_stis_multi(remote_data_path):
+    spec = SpectrumCollection.read(remote_data_path)
+
+    assert isinstance(spec, SpectrumCollection)
+    assert spec.flux.size > 0
+
+    # HDUList case
+    with fits.open(remote_data_path) as hdulist:
+        spec = SpectrumCollection.read(hdulist, format="HST/STIS multi")
+    assert isinstance(spec, SpectrumCollection)
     assert spec.flux.size > 0
 
 


### PR DESCRIPTION
### Echelle datasets
HST/STIS can have multivalued wavelengths where echelle orders overlap.  Simply sorting by
wavelength will interleave high- and low-SNR data near the edges of these orders.  Rather
than solving the complex task of combining orders into a single 1D spectrum, we created
a second loader, "HST/STIS multi", to handle loading individual orders into rows of a
SpectrumCollection object.

Orders (each with independent wavelength solutions) overlap, so simply sorting by wavelength and combining all orders leads to non-physical Δλ.  Here's an example showing the overlaps:
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/bf48a51f-ac6f-40ae-8b24-dd779597afc3" />

The edges of orders have especially variable SNR (mainly due to the blaze function shape), so interleaving in the overlap regions would be non-physical:
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/9b68a8be-4ef4-49eb-b4fa-ffad9230368a" />

### Multi-read datasets
Additionally, some STIS datasets contain multiple reads (i.e. when REPEATOBS > 1 or
OCRREJECT="OMIT").  These reads are stored as additional FITS extensions.  Any multi-read
dataset also produces a SpectrumCollection object via the "HST/STIS multi" reader.

### Metadata
We supplemented the meta information with the relevant SCI extension header, as well as
the scalar table values describing the 1D extraction parameters for each order.

### Data masking
We used the STIS data quality (DQ) array, masked via bitwise-and with an SDQFLAGS
(serious DQ flags) scalar value to produce a boolean mask.  STIS DQ values are
integers, allowing the user to choose which DQ flags are relevant to their analysis via
the selection of the SDQFLAGS value.  By default, this value is read from the relevant
SCI extension header.  We also provided the capability for users to override this value
by specifying "sdqflags=<int>" to the STIS data readers.

### Caveat about echelle wavelength ordering
Note that while the wavelengths of any individual STIS echelle order are in ascending
ordered, the order of the wavelengths across echelle orders is descending (corresponding
to increasing SPORDER number).  This was chosen to remain consistent with the source
data.

### Flux units
While "Unit('erg/cm**2 Angstrom s')" appears to evaluate as intended, we
used a more explicit formulation.

### Identifiers
We modified the identifiers to not raise an exception upon the non-detection
of a FITS header keyword.

### Testing
Updated HST/STIS test_loaders tests.
New test data covering different file dimensionality are available at:
https://zenodo.org/records/15320389

### Updated `CHANGES.rst`