### PR TITLE
Fix warning from GWCS 1.0

### DIFF
--- a/specutils/utils/wcs_utils.py
+++ b/specutils/utils/wcs_utils.py
@@ -277,6 +277,7 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
                                            axes_type=['Spectral',],
                                            axes_order=(spectral_axis_index,))
     else:
+        phys_types = None
         # Note that some units have multiple physical types, so we can't just set the
         # axis name to the physical type string.
         if array.unit.physical_type == 'length':
@@ -285,6 +286,7 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
             axes_names = ['frequency',]
         elif array.unit.physical_type == 'velocity':
             axes_names = ['velocity',]
+            phys_types = ['spect.dopplerVeloc.optical',]
         elif array.unit.physical_type == 'wavenumber':
             axes_names = ['wavenumber',]
         elif array.unit.physical_type == 'energy':
@@ -292,8 +294,9 @@ def gwcs_from_array(array, flux_shape, spectral_axis_index=None):
         else:
             raise ValueError("Spectral axis units must be one of length,"
                              "frequency, velocity, energy, or wavenumber")
+
         spectral_frame = cf.SpectralFrame(unit=array.unit, axes_order=(spectral_axis_index,),
-                                          axes_names=axes_names)
+                                          axes_names=axes_names, axis_physical_types=phys_types)
 
     if naxes > 1:
         axes_order.remove(spectral_axis_index)


### PR DESCRIPTION
Specify physical type for velocity spectral axis to avoid ambiguous type warning.

Fix #1294 