### PR TITLE
TST: Use dev spectral-cube in devdeps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,7 @@ deps =
     devdeps: git+https://github.com/asdf-format/asdf.git
     devdeps: git+https://github.com/astropy/asdf-astropy.git
     devdeps: git+https://github.com/spacetelescope/stdatamodels.git
+    devdeps: git+https://github.com/radio-astro-tools/spectral-cube.git
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
Use dev spectral-cube in devdeps so the job will not pick up astropy test runner that is pending deprecation from upstream. If you don't like this, eventually you can revert when spectral-cube makes a compatible release in the future.