### PR TITLE
CI: Adding workflow_dispatch to GHA

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     # run every Monday at 6am UTC
     - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     # run every Wednesday at 5pm UTC
     - cron: '17 0 * * 3'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   push:
+    branches:
+    - main
+    tags:
+    - '*'
   pull_request:
   schedule:
     # run every Wednesday at 5pm UTC

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
   release:
     types: [released]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         cd ..
         python -m venv testenv
-        testenv/bin/pip install pytest pytest-astropy pytest-tornasync specutils/dist/*.whl
+        testenv/bin/pip install pytest pytest-astropy pytest-tornasync pytest-asdf-plugin specutils/dist/*.whl
         testenv/bin/pytest --astropy-header --remote-data --pyargs specutils
 
     # NOTE: Do not run this part for PR testing.


### PR DESCRIPTION
I'm fairly certain that the CI failure in #1269 is unrelated, yet I couldn't make 100% certainty as there is no way to trigger CI on `main`