### PR TITLE
use new pytest asdf plugin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
 
 [options.extras_require]
 test =
+    pytest-asdf-plugin
     pytest-astropy
     tox
     matplotlib


### PR DESCRIPTION
Update test dependencies to use new https://pypi.org/project/pytest-asdf-plugin/ which is a feature-compatible replacement for the bundled asdf pytest plugin (which will soon be deprecated).

For context the pytest-asdf-plugin is responsible for finding and converting schema files into "tests" (to check the schema against the metaschema and validated any contained "examples"). Since both the bundled and now external plugins are feature-compatible there should be no change in test number (or new failures, etc).

On main 572 tests passed:
https://github.com/astropy/specutils/actions/runs/16924368657/job/47957149583#step:5:183

With this PR 572 tests passed:
https://github.com/astropy/specutils/actions/runs/17070847734/job/48399089755?pr=1265#step:5:184

Let me know if this needs a changelog if if there is a label to add to skip this check (I don't have permissions to change the labels).