### PR TITLE
properly handle units in SpectralRegion.invert

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ New Features
 
 Bug Fixes
 ^^^^^^^^^
-- Fix unit related issue when inverting spectral regions. [#1324]
+- Fix units related issue when inverting spectral regions. [#1324]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ New Features
 
 Bug Fixes
 ^^^^^^^^^
-- Fix unit related issues when inverting spectral regions. [#1324]
+- Fix unit related issue when inverting spectral regions. [#1324]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ New Features
 
 Bug Fixes
 ^^^^^^^^^
+- Fix unit related issues when inverting spectral regions. [#1324]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -369,16 +369,17 @@ class SpectralRegion:
         ----------
         lower_bound : `~astropy.units.Quantity`
            The lower bound of the region. Can be scalar with pixel or any
-           valid ``spectral_axis`` unit
+           valid ``spectral_axis`` unit that is equal to or compatible with the
+           unit of ``lower_bound``.
         upper_bound : `~astropy.units.Quantity`
            The upper bound of the region. Can be scalar with pixel or any
-              valid ``spectral_axis`` unit. If compatible with ``lower_bound``,
-              this value is converted to ``lower_bound`` units.
+           valid ``spectral_axis`` unit that is equal to or compatible with the
+           unit of ``lower_bound``.
 
         Returns
         -------
         spectral_region : `~specutils.SpectralRegion`
-           Spectral region of the non-selected regions
+           Spectral region of the non-selected regions.
 
         Raises
         ------
@@ -411,7 +412,7 @@ class SpectralRegion:
         #
         min_num = -sys.maxsize-1
         max_num = sys.maxsize
-        
+
         rs = self._subregions + [(min_num* lower_bound.unit, lower_bound),
                                  (upper_bound, max_num * upper_bound.unit)]
 

--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -413,7 +413,7 @@ class SpectralRegion:
         min_num = -sys.maxsize-1
         max_num = sys.maxsize
 
-        rs = self._subregions + [(min_num* lower_bound.unit, lower_bound),
+        rs = self._subregions + [(min_num * lower_bound.unit, lower_bound),
                                  (upper_bound, max_num * upper_bound.unit)]
 
         #

--- a/specutils/spectra/spectral_region.py
+++ b/specutils/spectra/spectral_region.py
@@ -372,12 +372,19 @@ class SpectralRegion:
            valid ``spectral_axis`` unit
         upper_bound : `~astropy.units.Quantity`
            The upper bound of the region. Can be scalar with pixel or any
-           valid ``spectral_axis`` unit
+              valid ``spectral_axis`` unit. If compatible with ``lower_bound``,
+              this value is converted to ``lower_bound`` units.
 
         Returns
         -------
         spectral_region : `~specutils.SpectralRegion`
            Spectral region of the non-selected regions
+
+        Raises
+        ------
+        ValueError
+            Raised when ``upper_bound`` and ``lower_bound`` do not have
+            compatible units.
 
         Notes
         -----
@@ -394,13 +401,19 @@ class SpectralRegion:
 
         """
 
+        try:
+            upper_bound = upper_bound.to(lower_bound.unit)
+        except u.UnitConversionError as exc:
+            raise ValueError("lower_bound and upper_bound must have compatible units.") from exc
+
         #
         # Create 'rs' region list with left and right extra ranges.
         #
         min_num = -sys.maxsize-1
         max_num = sys.maxsize
-        rs = self._subregions + [(min_num*u.um, lower_bound),
-                                 (upper_bound, max_num*u.um)]
+        
+        rs = self._subregions + [(min_num* lower_bound.unit, lower_bound),
+                                 (upper_bound, max_num * upper_bound.unit)]
 
         #
         # Sort the region list based on lower bound.
@@ -421,8 +434,8 @@ class SpectralRegion:
                 # test for intersection between lower and higher:
                 # we know via sorting that lower[0] <= higher[0]
                 if higher[0] <= lower[1]:
-                    upper_bound = max(lower[1], higher[1])
-                    merged[-1] = (lower[0], upper_bound)  # replace by merged interval
+                    merged_upper = max(lower[1], higher[1])
+                    merged[-1] = (lower[0], merged_upper)  # replace by merged interval
                 else:
                     merged.append(higher)
 

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -172,6 +172,33 @@ def test_invert():
         assert sr_inverted.subregions[ii] == sr_inverted_expected[ii]
 
 
+def test_invert_converts_upper_bound_units():
+    """
+    Check that when .invert is called with upper_bound and lower_bound in
+    different (but compatible units) that the upper_bound is correctly converted
+    to the units of lower_bound.
+    """
+    sr = SpectralRegion([(4500*u.AA, 6000*u.AA), (8000*u.AA, 9000*u.AA)])
+
+    # upper_bound is provided in nm and converted to lower_bound units (AA).
+    sr_inverted = sr.invert(3000*u.AA, 1000*u.nm)
+
+    expected = [(3000*u.AA, 4500*u.AA), (6000*u.AA, 8000*u.AA), (9000*u.AA, 10000*u.AA)]
+    for ii, exp in enumerate(expected):
+        assert sr_inverted.subregions[ii] == exp
+
+
+def test_invert_incompatible_bounds_units_raises():
+    """
+    Check that when .invert is called with upper_bound and lower_bound in
+    incompatible units, a ValueError is raised.
+    """
+    sr = SpectralRegion([(0.45*u.um, 0.6*u.um)])
+
+    with pytest.raises(ValueError, match="compatible units"):
+        sr.invert(0.3*u.um, 1*u.s)
+
+
 def test_from_list_list():
     g1 = Gaussian1D(1, 4.6, 0.2)
     g2 = Gaussian1D(2.5, 5.5, 0.1)

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -178,7 +178,7 @@ def test_invert_converts_upper_bound_units():
     different (but compatible units) that the upper_bound is correctly converted
     to the units of lower_bound.
     """
-    sr = (SpectralRegion(0.15*u.um, *u.um) +
+    sr = (SpectralRegion(0.15*u.um, 0.2*u.um) +
           SpectralRegion(0.3*u.um, 0.4*u.um) +
           SpectralRegion(0.45*u.um, 0.6*u.um) +
           SpectralRegion(0.8*u.um, 0.9*u.um) +

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -179,21 +179,27 @@ def test_invert_converts_upper_bound_units():
     Check that when .invert is called with upper_bound and lower_bound in
     different (but compatible units) that the upper_bound is correctly converted
     to the units of lower_bound.
-    """
-    sr = (SpectralRegion(1500*u.AA, 2000*u.AA) +
-          SpectralRegion(3000*u.AA, 4000*u.AA) +
-          SpectralRegion(4500*u.AA, 6000*u.AA) +
-          SpectralRegion(8000*u.AA, 9000*u.AA) +
-          SpectralRegion(10000*u.AA, 12000*u.AA) +
-          SpectralRegion(13000*u.AA, 15000*u.AA))
 
-    sr_inverted_expected = [(500*u.AA, 1500*u.AA), (2000*u.AA, 3000*u.AA),
-                            (4000*u.AA, 4500*u.AA), (6000*u.AA, 8000*u.AA),
-                            (9000*u.AA, 10000*u.AA), (12000*u.AA, 13000*u.AA),
-                            (15000*u.AA, 30000*u.AA)]
+    This regression test covers a previously reported bug where using an
+    arbitrary hard-coded unit for setting the 'zero' and 'inf' values
+    based on sys.maxsize was not wokring in the case where the units were
+    not directly convertable to this hard-coded unit.
+
+    """
+    sr = (SpectralRegion(1500*u.GHz, 2000*u.GHz) +
+        SpectralRegion(3000*u.GHz, 4000*u.GHz) +
+        SpectralRegion(4500*u.GHz, 6000*u.GHz) +
+        SpectralRegion(8000*u.GHz, 9000*u.GHz) +
+        SpectralRegion(10000*u.GHz, 12000*u.GHz) +
+        SpectralRegion(13000*u.GHz, 15000*u.GHz))
+
+    sr_inverted_expected = [(500*u.GHz, 1500*u.GHz), (2000*u.GHz, 3000*u.GHz),
+                    (4000*u.GHz, 4500*u.GHz), (6000*u.GHz, 8000*u.GHz),
+                    (9000*u.GHz, 10000*u.GHz), (12000*u.GHz, 13000*u.GHz),
+                    (15000*u.GHz, 30000*u.GHz)]
 
     # Invert from range.
-    sr_inverted = sr.invert(500*u.AA, 3000*u.nm)
+    sr_inverted = sr.invert(500*u.GHz, 30000000*u.MHz)
 
     for ii, _ in enumerate(sr_inverted_expected):
         assert_quantity_allclose(sr_inverted.subregions[ii],

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -196,7 +196,7 @@ def test_invert_converts_upper_bound_units():
     sr_inverted = sr.invert(500*u.AA, 3000*u.nm)
 
     for ii, _ in enumerate(sr_inverted_expected):
-        assert_quantity_allclose(sr_inverted.subregions[ii], 
+        assert_quantity_allclose(sr_inverted.subregions[ii],
                                  sr_inverted_expected[ii])
 
 

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -168,7 +168,7 @@ def test_invert():
     spectrum = Spectrum(spectral_axis=np.linspace(0.05, 3, 20)*u.um,
                           flux=np.random.random(20)*u.Jy)
     sr_inverted = sr.invert_from_spectrum(spectrum)
-    for ii, expected in enumerate(sr_inverted_expected):
+    for ii, _ in enumerate(sr_inverted_expected):
         assert sr_inverted.subregions[ii] == sr_inverted_expected[ii]
 
 
@@ -178,22 +178,22 @@ def test_invert_converts_upper_bound_units():
     different (but compatible units) that the upper_bound is correctly converted
     to the units of lower_bound.
     """
-    sr = (SpectralRegion(0.15*u.um, 0.2*u.um) +
-          SpectralRegion(0.3*u.um, 0.4*u.um) +
-          SpectralRegion(0.45*u.um, 0.6*u.um) +
-          SpectralRegion(0.8*u.um, 0.9*u.um) +
-          SpectralRegion(1.0*u.um, 1.2*u.um) +
-          SpectralRegion(1.3*u.um, 1.5*u.um))
+    sr = (SpectralRegion(1500*u.AA, 2000*u.AA) +
+          SpectralRegion(3000*u.AA, 4000*u.AA) +
+          SpectralRegion(4500*u.AA, 6000*u.AA) +
+          SpectralRegion(8000*u.AA, 9000*u.AA) +
+          SpectralRegion(10000*u.AA, 12000*u.AA) +
+          SpectralRegion(13000*u.AA, 15000*u.AA))
 
-    sr_inverted_expected = [(0.05*u.um, 0.15*u.um), (0.2*u.um, 0.3*u.um),
-                            (0.4*u.um, 0.45*u.um), (0.6*u.um, 0.8*u.um),
-                            (0.9*u.um, 1.0*u.um), (1.2*u.um, 1.3*u.um),
-                            (1.5*u.um, 3.0*u.um)]
+    sr_inverted_expected = [(500*u.AA, 1500*u.AA), (2000*u.AA, 3000*u.AA),
+                            (4000*u.AA, 4500*u.AA), (6000*u.AA, 8000*u.AA),
+                            (9000*u.AA, 10000*u.AA), (12000*u.AA, 13000*u.AA),
+                            (15000*u.AA, 30000*u.AA)]
 
     # Invert from range.
-    sr_inverted = sr.invert(0.05*u.um, 3000*u.nm)
+    sr_inverted = sr.invert(500*u.AA, 3000*u.nm)
 
-    for ii, expected in enumerate(sr_inverted_expected):
+    for ii, _ in enumerate(sr_inverted_expected):
         assert sr_inverted.subregions[ii] == sr_inverted_expected[ii]
 
 

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -178,14 +178,23 @@ def test_invert_converts_upper_bound_units():
     different (but compatible units) that the upper_bound is correctly converted
     to the units of lower_bound.
     """
-    sr = SpectralRegion([(4500*u.AA, 6000*u.AA), (8000*u.AA, 9000*u.AA)])
+    sr = (SpectralRegion(0.15*u.um, *u.um) +
+          SpectralRegion(0.3*u.um, 0.4*u.um) +
+          SpectralRegion(0.45*u.um, 0.6*u.um) +
+          SpectralRegion(0.8*u.um, 0.9*u.um) +
+          SpectralRegion(1.0*u.um, 1.2*u.um) +
+          SpectralRegion(1.3*u.um, 1.5*u.um))
 
-    # upper_bound is provided in nm and converted to lower_bound units (AA).
-    sr_inverted = sr.invert(3000*u.AA, 1000*u.nm)
+    sr_inverted_expected = [(0.05*u.um, 0.15*u.um), (0.2*u.um, 0.3*u.um),
+                            (0.4*u.um, 0.45*u.um), (0.6*u.um, 0.8*u.um),
+                            (0.9*u.um, 1.0*u.um), (1.2*u.um, 1.3*u.um),
+                            (1.5*u.um, 3.0*u.um)]
 
-    expected = [(3000*u.AA, 4500*u.AA), (6000*u.AA, 8000*u.AA), (9000*u.AA, 10000*u.AA)]
-    for ii, exp in enumerate(expected):
-        assert sr_inverted.subregions[ii] == exp
+    # Invert from range.
+    sr_inverted = sr.invert(0.05*u.um, 3000*u.nm)
+
+    for ii, expected in enumerate(sr_inverted_expected):
+        assert sr_inverted.subregions[ii] == sr_inverted_expected[ii]
 
 
 def test_invert_incompatible_bounds_units_raises():

--- a/specutils/tests/test_regions.py
+++ b/specutils/tests/test_regions.py
@@ -161,15 +161,17 @@ def test_invert():
     # Invert from range.
     sr_inverted = sr.invert(0.05*u.um, 3*u.um)
 
-    for ii, expected in enumerate(sr_inverted_expected):
-        assert sr_inverted.subregions[ii] == sr_inverted_expected[ii]
+    for ii, _ in enumerate(sr_inverted_expected):
+        assert_quantity_allclose(sr_inverted.subregions[ii],
+                                 sr_inverted_expected[ii])
 
     # Invert from spectrum.
     spectrum = Spectrum(spectral_axis=np.linspace(0.05, 3, 20)*u.um,
                           flux=np.random.random(20)*u.Jy)
     sr_inverted = sr.invert_from_spectrum(spectrum)
     for ii, _ in enumerate(sr_inverted_expected):
-        assert sr_inverted.subregions[ii] == sr_inverted_expected[ii]
+        assert_quantity_allclose(sr_inverted.subregions[ii],
+                                 sr_inverted_expected[ii])
 
 
 def test_invert_converts_upper_bound_units():
@@ -194,7 +196,8 @@ def test_invert_converts_upper_bound_units():
     sr_inverted = sr.invert(500*u.AA, 3000*u.nm)
 
     for ii, _ in enumerate(sr_inverted_expected):
-        assert sr_inverted.subregions[ii] == sr_inverted_expected[ii]
+        assert_quantity_allclose(sr_inverted.subregions[ii], 
+                                 sr_inverted_expected[ii])
 
 
 def test_invert_incompatible_bounds_units_raises():


### PR DESCRIPTION
The invert method for SpectralRegion had hard coded units of u.um applied to upper_bound and lower_bound inputs. These inputs are quantity objects themselves so their own units should be used. 

This PR removes the hard coded units and uses the actual units of upper_bound and lower_bound - if these units differ, upper_bound is converted to the unit of lower_bound (and this is explained in the docstring). If the units are not compatible, then an error is raised. Test coverage is added as well. 