### PR TITLE
DOC: ndcube 2.4.0 has bad inherited ref in docstring

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ test =
 jwst =
     stdatamodels>=1.1.0
 docs =
+    ndcube>=2.0,<2.4
     sphinx<9
     sphinx-astropy
     matplotlib


### PR DESCRIPTION
This temporarily works around https://github.com/astropy/specutils/issues/1307 until we can figure out https://github.com/sunpy/ndcube/issues/915