### PR TITLE
Update release procedure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  # NOTE: PR trigger is to ensure changes do not break packaging.
+  pull_request:
+  release:
+    types: [released]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    if: github.repository == 'astropy/specutils'
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      with:
+        python-version: '3.11'
+
+    - name: Install python-build and twine
+      run: python -m pip install build "twine>=3.3" "importlib_metadata!=8.0.0"
+
+    - name: Build package
+      run: python -m build --sdist --wheel .
+
+    - name: List result
+      run: ls -l dist
+
+    - name: Check dist
+      run: python -m twine check --strict dist/*
+
+    - name: Test package
+      run: |
+        cd ..
+        python -m venv testenv
+        testenv/bin/pip install pytest pytest-astropy pytest-tornasync specutils/dist/*.whl
+        testenv/bin/pytest -p no:warnings --astropy-header --remote-data --pyargs specutils
+
+    # NOTE: Do not run this part for PR testing.
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
+      if: github.event_name != 'pull_request'
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -4,34 +4,17 @@
 Release Instructions
 ====================
 
-You will need to set up a gpg key (see the `astropy docs section on this <http://docs.astropy.org/en/stable/development/releasing.html#key-signing-info>`_ for more), PyPI account, and install twine before
-following these steps.
 
 1. Ensure all of the issues slated for this release on GitHub are either closed or moved to a new milestone.
 2. Pull a fresh copy of the main branch from GitHub down to your local machine.
 3. Update the Changelog - Move the filled out changelog headers from unreleased to a new released section with release version number.
-4. Make a commit with this change.
-5. Tag the commit you just made (replace version numbers with your new number)::
-
-    $ git tag -s v0.5.2 -m "tagging version 0.5.2"
-
-6. Checkout tagged version (replace version number)::
-
-    $ git checkout v0.5.2
-
-7. (optional but encouraged) Run test suite locally, make sure they pass.
-8. Now we do the PyPI release (steps 20,21 in the `astropy release procedures <http://docs.astropy.org/en/stable/development/releasing.html>`_)::
-
-    $ git clean -dfx
-    $ cd astropy_helpers; git clean -dfx; cd ..
-    $ python setup.py build sdist
-    $ gpg --detach-sign -a dist/specutils-0.5.1.tar.gz
-    $ twine upload dist/specutils-0.5.1.tar.gz
-
-9. Checkout main.
-10. Back to development - add the next version number to the changelog as an "unreleased" section
-11. Push to Github with  ``--tags`` (you may need to lift direct main push restrictions on the GitHub repo)
+4. Make a commit with this change and push to main, if you have permission, otherwise open a PR to main.
+5. Go to `Releases on GitHub <https://github.com/spacetelescope/jdaviz/releases>`_
+   and `create a new GitHub release <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`_
+   targeting the new branch you created (not ``main``!), and give it a new ``vX.Y.Z``
+   tag (do not choose any existing tags). Copy the relevant section from CHANGES.rst
+   into the release notes section and clean up any formatting problems.
 12. Do "release" with new tag on GitHub repo.
 13. If there is a milestone for this release, "close" the milestone on GitHub.
-14. Double-check (and fix if necessary) that relevant conda builds have proceeded sucessfully (e.g. https://github.com/conda-forge/specutils-feedstock)
-
+14. Check that the release was successfully uploaded to PyPi.
+15. Double-check (and fix if necessary) that relevant conda builds have proceeded sucessfully (e.g. https://github.com/conda-forge/specutils-feedstock)


### PR DESCRIPTION
Updates our release procedure to use Github Actions for the wheel creation and PyPi upload rather than having a maintainer build the package locally for release.