### PR TITLE
DNM: fix remote data loading on 3.14

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -57,6 +57,39 @@ jobs:
             python: '3.11'
             toxenv: py311-test-oldestdeps
 
+          - name: Python 3.13 with remote data
+            os: ubuntu-latest
+            python: '3.13'
+            toxenv: py313-test
+            toxargs: -v
+            toxposargs: --remote-data=any
+
+          - name: Python 3.14
+            os: ubuntu-latest
+            python: '3.14'
+            toxenv: py314-test
+
+          - name: Python 3.14 with remote data
+            os: ubuntu-latest
+            python: '3.14'
+            toxenv: py314-test
+            toxargs: -v
+            toxposargs: --remote-data=any
+
+          - name: Python 3.14 (macOS) with remote data
+            os: macos-latest
+            python: '3.14'
+            toxenv: py314-test
+            toxargs: -v
+            toxposargs: --remote-data=any
+
+          - name: Python 3.14 (Windows) with remote data
+            os: windows-latest
+            python: '3.14'
+            toxenv: py314-test
+            toxargs: -v
+            toxposargs: --remote-data=any
+
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0


### PR DESCRIPTION
Found the --remote-data option to be broken locally under Python 3.14 on macOS, investigating here for other OS/Python combos.

These files
```
../../.tox/py314-test/lib/python3.14/site-packages/astropy/io/registry/base.py:357: IORegistryError
_____________________ test_jwst_x1d_c1d[remote_data_path1] _____________________
remote_data_path = '/tmp/pytest-of-runner/pytest-0/test_jwst_x1d_c1d_remote_data_1/jw00787-o014_s00002_niriss_f150w-gr150c-gr150r_c1d.fits'
```
are all intact in the local test env and can be read in interactively just fine.
Failure in docs with 3.13 seems unrelated.