### PR TITLE
Max pin Sphinx<9 until upstream issues are resolved

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ test =
 jwst =
     stdatamodels>=1.1.0
 docs =
+    sphinx<9
     sphinx-astropy
     matplotlib
     graphviz


### PR DESCRIPTION
Does what it says on the tin. Some of the issues are tracked in https://github.com/astropy/sphinx-automodapi/issues/230.