### PR TITLE
Add missing axes_names to constructed spectral GWCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,15 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.1.1 (unreleased)
+------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- Add appropriate axes_names to resulting GWCS when a ``Spectrum`` is created with a spectral axis
+  specified and no WCS, based on the spectral axis units. [#1264]
+
 2.1.0 (2025-07-30)
 ------------------
 

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -277,12 +277,21 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
                                            axes_type=['Spectral',],
                                            axes_order=(spectral_axis_index,))
     else:
+        # Note that some units have multiple physical types, so we can't just set the
+        # axis name to the physical type string.
         if array.unit.physical_type == 'length':
             axes_names = ['wavelength',]
         elif array.unit.physical_type == 'frequency':
             axes_names = ['frequency',]
+        elif array.unit.physical_type == 'velocity':
+            axes_names = ['velocity',]
+        elif array.unit.physical_type == 'wavenumber':
+            axes_names = ['wavenumber',]
+        elif array.unit.physical_type == 'energy':
+            axes_names = ['energy',]
         else:
-            raise ValueError("Only length and frequency units are supported for spectral axis")
+            raise ValueError("Spectral axis units must be one of length,"
+                             "frequency, velocity, energy, or wavenumber")
         spectral_frame = cf.SpectralFrame(unit=array.unit, axes_order=(spectral_axis_index,),
                                           axes_names=axes_names)
 

--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -277,7 +277,14 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
                                            axes_type=['Spectral',],
                                            axes_order=(spectral_axis_index,))
     else:
-        spectral_frame = cf.SpectralFrame(unit=array.unit, axes_order=(spectral_axis_index,))
+        if array.unit.physical_type == 'length':
+            axes_names = ['wavelength',]
+        elif array.unit.physical_type == 'frequency':
+            axes_names = ['frequency',]
+        else:
+            raise ValueError("Only length and frequency units are supported for spectral axis")
+        spectral_frame = cf.SpectralFrame(unit=array.unit, axes_order=(spectral_axis_index,),
+                                          axes_names=axes_names)
 
     if naxes > 1:
         axes_order.remove(spectral_axis_index)


### PR DESCRIPTION
This will help with a couple downstream things, like Glue properly assigning world axis components when loading Spectrum objects. Also just nice to have in the GWCS in general.