### PR TITLE
Fix JWST WFSS read to handle spectrum padding

### DIFF
--- a/specutils/io/default_loaders/jwst_reader.py
+++ b/specutils/io/default_loaders/jwst_reader.py
@@ -296,12 +296,11 @@ def _jwst_spectrum_from_table(data, hdu_header, primary_header, flux_col=None, s
 
     wavelength = Quantity(data['WAVELENGTH'])
 
+    unpadded_indices = None
     if hasattr(wavelength, 'mask'):
         # In this case the spectra have been padded to make their arrays have equal length
         unpadded_indices = np.where(~wavelength.mask)[0]
         wavelength = wavelength[unpadded_indices].unmasked
-    else:
-        unpadded_indices = slice(None)
 
     # Determine if FLUX or SURF_BRIGHT column should be returned
     # based on whether it is point or extended source. This will be overridden
@@ -356,10 +355,10 @@ def _jwst_spectrum_from_table(data, hdu_header, primary_header, flux_col=None, s
     if 'SOURCE_ID' in data.colnames:
         meta['source_id'] = data['SOURCE_ID']
 
-    if unpadded_indices != slice(None):
+    if unpadded_indices is not None:
         # In this case the spectra arrays have been padded to make them have consistent length
         flux = flux[unpadded_indices].unmasked
-        uncertainty = uncertainty[unpadded_indices].unmasked
+        uncertainty = uncertainty[unpadded_indices]
 
     return Spectrum(flux=flux, spectral_axis=wavelength,
                         uncertainty=uncertainty, meta=meta)


### PR DESCRIPTION
When I updated the loader to handle the new WFSS format for JWST, I didn't realize that all spectra in the file were padded to be the same length, which led to having `MaskedQuantity`s for the spectral axes. This PR removes the padding before it creates a `Spectrum` object for each spectrum.