### PR TITLE
identify-tabular-fits more strict JWST test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ New Features
 
 Bug Fixes
 ^^^^^^^^^
+- Made `tabular-fits` identifier more strict for which kinds of JWST data to exclude [#1234]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -35,8 +35,9 @@ def identify_tabular_fits(origin, *args, **kwargs):
                 (hdulist[0].header.get('TELESCOP') == 'SDSS 2.5-M' and
                 hdulist[0].header.get('FIBERID') > 0) and not
                 (hdulist[0].header.get('TELESCOP') == 'HST' and
-                hdulist[0].header.get('INSTRUME') in ('COS', 'STIS')) and not
-                hdulist[0].header.get('TELESCOP') == 'JWST')
+                hdulist[0].header.get('INSTRUME') in ('COS', 'STIS')) and not 
+                (hdulist[0].header.get('TELESCOP') == 'JWST' and
+                ("EXTRACT1D" in hdulist or "COMBINE1D" in hdulist)))
 
 
 @data_loader("tabular-fits", identifier=identify_tabular_fits,

--- a/specutils/io/default_loaders/tabular_fits.py
+++ b/specutils/io/default_loaders/tabular_fits.py
@@ -35,7 +35,7 @@ def identify_tabular_fits(origin, *args, **kwargs):
                 (hdulist[0].header.get('TELESCOP') == 'SDSS 2.5-M' and
                 hdulist[0].header.get('FIBERID') > 0) and not
                 (hdulist[0].header.get('TELESCOP') == 'HST' and
-                hdulist[0].header.get('INSTRUME') in ('COS', 'STIS')) and not 
+                hdulist[0].header.get('INSTRUME') in ('COS', 'STIS')) and not
                 (hdulist[0].header.get('TELESCOP') == 'JWST' and
                 ("EXTRACT1D" in hdulist or "COMBINE1D" in hdulist)))
 

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -870,6 +870,7 @@ def test_tabular_fits_compressed(compress, tmp_path):
     assert quantity_allclose(spec.flux, spectrum.flux)
 
 
+@pytest.mark.remote_data
 def test_tabular_fits_jwst():
     """Test reading of tabular FITS file of a JWST spectrum."""
     spec = Spectrum.read("https://bdnyc.s3.us-east-1.amazonaws.com/Beiler24/SDSSpJ1346-00NIR.fits")

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -879,6 +879,7 @@ def test_tabular_fits_jwst():
     assert spec.spectral_axis.shape == (376,)
     assert spec.flux.unit == u.Jy
     assert spec.spectral_axis.unit == u.micron
+    assert spec.uncertainty.unit == u.Jy
     assert spec.meta['header']['TELESCOP'] == 'JWST'
 
 

--- a/specutils/tests/test_loaders.py
+++ b/specutils/tests/test_loaders.py
@@ -870,6 +870,17 @@ def test_tabular_fits_compressed(compress, tmp_path):
     assert quantity_allclose(spec.flux, spectrum.flux)
 
 
+def test_tabular_fits_jwst():
+    """Test reading of tabular FITS file of a JWST spectrum."""
+    spec = Spectrum.read("https://bdnyc.s3.us-east-1.amazonaws.com/Beiler24/SDSSpJ1346-00NIR.fits")
+    assert isinstance(spec, Spectrum)
+    assert spec.flux.shape == (376,)
+    assert spec.spectral_axis.shape == (376,)
+    assert spec.flux.unit == u.Jy
+    assert spec.spectral_axis.unit == u.micron
+    assert spec.meta['header']['TELESCOP'] == 'JWST'
+
+
 @pytest.mark.parametrize("spectral_axis", ['WAVE', 'FREQ', 'ENER', 'WAVN'])
 @pytest.mark.parametrize("uncertainty",
                          [None, StdDevUncertainty, VarianceUncertainty, InverseVariance])


### PR DESCRIPTION
Currently, `tabular-fits` won't identify on any spectrum with TELESCOP=JWST.  This is far too broad since folks are re-reducing JWST data and outputting tabular-fits format spectra.  I've modified the identifier to only ignore JWST spectra with specific HDU names that have their own JWST loaders.