### PR TITLE
Ignore UnitBase and ConfigItem so 1.20.x docs will build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.20.3 (2025-06-13)
+-------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- Ignore problematic astropy classes so docs will build. [#1241]
+
 1.20.2 (2025-05-27)
 -------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,59 +28,12 @@ guiding document for spectroscopic development in the Astropy Project.
     development stage that some interfaces may change if user feedback and
     experience warrants it.
 
-Changes coming in version 2.0
-=============================
+Changes in version 2.0
+======================
 
-Specutils 2.0 has been in development for some time and is nearly ready for release.
-The major changes that will affect users are detailed here in an attempt to prepare
-users for the transition.
+Specutils 2.0 has been released, see the stable docs for a summary of the changes.
+This version of the documentation will remain available for user of ``specutils`` 1.x.
 
-The most visible change is that the `~specutils.Spectrum1D` class will be renamed
-to ``Spectrum`` to reduce confusion about multi-dimensional flux arrays being supported.
-The current class name will be deprecated in version 2.1; importing the old name will
-work but raise a deprecation warning until then. Version 1.20 implemented a ``Spectrum``
-class as a simple wrapper around `~specutils.Spectrum1D` so that you may update your
-code to the new class name now and avoid deprecation warnings when 2.0 releases. Note
-that the new keyword arguments ``move_spectral_axis`` and ``spectral_axis_index`` being
-introduced in 2.0 will be ignored in 1.x if used when initializing the ``Spectrum`` class.
-
-Single-dimensional flux use cases should be mostly unchanged in 2.0, with the exception
-being that spectrum arithmetic will check that the spectral axis of both operands are
-equal, rather than simply checking that they are the same length. Thus, you will need
-to resample onto a common spectral axis if doing arithmetic on spectra with differing
-spectral axes.
-
-Specutils version 2 implements a major change in that ``Spectrum``
-no longer forces the spectral axis to be last for multi-dimensional data. This
-was motivated by the desire for greater flexibility to allow for interoperability
-with other packages that may wish to use ``specutils`` classes as the basis for
-their own, and by the desire for consistency with the axis order that results
-from a simple ``astropy.io.fits.read`` of a file. The legacy behavior can be
-replicated by setting ``move_spectral_axis='last'`` when creating a new
-``Spectrum`` object. ``Spectrum`` will attempt to automatically
-determine which flux axis corresponds to the spectral axis during initialization
-based on the WCS (if provided) or the shape of the flux and spectral axis arrays,
-but if the spectral axis index is unable to be automatically determined you will
-need to specify which flux array axis is the dispersion axis with the
-``spectral_axis_index`` keyword. Note that since the ``spectral_axis`` can specify
-either bin edges or bin centers, a flux array of shape ``(10, 11)`` with spectral axis
-of length 10 or 11 would be ambigious. In this case you could initialize a
-``Spectrum`` with ``bin_specification`` set to either "edges" or "centers"
-to break the degeneracy.
-
-An additional change for multi-dimensional spectra is that previously, initializing
-such a ``Spectrum`` with a  ``spectral_axis`` specified, but no WCS, would
-create a ``Spectrum`` instance with a one-dimensional GWCS that was essentially
-a lookup table with the spectral axis values. In 2.0 this case will result in a GWCS with
-dimensionality matching that of the flux array to facilitate use with downstream packages
-that expect WCS dimensionality to match that of the data. The resulting spatial axes
-transforms are simple pixel to pixel identity operations, since no actual spatial
-coordinate information is available.
-
-In addition to the changes to the generated GWCS, handling of input GWCS will also be
-improved. This mostly manifests in the full GWCS (including spatial information) being
-retained in the resulting ``Spectrum`` objects when reading, e.g., JWST spectral
-cubes.
 
 Getting started with :ref:`specutils <specutils>`
 =================================================

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -7,7 +7,8 @@ py:obj NDUncertainty
 
 # Links that might not work yet, depending on the astropy version
 py:obj astropy.coordinates.SpectralQuantity
-py:class astropy.units.UnitBase
+py:class UnitBase
+py:class ConfigItem
 
 # Classes in the SpectralCoord/SpectralQuantity methods for which we can't
 # control the API links.


### PR DESCRIPTION
A fix for these docs build errors has been merged in astropy but not released yet, this is just so I can get the 1.20.x docs to build now so I can make them available on readthedocs.