### PR TITLE
Updates the sdss mwmStar loader to fix bug with file datasums

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ Other Changes and Additions
 - Updated the JWST data readers to accomodate new WFSS file formats
   with ``SpectrumList.read()``. [#1252]
 
+Bug Fixes
+^^^^^^^^^
+
+- Fixed/updated SDSS-V mwm data loader to account for a subset of targets with bad datasums. [#1253]
+
+
 2.0.0 (2025-06-12)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,17 +11,16 @@ New Features
   solutions; at the same time the IRAF equispec format gains the ability to read log-linear
   wavelength solutions. [#1254]
 
-Other Changes and Additions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- Updated the JWST data readers to accomodate new WFSS file formats
-  with ``SpectrumList.read()``. [#1252]
-
 Bug Fixes
 ^^^^^^^^^
 
 - Fixed/updated SDSS-V mwm data loader to account for a subset of targets with bad datasums. [#1253]
 
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Updated the JWST data readers to accomodate new WFSS file formats
+  with ``SpectrumList.read()``. [#1252]
 
 2.0.0 (2025-06-12)
 ------------------

--- a/specutils/io/default_loaders/sdss_v.py
+++ b/specutils/io/default_loaders/sdss_v.py
@@ -466,19 +466,18 @@ def load_sdss_mwm_1d(file_obj,
     with read_fileobj_or_hdulist(file_obj, memmap=False, **kwargs) as hdulist:
         # Check if file is empty first
         datasums = []
-        for i in range(1, len(hdulist)):
-            datasums.append(int(hdulist[i].header.get("DATASUM")))
+        for i, hduext in enumerate(hdulist[1:]):
+            datasums.append(int(hduext.header.get("DATASUM")))
         if (np.array(datasums) == 0).all():
             raise ValueError("Specified file is empty.")
 
         # TODO: how should we handle this -- multiple things in file, but the user cannot choose.
         if hdu is None:
-            for i in range(1, len(hdulist)):
-                if hdulist[i].header.get("DATASUM") != "0":
+            for i, hduext in enumerate(hdulist):
+                if hduext.header.get("DATASUM") != "0" and len(hduext.data) > 0:
                     hdu = i
                     warnings.warn(
-                        'HDU not specified. Loading spectrum at (HDU{})'.
-                        format(i), AstropyUserWarning)
+                        f'HDU not specified. Loading spectrum at (HDU{i})', AstropyUserWarning)
                     break
 
         # load spectra and return
@@ -512,17 +511,17 @@ def load_sdss_mwm_list(file_obj, **kwargs):
     with read_fileobj_or_hdulist(file_obj, memmap=False, **kwargs) as hdulist:
         # Check if file is empty first
         datasums = []
-        for hdu in range(1, len(hdulist)):
-            datasums.append(int(hdulist[hdu].header.get("DATASUM")))
+        for hduext in hdulist[1:]:
+            datasums.append(int(hduext.header.get("DATASUM")))
         if (np.array(datasums) == 0).all():
             raise ValueError("Specified file is empty.")
 
         # Now load file
-        for hdu in range(1, len(hdulist)):
-            if hdulist[hdu].header.get("DATASUM") == "0":
+        for i, hduext in enumerate(hdulist):
+            if hduext.header.get("DATASUM") == "0" or len(hduext.data) == 0:
                 # Skip zero data HDU's
                 continue
-            spectra.append(_load_mwmVisit_or_mwmStar_hdu(hdulist, hdu))
+            spectra.append(_load_mwmVisit_or_mwmStar_hdu(hdulist, i))
     return spectra
 
 

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -470,19 +470,6 @@ def test_mwm_1d_nohdu(file_obj, hdu, with_wl, hduflags, nvisits):
         assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
         os.remove(tmpfile)
 
-def test_mwm_1d_baddatasum(tmp_path):
-    """ test load a mwm star file with a bad datasum"""
-    tmpfile = tmp_path / "mwm-temp.fits"
-    hdulist = mwm_HDUList([1,0,1,0], True, nvisits=1)
-    hdulist[1].data = fits.FITS_rec.from_columns([])
-    hdulist.writeto(tmpfile, overwrite=True)
-
-    assert hdulist[1].header['DATASUM'] != "0"
-    assert len(hdulist[1].data) == 0
-
-    with pytest.warns(AstropyUserWarning, match="HDU not specified. Loading spectrum at (HDU3)*"):
-        data = Spectrum.read(tmpfile, format='SDSS-V mwm')
-        assert isinstance(data, Spectrum)
 
 def test_mwm_1d_baddatasum():
     """ test load a mwm star file with a bad datasum"""

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -471,18 +471,16 @@ def test_mwm_1d_nohdu(file_obj, hdu, with_wl, hduflags, nvisits):
         os.remove(tmpfile)
 
 
-def test_mwm_1d_baddatasum(tmp_path):
+def test_mwm_1d_baddatasum():
     """ test load a mwm star file with a bad datasum"""
-    tmpfile = tmp_path / "mwm-temp.fits"
     hdulist = mwm_HDUList([1,0,1,0], True, nvisits=1)
     hdulist[1].data = fits.FITS_rec.from_columns([])
-    hdulist.writeto(tmpfile, overwrite=True)
 
     assert hdulist[1].header['DATASUM'] != "0"
     assert len(hdulist[1].data) == 0
 
     with pytest.warns(AstropyUserWarning, match="HDU not specified. Loading spectrum at (HDU3)*"):
-        data = Spectrum.read(tmpfile, format='SDSS-V mwm')
+        data = Spectrum.read(hdulist, format='SDSS-V mwm')
         assert isinstance(data, Spectrum)
 
 

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -470,6 +470,19 @@ def test_mwm_1d_nohdu(file_obj, hdu, with_wl, hduflags, nvisits):
         assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
         os.remove(tmpfile)
 
+def test_mwm_1d_baddatasum(tmp_path):
+    """ test load a mwm star file with a bad datasum"""
+    tmpfile = tmp_path / "mwm-temp.fits"
+    hdulist = mwm_HDUList([1,0,1,0], True, nvisits=1)
+    hdulist[1].data = fits.FITS_rec.from_columns([])
+    hdulist.writeto(tmpfile, overwrite=True)
+
+    assert hdulist[1].header['DATASUM'] != "0"
+    assert len(hdulist[1].data) == 0
+
+    with pytest.warns(AstropyUserWarning, match="HDU not specified. Loading spectrum at (HDU3)*"):
+        data = Spectrum.read(tmpfile, format='SDSS-V mwm')
+        assert isinstance(data, Spectrum)
 
 # TEST MWM loaders
 @pytest.mark.parametrize(

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -470,6 +470,7 @@ def test_mwm_1d_nohdu(file_obj, hdu, with_wl, hduflags, nvisits):
         assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
         os.remove(tmpfile)
 
+
 def test_mwm_1d_baddatasum(tmp_path):
     """ test load a mwm star file with a bad datasum"""
     tmpfile = tmp_path / "mwm-temp.fits"
@@ -483,6 +484,7 @@ def test_mwm_1d_baddatasum(tmp_path):
     with pytest.warns(AstropyUserWarning, match="HDU not specified. Loading spectrum at (HDU3)*"):
         data = Spectrum.read(tmpfile, format='SDSS-V mwm')
         assert isinstance(data, Spectrum)
+
 
 # TEST MWM loaders
 @pytest.mark.parametrize(

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -470,6 +470,19 @@ def test_mwm_1d_nohdu(file_obj, hdu, with_wl, hduflags, nvisits):
         assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
         os.remove(tmpfile)
 
+def test_mwm_1d_baddatasum(tmp_path):
+    """ test load a mwm star file with a bad datasum"""
+    tmpfile = tmp_path / "mwm-temp.fits"
+    hdulist = mwm_HDUList([1,0,1,0], True, nvisits=1)
+    hdulist[1].data = fits.FITS_rec.from_columns([])
+    hdulist.writeto(tmpfile, overwrite=True)
+
+    assert hdulist[1].header['DATASUM'] != "0"
+    assert len(hdulist[1].data) == 0
+
+    with pytest.warns(AstropyUserWarning, match="HDU not specified. Loading spectrum at (HDU3)*"):
+        data = Spectrum.read(tmpfile, format='SDSS-V mwm')
+        assert isinstance(data, Spectrum)
 
 def test_mwm_1d_baddatasum():
     """ test load a mwm star file with a bad datasum"""


### PR DESCRIPTION
This PR updates the SDSS-V mwm data loaders to account for a bug in a subset of the DR19 SDSS-V mwmStar files.  A subset of files have extensions with empty data arrays and non-zero DATASUM keywords.  This was due to some data needing to be cleaned out but the header wasn't fully scrubbed/corrected.  

The previous loader would attempt to load first extension found with non-zero DATASUM and would crash on the empty data.  This fix allows the loader to correctly skip over it and load the first real data extension it finds. 

It would be great if this can be backported to `specutils 1.x`, so it can be used currently in Jdaviz.  