### PR TITLE
Revert "Ignore upstream chararray deprecation warning"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,8 +83,6 @@ filterwarnings =
     ignore:No velocity defined on frame:astropy.coordinates.spectral_coordinate.NoVelocityWarning
     ignore:No observer defined on WCS:astropy.utils.exceptions.AstropyUserWarning
     ignore:COPY_IF_NEEDED is no longer needed now that astropy only supports numpy >= 2
-    # Remove when https://github.com/astropy/astropy/issues/19216 is resolved
-    ignore:The chararray class is deprecated and will be removed in a future release:DeprecationWarning
 
 [coverage:run]
 omit =


### PR DESCRIPTION
Reverts astropy/specutils#1314