### PR TITLE
SDSS-V `astraStar`/`astraVisit` default loaders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 New Features
 ^^^^^^^^^^^^
 
+- Added new SDSS-V ``Spectrum1D`` and ``SpectrumList`` default loaders for
+  ``astraStar`` and ``astraVisit`` model spectra datatypes. [#1203]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -206,11 +209,17 @@ Bug Fixes
 - Fixed extracting a spectral region when one of spectrum/region is in wavelength
   and the other is in frequency units. [#1187]
 
+- Fixed ``mwmVisit`` SDSS-V ``Spectrum1D`` and ``SpectrumList`` default loader being unable to load files containing only BOSS instrument spectra. [#1185]
+
+- Fixed automatic format detection for SDSS-V ``SpectrumList`` default loaders. [#1185]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Replaced ``LevMarLSQFitter`` with ``TRFLSQFitter`` as the former is no longer
   recommended by ``astropy``. [#1180]
+
+- "Multi" loaders have been removed from SDSS-V ``SpectrumList`` default loaders. [#1185]
 
 1.17.0 (2024-10-04)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ^^^^^^^^^^^^
 
 - Added new SDSS-V ``Spectrum1D`` and ``SpectrumList`` default loaders for
-  ``astraStar`` and ``astraVisit`` model spectra datatypes. [#1203]
+  ``astraStar`` and ``astraVisit`` model spectra datatypes. [#1325]
 
 Bug Fixes
 ^^^^^^^^^

--- a/specutils/io/default_loaders/sdss_v.py
+++ b/specutils/io/default_loaders/sdss_v.py
@@ -841,7 +841,7 @@ def _load_astra_hdu(hdulist: HDUList, hdu: int, visit: Optional[int] = None, **k
     pipeline = get_astra_pipeline(hdulist)
     if pipeline is None:
         raise ValueError(
-            "HDU{} does not appear to be associated with an astra pipeline.".format(hdu)
+            "HDU{} does not appear to be associated with an Astra pipeline.".format(hdu)
         )
 
     header = hdulist[hdu].header

--- a/specutils/io/default_loaders/sdss_v.py
+++ b/specutils/io/default_loaders/sdss_v.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import numpy as np
 from astropy.io.fits import BinTableHDU, HDUList, ImageHDU
-from astropy.nddata import InverseVariance, StdDevUncertainty
+from astropy.nddata import InverseVariance, StdDevUncertainty, UnknownUncertainty
 from astropy.units import Angstrom, Quantity, Unit, nanometer
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -856,8 +856,8 @@ def _load_astra_hdu(hdulist: HDUList, hdu: int, visit: Optional[int] = None, **k
     if 'ivar' in hdulist[hdu].columns.names:
         e_flux = InverseVariance(array=data["ivar"])
     else:
-        # NOTE: is this a good idea? Model spectra don't have ivar.
-        e_flux = StdDevUncertainty(np.zeros_like(model_flux))
+        # There is no associated uncertainty for model spectra.
+        e_flux = UnknownUncertainty(np.full_like(model_flux, np.nan))
 
     # Collect bitmask
     if "pixel_flags" in hdulist[hdu].columns.names:

--- a/specutils/io/default_loaders/sdss_v.py
+++ b/specutils/io/default_loaders/sdss_v.py
@@ -90,8 +90,34 @@ def mwm_identify(origin, *args, **kwargs):
         return (("V_ASTRA" in hdulist[0].header.keys()) and len(hdulist) > 0
                 and ("SDSS_ID" in hdulist[0].header.keys())
                 and (isinstance(hdulist[i], BinTableHDU) for i in range(1, 5))
+                and has_data(hdulist)
+                and all("flux" in hdulist[i].columns.names for i in range(1, 5))
                 and all("model_flux" not in hdulist[i].columns.names
                         for i in range(1, 5)))
+
+
+def has_data(hdulist: HDUList) -> bool:
+    """Check if any of the HDU's in the given HDUList have data."""
+
+    has_data = False
+    for hdu in hdulist:
+        if hdu.data is not None and len(hdu.data) > 0:
+            has_data = True
+            break
+    return has_data
+
+
+def has_model_flux(hdulist: HDUList) -> bool:
+    """Check if any of the HDU's in the given HDUList have a 'model_flux' column."""
+
+    if not has_data(hdulist):
+        return False
+
+    for hdu in hdulist:
+        if hdu.data is not None and "model_flux" in hdu.data.names:
+            return True
+
+    return False
 
 
 def get_astra_pipeline(hdulist: HDUList) -> Optional[str]:
@@ -115,13 +141,7 @@ def get_astra_pipeline(hdulist: HDUList) -> Optional[str]:
     pipeline = None
 
     # Check that at least one extension table has data.
-    has_data = False
-    for hdu in hdulist[1:]:
-        if len(hdu.data) > 0:
-            has_data = True
-            break
-
-    if not has_data:
+    if not has_data(hdulist):
         return None
 
     # astraStar/Visit files must have at least 5 extensions
@@ -156,7 +176,8 @@ def astra_identify(origin, *args, **kwargs):
             and ("V_ASTRA" in hdulist[0].header.keys())
             and ("SDSS_ID" in hdulist[0].header.keys())
             and (isinstance(hdulist[i], BinTableHDU) for i in range(1, 5))
-            and all("model_flux" in hdulist[i].columns.names for i in range(1, 5))
+            and has_data(hdulist)
+            and has_model_flux(hdulist)
         ):
             # Confirm that this file can be associated with a known astra pipeline
             pipeline = get_astra_pipeline(hdulist)
@@ -813,6 +834,9 @@ def _load_astra_hdu(hdulist: HDUList, hdu: int, visit: Optional[int] = None, **k
 
     if hdulist[hdu].header.get("DATASUM") == "0":
         raise IndexError("Attemped to load an empty HDU at HDU{}".format(hdu))
+
+    if not has_data(hdulist):
+        raise ValueError("The specified file does not contain any data.")
 
     pipeline = get_astra_pipeline(hdulist)
     if pipeline is None:

--- a/specutils/io/default_loaders/sdss_v.py
+++ b/specutils/io/default_loaders/sdss_v.py
@@ -94,17 +94,75 @@ def mwm_identify(origin, *args, **kwargs):
                         for i in range(1, 5)))
 
 
+def get_astra_pipeline(hdulist: HDUList) -> Optional[str]:
+    """Identify the pipeline that generated the astraStar/astraVisit file.
+
+    Currently there is no direct keyword in the astraStar files with the pipeline
+    name. We use a unique column in the data HDUs as a proxy.
+
+    Parameters
+    ----------
+    hdulist : HDUList
+        The HDUList to classify.
+
+    Returns
+    -------
+    str
+        The name of the pipeline, or ``None`` if it cannot be identified.
+
+    """
+
+    pipeline = None
+
+    # Check that at least one extension table has data.
+    has_data = False
+    for hdu in hdulist[1:]:
+        if len(hdu.data) > 0:
+            has_data = True
+            break
+
+    if not has_data:
+        return None
+
+    # astraStar/Visit files must have at least 5 extensions
+    if len(hdulist) < 5:
+        return None
+
+    for hdu in hdulist[1:]:
+        if len(hdu.data) == 0:
+            continue
+
+        try:
+            if "rho_fe_h_c12_c13" in hdu.data.names:
+                pipeline = "ThePayne"
+            elif "p_dc_ms" in hdu.data.names:
+                pipeline = "SnowWhite"
+            elif "model_flux_nd_h" in hdu.data.names:
+                pipeline = "ASPCAP"
+        except Exception:
+            pass
+
+    return pipeline
+
+
 def astra_identify(origin, *args, **kwargs):
     """
     Check whether given input is FITS and has SDSS-V astra model spectra
     BINTABLE in all 4 extensions. This is used for Astropy I/O Registry.
     """
     with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
-        return (("V_ASTRA" in hdulist[0].header.keys()) and len(hdulist) > 0
-                and ("SDSS_ID" in hdulist[0].header.keys())
-                and (isinstance(hdulist[i], BinTableHDU) for i in range(1, 5))
-                and all("model_flux" in hdulist[i].columns.names
-                        for i in range(1, 5)))
+        if (
+            len(hdulist) > 0
+            and ("V_ASTRA" in hdulist[0].header.keys())
+            and ("SDSS_ID" in hdulist[0].header.keys())
+            and (isinstance(hdulist[i], BinTableHDU) for i in range(1, 5))
+            and all("model_flux" in hdulist[i].columns.names for i in range(1, 5))
+        ):
+            # Confirm that this file can be associated with a known astra pipeline
+            pipeline = get_astra_pipeline(hdulist)
+            if pipeline is not None:
+                return True
+        return False
 
 
 def _wcs_log_linear(naxis, cdelt, crval):
@@ -634,7 +692,7 @@ def _load_mwmVisit_or_mwmStar_hdu(hdulist: HDUList, hdu: int, **kwargs):
 
 
 @data_loader(
-    "SDSS-V Astra model spectrum",
+    "SDSS-V astra",
     identifier=astra_identify,
     dtype=Spectrum,
     priority=20,
@@ -646,7 +704,7 @@ def load_sdss_astra_1d(
     visit: Optional[int] = None,
     **kwargs,
 ):
-    """Load an Astra model spectrum file as a `~specutils.Spectrum`.
+    """Load an Astra model spectrum file (astraStar/Visit) as a `~specutils.Spectrum`.
 
     Parameters
     ----------
@@ -685,7 +743,7 @@ def load_sdss_astra_1d(
 
 
 @data_loader(
-    "SDSS-V Astra model",
+    "SDSS-V astra",
     identifier=astra_identify,
     force=True,
     dtype=SpectrumList,
@@ -693,7 +751,7 @@ def load_sdss_astra_1d(
     extensions=["fits"],
 )
 def load_sdss_astra_list(file_obj, **kwargs):
-    """Load an astra model spectrum file as a `~specutils.SpectrumList`.
+    """Load an astraStar/astraVisit model spectrum file as a `~specutils.SpectrumList`.
 
     Parameters
     ----------
@@ -731,7 +789,7 @@ def load_sdss_astra_list(file_obj, **kwargs):
 
 
 def _load_astra_hdu(hdulist: HDUList, hdu: int, visit: Optional[int] = None, **kwargs):
-    """HDU loader subfunction for astra model spectrum files
+    """HDU loader subfunction for astraStar/astraVisit model spectrum files
 
     Parameters
     ----------
@@ -753,16 +811,26 @@ def _load_astra_hdu(hdulist: HDUList, hdu: int, visit: Optional[int] = None, **k
     if hdulist[hdu].header.get("DATASUM") == "0":
         raise IndexError("Attemped to load an empty HDU at HDU{}".format(hdu))
 
-    # Fetch wavelength
-    # encoded as WCS for visit, and 'wavelength' for star
-    try:
-        wavelength = np.array(hdulist[hdu].data["wavelength"])[0]
-    except KeyError:
-        wavelength = _wcs_log_linear(
-            hdulist[hdu].header.get("NPIXELS"),
-            hdulist[hdu].header.get("CDELT"),
-            hdulist[hdu].header.get("CRVAL"),
+    pipeline = get_astra_pipeline(hdulist)
+    if pipeline is None:
+        raise ValueError(
+            "HDU{} does not appear to be associated with an astra pipeline.".format(hdu)
         )
+
+    header = hdulist[hdu].header
+    data = hdulist[hdu].data
+
+    # Fetch wavelength encoded as WCS for visit, and 'wavelength' for star
+    wavelength = None
+    try:
+        wavelength = np.array(data["wavelength"])[0]
+    except KeyError:
+        if "CTYPE" in header.keys() and header["CTYPE"].upper() == "LOG-LINEAR":
+            wavelength = _wcs_log_linear(
+                header.get("NPIXELS"),
+                header.get("CDELT"),
+                header.get("CRVAL"),
+            )
     finally:
         if wavelength is None:
             raise ValueError("Couldn't find wavelength data in HDU{}.".format(hdu))
@@ -770,23 +838,27 @@ def _load_astra_hdu(hdulist: HDUList, hdu: int, visit: Optional[int] = None, **k
 
     # Fetch flux, e_flux
     flux_unit = Unit("1e-17 erg / (Angstrom cm2 s)")  # NOTE: hardcoded unit
-    model_flux = hdulist[hdu].data["model_flux"]
+    model_flux = data["model_flux"]
 
-    if "continuum" in hdulist[hdu].columns.names:
-        continuum = hdulist[hdu].data["continuum"]
+    if pipeline in ["ThePayne", "SnowWhite"]:
+        # In The Payne and SnowWhite the model_flux includes the continuum.
+        flux = Quantity(model_flux, unit=flux_unit)
+    elif pipeline in ["ASPCAP"]:
+        # In ASPCAP the model_flux is normalized to the continuum at each wavelength.
+        continuum = data["continuum"]
         flux = Quantity(model_flux * continuum, unit=flux_unit)
     else:
-        flux = Quantity(model_flux, unit=flux_unit)
+        raise ValueError("Invalid astra pipeline {!r}.".format(pipeline))
 
     if 'ivar' in hdulist[hdu].columns.names:
-        e_flux = InverseVariance(array=hdulist[hdu].data["ivar"])
+        e_flux = InverseVariance(array=data["ivar"])
     else:
         # NOTE: is this a good idea? Model spectra don't have ivar.
         e_flux = StdDevUncertainty(np.zeros_like(model_flux))
 
     # Collect bitmask
     if "pixel_flags" in hdulist[hdu].columns.names:
-        mask = hdulist[hdu].data["pixel_flags"]
+        mask = data["pixel_flags"]
         # NOTE: specutils considers 0/False as valid values, simlar to numpy convention
         mask = mask != 0
     else:
@@ -797,24 +869,25 @@ def _load_astra_hdu(hdulist: HDUList, hdu: int, visit: Optional[int] = None, **k
     meta["header"] = hdulist[0].header
 
     # Add identifiers (obj, telescope, mjd, datatype)
-    meta["telescope"] = hdulist[hdu].data["telescope"]
+    meta["telescope"] = data["telescope"]
     meta["instrument"] = "BOSS" if hdu <= 2 else "APOGEE"
     try:  # get obj if exists
-        meta["obj"] = hdulist[hdu].data["obj"]
+        meta["obj"] = data["obj"]
     except KeyError:
         pass
 
     # choose between mwmVisit/Star via KeyError except
     try:
-        meta["mjd"] = hdulist[hdu].data["mjd"]
+        meta["mjd"] = data["mjd"]
         meta["datatype"] = "astraVisit"
     except KeyError:
-        meta["min_mjd"] = str(hdulist[hdu].data["min_mjd"][0])
-        meta["max_mjd"] = str(hdulist[hdu].data["max_mjd"][0])
+        meta["min_mjd"] = str(data["min_mjd"][0])
+        meta["max_mjd"] = str(data["max_mjd"][0])
         meta["datatype"] = "astraStar"
     finally:
         meta["name"] = hdulist[hdu].name
         meta["sdss_id"] = hdulist[0].header["sdss_id"]
+        meta["pipeline"] = pipeline
 
     # drop back a list of Spectrum objects to unpack
     metadicts = _split_mwm_meta_dict(meta)

--- a/specutils/io/default_loaders/sdss_v.py
+++ b/specutils/io/default_loaders/sdss_v.py
@@ -5,7 +5,7 @@ from typing import Optional
 import numpy as np
 from astropy.io.fits import BinTableHDU, HDUList, ImageHDU
 from astropy.nddata import InverseVariance, StdDevUncertainty
-from astropy.units import Angstrom, Quantity, Unit
+from astropy.units import Angstrom, Quantity, Unit, nanometer
 from astropy.utils.exceptions import AstropyUserWarning
 
 from ...spectra import Spectrum, SpectrumList
@@ -21,6 +21,8 @@ __all__ = [
     "load_sdss_spec_list",
     "load_sdss_mwm_1d",
     "load_sdss_mwm_list",
+    "load_sdss_astra_1d",
+    "load_sdss_astra_list",
 ]
 
 
@@ -87,7 +89,22 @@ def mwm_identify(origin, *args, **kwargs):
     with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
         return (("V_ASTRA" in hdulist[0].header.keys()) and len(hdulist) > 0
                 and ("SDSS_ID" in hdulist[0].header.keys())
-                and (isinstance(hdulist[i], BinTableHDU) for i in range(1, 5)))
+                and (isinstance(hdulist[i], BinTableHDU) for i in range(1, 5))
+                and all("model_flux" not in hdulist[i].columns.names
+                        for i in range(1, 5)))
+
+
+def astra_identify(origin, *args, **kwargs):
+    """
+    Check whether given input is FITS and has SDSS-V astra model spectra
+    BINTABLE in all 4 extensions. This is used for Astropy I/O Registry.
+    """
+    with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
+        return (("V_ASTRA" in hdulist[0].header.keys()) and len(hdulist) > 0
+                and ("SDSS_ID" in hdulist[0].header.keys())
+                and (isinstance(hdulist[i], BinTableHDU) for i in range(1, 5))
+                and all("model_flux" in hdulist[i].columns.names
+                        for i in range(1, 5)))
 
 
 def _wcs_log_linear(naxis, cdelt, crval):
@@ -442,12 +459,9 @@ def _load_BOSS_HDU(hdulist: HDUList, hdu: int, **kwargs):
     priority=20,
     extensions=["fits"],
 )
-def load_sdss_mwm_1d(file_obj,
-                     hdu: Optional[int] = None,
-                     visit: Optional[int] = None,
-                     **kwargs):
+def load_sdss_mwm_1d(file_obj, hdu: Optional[int] = None, **kwargs):
     """
-    Load an unspecified spec file as a Spectrum.
+    Load an unspecified MWM spec file as a Spectrum.
 
     Parameters
     ----------
@@ -471,7 +485,6 @@ def load_sdss_mwm_1d(file_obj,
         if (np.array(datasums) == 0).all():
             raise ValueError("Specified file is empty.")
 
-        # TODO: how should we handle this -- multiple things in file, but the user cannot choose.
         if hdu is None:
             for i, hduext in enumerate(hdulist):
                 if hduext.header.get("DATASUM") != "0" and len(hduext.data) > 0:
@@ -479,6 +492,9 @@ def load_sdss_mwm_1d(file_obj,
                     warnings.warn(
                         f'HDU not specified. Loading spectrum at (HDU{i})', AstropyUserWarning)
                     break
+
+            if hdu is None:
+                raise ValueError("No valid HDU found to load.")
 
         # load spectra and return
         return _load_mwmVisit_or_mwmStar_hdu(hdulist, hdu)
@@ -597,7 +613,7 @@ def _load_mwmVisit_or_mwmStar_hdu(hdulist: HDUList, hdu: int, **kwargs):
 
     # choose between mwmVisit/Star via KeyError except
     try:
-        meta['mjd'] = hdulist[hdu].data['mjd']
+        meta["mjd"] = hdulist[hdu].data["mjd"]
         meta["datatype"] = "mwmVisit"
     except KeyError:
         meta["min_mjd"] = str(hdulist[hdu].data["min_mjd"][0])
@@ -605,7 +621,7 @@ def _load_mwmVisit_or_mwmStar_hdu(hdulist: HDUList, hdu: int, **kwargs):
         meta["datatype"] = "mwmStar"
     finally:
         meta["name"] = hdulist[hdu].name
-        meta["sdss_id"] = hdulist[hdu].data['sdss_id']
+        meta["sdss_id"] = hdulist[hdu].data["sdss_id"]
 
     # drop back a list of Spectrum objects to unpack
     return Spectrum(
@@ -615,3 +631,244 @@ def _load_mwmVisit_or_mwmStar_hdu(hdulist: HDUList, hdu: int, **kwargs):
         mask=mask,
         meta=meta,
     )
+
+
+@data_loader(
+    "SDSS-V Astra model spectrum",
+    identifier=astra_identify,
+    dtype=Spectrum,
+    priority=20,
+    extensions=["fits"],
+)
+def load_sdss_astra_1d(
+    file_obj,
+    hdu: Optional[int] = None,
+    visit: Optional[int] = None,
+    **kwargs,
+):
+    """Load an Astra model spectrum file as a `~specutils.Spectrum`.
+
+    Parameters
+    ----------
+    file_obj : str, file-like, or HDUList
+        FITS file name, file object, or HDUList.
+    hdu : int
+        Specified HDU to load.
+    visit : Optional[int]
+        Specified visit index to load.
+
+    Returns
+    -------
+    spectrum : `~specutils.Spectrum`
+        The spectra contained in the file from the provided HDU OR the first entry.
+
+    """
+
+    with read_fileobj_or_hdulist(file_obj, memmap=False, **kwargs) as hdulist:
+        # Check if file is empty first
+        datasums = []
+        for i in range(1, len(hdulist)):
+            datasums.append(int(hdulist[i].header.get("DATASUM")))
+        if (np.array(datasums) == 0).all():
+            raise ValueError("Specified file is empty.")
+
+        if hdu is None:
+            for i in range(1, len(hdulist)):
+                if hdulist[i].header.get("DATASUM") != "0":
+                    hdu = i
+                    break
+
+            if hdu is None:
+                raise ValueError("No valid HDU found to load.")
+
+        return _load_astra_hdu(hdulist, hdu, visit=(visit or 0), **kwargs)
+
+
+@data_loader(
+    "SDSS-V Astra model",
+    identifier=astra_identify,
+    force=True,
+    dtype=SpectrumList,
+    priority=20,
+    extensions=["fits"],
+)
+def load_sdss_astra_list(file_obj, **kwargs):
+    """Load an astra model spectrum file as a `~specutils.SpectrumList`.
+
+    Parameters
+    ----------
+    file_obj : str, file-like, or HDUList
+        FITS file name, file object, or HDUList.
+
+    Returns
+    -------
+    spectra: `~specutils.SpectrumList`
+        All of the spectra contained in the file.
+
+    """
+
+    spectra = SpectrumList()
+
+    with read_fileobj_or_hdulist(file_obj, memmap=False, **kwargs) as hdulist:
+        # Check if file is empty first
+        datasums = []
+        for hdu in range(1, len(hdulist)):
+            datasums.append(int(hdulist[hdu].header.get("DATASUM")))
+        if (np.array(datasums) == 0).all():
+            raise ValueError("Specified file is empty.")
+
+        # Now load file
+        for hdu in range(1, len(hdulist)):
+            if hdulist[hdu].header.get("DATASUM") == "0":
+                # Skip zero data HDU's
+                continue
+            spectra.extend(_load_astra_hdu(hdulist, hdu))
+
+    if len(spectra) == 0:
+        raise ValueError("No valid HDU found to load.")
+
+    return spectra
+
+
+def _load_astra_hdu(hdulist: HDUList, hdu: int, visit: Optional[int] = None, **kwargs):
+    """HDU loader subfunction for astra model spectrum files
+
+    Parameters
+    ----------
+    hdulist: HDUList
+        HDUList generated from imported file.
+    hdu: int
+        Specified HDU to load.
+    visit: Optional[int]
+        Specified visit index to load. If None, returns a list of
+        all spectra in the HDU.
+
+    Returns
+    -------
+    list[Spectrum]
+        List of spectrum with 1D flux contained in the HDU.
+
+    """
+
+    if hdulist[hdu].header.get("DATASUM") == "0":
+        raise IndexError("Attemped to load an empty HDU at HDU{}".format(hdu))
+
+    # Fetch wavelength
+    # encoded as WCS for visit, and 'wavelength' for star
+    try:
+        wavelength = np.array(hdulist[hdu].data["wavelength"])[0]
+    except KeyError:
+        wavelength = _wcs_log_linear(
+            hdulist[hdu].header.get("NPIXELS"),
+            hdulist[hdu].header.get("CDELT"),
+            hdulist[hdu].header.get("CRVAL"),
+        )
+    finally:
+        if wavelength is None:
+            raise ValueError("Couldn't find wavelength data in HDU{}.".format(hdu))
+        spectral_axis = Quantity(wavelength, unit=nanometer * 0.1)
+
+    # Fetch flux, e_flux
+    flux_unit = Unit("1e-17 erg / (Angstrom cm2 s)")  # NOTE: hardcoded unit
+    model_flux = hdulist[hdu].data["model_flux"]
+
+    if "continuum" in hdulist[hdu].columns.names:
+        continuum = hdulist[hdu].data["continuum"]
+        flux = Quantity(model_flux * continuum, unit=flux_unit)
+    else:
+        flux = Quantity(model_flux, unit=flux_unit)
+
+    if 'ivar' in hdulist[hdu].columns.names:
+        e_flux = InverseVariance(array=hdulist[hdu].data["ivar"])
+    else:
+        # NOTE: is this a good idea? Model spectra don't have ivar.
+        e_flux = StdDevUncertainty(np.zeros_like(model_flux))
+
+    # Collect bitmask
+    if "pixel_flags" in hdulist[hdu].columns.names:
+        mask = hdulist[hdu].data["pixel_flags"]
+        # NOTE: specutils considers 0/False as valid values, simlar to numpy convention
+        mask = mask != 0
+    else:
+        mask = ~np.isfinite(flux)
+
+    # Create metadata
+    meta = dict()
+    meta["header"] = hdulist[0].header
+
+    # Add identifiers (obj, telescope, mjd, datatype)
+    meta["telescope"] = hdulist[hdu].data["telescope"]
+    meta["instrument"] = "BOSS" if hdu <= 2 else "APOGEE"
+    try:  # get obj if exists
+        meta["obj"] = hdulist[hdu].data["obj"]
+    except KeyError:
+        pass
+
+    # choose between mwmVisit/Star via KeyError except
+    try:
+        meta["mjd"] = hdulist[hdu].data["mjd"]
+        meta["datatype"] = "astraVisit"
+    except KeyError:
+        meta["min_mjd"] = str(hdulist[hdu].data["min_mjd"][0])
+        meta["max_mjd"] = str(hdulist[hdu].data["max_mjd"][0])
+        meta["datatype"] = "astraStar"
+    finally:
+        meta["name"] = hdulist[hdu].name
+        meta["sdss_id"] = hdulist[0].header["sdss_id"]
+
+    # drop back a list of Spectrum objects to unpack
+    metadicts = _split_mwm_meta_dict(meta)
+
+    spectra = [
+        Spectrum(
+            spectral_axis=spectral_axis,
+            flux=flux[i],
+            uncertainty=e_flux[i],
+            mask=mask[i],
+            meta=metadicts[i],
+        )
+        for i in (range(flux.shape[0]) if visit is None else [visit])
+    ]
+
+    if len(spectra) == 1 and visit is not None:
+        return spectra[0]
+
+    return spectra
+
+
+def _split_mwm_meta_dict(d):
+    """
+    Metadata sub-loader subfunction for MWM files.
+
+    Parameters
+    ----------
+    d: dict
+        Initial metadata dictionary.
+
+    Returns
+    -------
+    dicts: list[dict]
+        List of dicts with unpacked metadata for length > 1 array objects.
+
+    """
+    # find the length of entries
+    N = max(len(v) if isinstance(v, np.ndarray) else 1 for v in d.values())
+
+    # create N dictionaries to hold the split results
+    dicts = [{} for _ in range(N)]
+
+    for key, value in d.items():
+        if isinstance(value, np.ndarray):
+            # Ensure that the length of the list matches N
+            if len(value) != N:
+                # an error case we ignore
+                continue
+            # distribute each element to the corresponding metadict
+            for i in range(N):
+                dicts[i][key] = value[i]
+        else:
+            # if it's a single object, copy it to each metadict
+            for i in range(N):
+                dicts[i][key] = value
+
+    return dicts

--- a/specutils/io/default_loaders/sdss_v.py
+++ b/specutils/io/default_loaders/sdss_v.py
@@ -739,6 +739,9 @@ def load_sdss_astra_1d(
             if hdu is None:
                 raise ValueError("No valid HDU found to load.")
 
+        # The astraVisit files have the same format as astraStar but with
+        # multiple rows per BinTable HDU. If the visit index is not specified,
+        # we default to loading the first spectrum.
         return _load_astra_hdu(hdulist, hdu, visit=(visit or 0), **kwargs)
 
 

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -13,7 +13,8 @@ from specutils import Spectrum, SpectrumList
 def generate_apogee_hdu(observatory="APO",
                         with_wl=True,
                         datasum="0",
-                        nvisits=1):
+                        nvisits=1,
+                        astra=False):
     wl = (10**(4.179 + 6e-6 * np.arange(8575))).reshape((1, -1))
     flux = np.array([np.zeros_like(wl)] * nvisits)
     ivar = np.array([np.zeros_like(wl)] * nvisits)
@@ -23,15 +24,15 @@ def generate_apogee_hdu(observatory="APO",
 
     columns = [
         fits.Column(name="spectrum_pk_id", array=[159783564], format="K"),
-        fits.Column(name="release", array=[b"sdss5"], format="5A"),
-        fits.Column(name="filetype", array=[b"apStar"], format="6A"),
-        fits.Column(name="v_astra", array=[b"0.5.0"], format="5A"),
+        fits.Column(name="release", array=[b"sdss5"] * nvisits, format="5A"),
+        fits.Column(name="v_astra", array=[b"0.5.0"] * nvisits, format="5A"),
         fits.Column(name="healpix", array=[3], format="J"),
-        fits.Column(name="sdss_id", array=[42], format="K"),
-        fits.Column(name="apred", array=[b"1.2"], format="3A"),
+        fits.Column(name="sdss_id", array=[42] * nvisits, format="K"),
+        fits.Column(name="apred", array=[b"1.2"] * nvisits, format="3A"),
         fits.Column(name="obj", array=[b"2M19534321+6705175"], format="18A"),
-        fits.Column(name="telescope", array=[b"apo25m"], format="6A"),
-        fits.Column(name="snr", array=[50], format="E"),
+        fits.Column(name="telescope", array=[b"apo25m"] * nvisits,
+                    format="6A"),
+        fits.Column(name="snr", array=[50] * nvisits, format="E"),
     ]
     if with_wl:
         columns.append(
@@ -47,8 +48,10 @@ def generate_apogee_hdu(observatory="APO",
         columns += [
             fits.Column(name="mjd", array=[59804], format="J"),
         ]
+    flux_col = "model_flux" if astra else "flux"
+
     columns += [
-        fits.Column(name="flux", array=flux, format="8575E", dim="(8575)"),
+        fits.Column(name=flux_col, array=flux, format="8575E", dim="(8575)"),
         fits.Column(name="ivar", array=ivar, format="8575E", dim="(8575)"),
         fits.Column(name="pixel_flags",
                     array=pixel_flags,
@@ -84,7 +87,11 @@ def generate_apogee_hdu(observatory="APO",
     return fits.BinTableHDU.from_columns(columns, header=header)
 
 
-def generate_boss_hdu(observatory="APO", with_wl=True, datasum="0", nvisits=1):
+def generate_boss_hdu(observatory="APO",
+                      with_wl=True,
+                      datasum="0",
+                      nvisits=1,
+                      astra=False):
     wl = (10**(3.5523 + 1e-4 * np.arange(4648))).reshape((1, -1))
     flux = np.array([np.zeros_like(wl)] * nvisits)
     ivar = np.array([np.zeros_like(wl)] * nvisits)
@@ -92,15 +99,14 @@ def generate_boss_hdu(observatory="APO", with_wl=True, datasum="0", nvisits=1):
     continuum = np.array([np.zeros_like(wl)] * nvisits)
     nmf_rectified_model_flux = np.array([np.zeros_like(wl)] * nvisits)
     columns = [
-        fits.Column(name="spectrum_pk_id", array=[0], format="K"),
-        fits.Column(name="release", array=["sdss5"], format="5A"),
-        fits.Column(name="filetype", array=["specFull"], format="7A"),
+        fits.Column(name="spectrum_pk_id", array=[0] * nvisits, format="K"),
+        fits.Column(name="release", array=["sdss5"] * nvisits, format="5A"),
         fits.Column(name="v_astra", array=["0.5.0"], format="5A"),
         fits.Column(name="healpix", array=[34], format="J"),
         fits.Column(name="sdss_id", array=[42], format="K"),
         fits.Column(name="run2d", array=["6_1_2"], format="6A"),
-        fits.Column(name="telescope", array=["apo25m"], format="6A"),
-        fits.Column(name="snr", array=[50], format="E"),
+        fits.Column(name="telescope", array=["apo25m"] * nvisits, format="6A"),
+        fits.Column(name="snr", array=[50] * nvisits, format="E"),
     ]
 
     if with_wl:
@@ -117,8 +123,9 @@ def generate_boss_hdu(observatory="APO", with_wl=True, datasum="0", nvisits=1):
         columns += [
             fits.Column(name="mjd", array=[59804], format="J"),
         ]
+    flux_col = "model_flux" if astra else "flux"
     columns += [
-        fits.Column(name="flux", array=flux, format="4648E", dim="(4648)"),
+        fits.Column(name=flux_col, array=flux, format="4648E", dim="(4648)"),
         fits.Column(name="ivar", array=ivar, format="4648E", dim="(4648)"),
         fits.Column(name="pixel_flags",
                     array=pixel_flags,
@@ -465,7 +472,50 @@ def test_mwm_1d_nohdu(file_obj, hdu, with_wl, hduflags, nvisits):
         assert data.flux.value.shape[-1] == length
         if nvisits > 1:
             assert data.flux.value.shape[0] == nvisits
+        if with_wl:
+            assert data.meta["datatype"].lower() == "mwmstar"
+        else:
+            assert data.meta["datatype"].lower() == "mwmvisit"
+        assert data.spectral_axis.unit == Angstrom
+        assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
+        os.remove(tmpfile)
 
+
+@pytest.mark.parametrize(
+    "file_obj, hdu, with_wl, hduflags, nvisits",
+    [
+        ("mwm-temp", None, False, [0, 0, 1, 0], 1),  # visit
+        ("mwm-temp", None, False, [0, 1, 1, 0], 3),  # multi-ext visits
+        ("mwm-temp", None, True, [0, 0, 1, 0], 1),  # star
+        ("mwm-temp", None, True, [0, 1, 1, 0], 1),
+    ],
+)
+def test_astra_nohdu(file_obj, hdu, with_wl, hduflags, nvisits):
+    """Test astra Spectrum loader when HDU isn't specified"""
+    tmpfile = str(file_obj) + ".fits"
+    mwm_HDUList(hduflags, with_wl, nvisits=nvisits,
+                astra=True).writeto(tmpfile, overwrite=True)
+
+    with pytest.warns(AstropyUserWarning):
+        data = Spectrum.read(tmpfile, hdu=hdu)
+        assert isinstance(data, Spectrum)
+        assert isinstance(data.meta["header"], fits.Header)
+
+        if data.meta["instrument"].lower() == "apogee":
+            length = 8575
+        elif data.meta["instrument"].lower() == "boss":
+            length = 4648
+        else:
+            raise ValueError(
+                "INSTRMNT tag in test HDU header is not set properly.")
+        assert len(data.spectral_axis.value) == length
+        assert data.flux.value.shape[-1] == length
+        if nvisits > 1:
+            assert data.flux.value.shape[0] == nvisits
+        if with_wl:
+            assert data.meta["datatype"].lower() == "astrastar"
+        else:
+            assert data.meta["datatype"].lower() == "astravisit"
         assert data.spectral_axis.unit == Angstrom
         assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
         os.remove(tmpfile)
@@ -514,6 +564,49 @@ def test_mwm_1d(file_obj, hdu, with_wl, hduflags, nvisits):
     assert data.flux.value.shape[-1] == length
     if nvisits > 1:
         assert data.flux.value.shape[0] == nvisits
+    if with_wl:
+        assert data.meta["datatype"].lower() == "mwmstar"
+    else:
+        assert data.meta["datatype"].lower() == "mwmvisit"
+    assert data.spectral_axis.unit == Angstrom
+    assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
+    os.remove(tmpfile)
+
+
+@pytest.mark.parametrize(
+    "file_obj, hdu, with_wl, hduflags, nvisits",
+    [
+        ("astra-temp", 3, False, [0, 0, 1, 0], 1),
+        ("astra-temp", 3, False, [0, 1, 1, 0], 5),
+        ("astra-temp", 3, True, [0, 0, 1, 0], 1),
+        ("astra-temp", 2, True, [0, 1, 1, 0], 1),
+    ],
+)
+def test_astra_1d(file_obj, hdu, with_wl, hduflags, nvisits):
+    """Test astra Spectrum loader"""
+    tmpfile = str(file_obj) + ".fits"
+    mwm_HDUList(hduflags, with_wl, nvisits=nvisits,
+                astra=True).writeto(tmpfile, overwrite=True)
+
+    data = Spectrum.read(tmpfile, hdu=hdu)
+    assert isinstance(data, Spectrum)
+    assert isinstance(data.meta["header"], fits.Header)
+    if data.meta["instrument"].lower() == "apogee":
+        length = 8575
+    elif data.meta["instrument"].lower() == "boss":
+        length = 4648
+    else:
+        raise ValueError(
+            "INSTRMNT tag in test HDU header is not set properly.")
+    assert len(data.spectral_axis.value) == length
+    assert data.flux.value.shape[-1] == length
+    if nvisits > 1:
+        assert data.flux.value.shape[0] == nvisits
+
+    if with_wl:
+        assert data.meta["datatype"].lower() == "astrastar"
+    else:
+        assert data.meta["datatype"].lower() == "astravisit"
 
     assert data.spectral_axis.unit == Angstrom
     assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
@@ -553,9 +646,54 @@ def test_mwm_list(file_obj, with_wl, hduflags):
             raise ValueError(
                 "INSTRMNT tag in test HDU header is not set properly.")
         if with_wl:
-            assert data[i].meta['datatype'].lower() == 'mwmstar'
+            assert data[i].meta["datatype"].lower() == "mwmstar"
         else:
-            assert data[i].meta['datatype'].lower() == 'mwmvisit'
+            assert data[i].meta["datatype"].lower() == "mwmvisit"
+        assert len(data[i].spectral_axis.value) == length
+        assert data[i].flux.value.shape[-1] == length
+        if nvisits > 1:
+            assert data[i].flux.value.shape[0] == nvisits
+        assert data[i].spectral_axis.unit == Angstrom
+        assert data[i].flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
+    os.remove(tmpfile)
+
+
+@pytest.mark.parametrize(
+    "file_obj, with_wl, hduflags",
+    [
+        ("astra-temp", False, [0, 0, 1, 1]),
+        ("astra-temp", False, [0, 1, 1, 0]),
+        ("astra-temp", False, [1, 1, 0, 0]),
+        ("astra-temp", False, [1, 1, 1, 1]),
+        ("astra-temp", True, [0, 0, 1, 1]),
+        ("astra-temp", True, [0, 1, 1, 0]),
+        ("astra-temp", True, [1, 1, 0, 0]),
+        ("astra-temp", True, [1, 1, 1, 1]),
+    ],
+)
+def test_astra_list(file_obj, with_wl, hduflags):
+    """Test astra SpectrumList loader"""
+    tmpfile = str(file_obj) + ".fits"
+    nvisits = 1 if with_wl else 3
+    mwm_HDUList(hduflags, with_wl, nvisits=nvisits,
+                astra=True).writeto(tmpfile, overwrite=True)
+
+    data = SpectrumList.read(tmpfile)
+    assert isinstance(data, SpectrumList)
+    for i in range(len(data)):
+        assert isinstance(data[i], Spectrum)
+        assert isinstance(data[i].meta["header"], fits.Header)
+        if data[i].meta["instrument"].lower() == "apogee":
+            length = 8575
+        elif data[i].meta["instrument"].lower() == "boss":
+            length = 4648
+        else:
+            raise ValueError(
+                "INSTRMNT tag in test HDU header is not set properly.")
+        if with_wl:
+            assert data[i].meta["datatype"].lower() == "astrastar"
+        else:
+            assert data[i].meta["datatype"].lower() == "astravisit"
         assert len(data[i].spectral_axis.value) == length
         assert data[i].flux.value.shape[-1] == length
         if nvisits > 1:
@@ -603,6 +741,24 @@ def test_mwm_1d_fail(file_obj, with_wl):
 @pytest.mark.parametrize(
     "file_obj, with_wl",
     [
+        ("astra-temp", False),
+        ("astra-temp", True),
+    ],
+)
+def test_astra_1d_fail(file_obj, with_wl):
+    """Test astra Spectrum loader fail on empty"""
+    tmpfile = str(file_obj) + ".fits"
+    mwm_HDUList([0, 0, 0, 0], with_wl, astra=True).writeto(tmpfile,
+                                                           overwrite=True)
+
+    with pytest.raises(ValueError):
+        Spectrum.read(tmpfile)
+    os.remove(tmpfile)
+
+
+@pytest.mark.parametrize(
+    "file_obj, with_wl",
+    [
         ("mwm-temp", False),
         ("mwm-temp", True),
     ],
@@ -611,6 +767,24 @@ def test_mwm_list_fail(file_obj, with_wl):
     """Test mwm SpectrumList loader fail on empty"""
     tmpfile = str(file_obj) + ".fits"
     mwm_HDUList([0, 0, 0, 0], with_wl).writeto(tmpfile, overwrite=True)
+
+    with pytest.raises(ValueError):
+        SpectrumList.read(tmpfile)
+    os.remove(tmpfile)
+
+
+@pytest.mark.parametrize(
+    "file_obj, with_wl",
+    [
+        ("astra-temp", False),
+        ("astra-temp", True),
+    ],
+)
+def test_astra_list_fail(file_obj, with_wl):
+    """Test astra SpectrumList loader fail on empty"""
+    tmpfile = str(file_obj) + ".fits"
+    mwm_HDUList([0, 0, 0, 0], with_wl, astra=True).writeto(tmpfile,
+                                                           overwrite=True)
 
     with pytest.raises(ValueError):
         SpectrumList.read(tmpfile)

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -10,12 +10,14 @@ from astropy.utils.exceptions import AstropyUserWarning
 from specutils import Spectrum, SpectrumList
 
 
-def generate_apogee_hdu(observatory="APO",
-                        with_wl=True,
-                        astra_pipeline=None,
-                        datasum="0",
-                        nvisits=1,
-                        astra=False):
+def generate_apogee_hdu(
+    observatory="APO",
+    with_wl=True,
+    astra=False,
+    astra_pipeline="ASPCAP",
+    datasum="0",
+    nvisits=1,
+):
     wl = (10 ** (4.179 + 6e-6 * np.arange(8575))).reshape((1, -1))
     flux = np.array([np.zeros_like(wl)] * nvisits)
     ivar = np.array([np.zeros_like(wl)] * nvisits)
@@ -92,12 +94,14 @@ def generate_apogee_hdu(observatory="APO",
     return fits.BinTableHDU.from_columns(columns, header=header)
 
 
-def generate_boss_hdu(observatory="APO",
-                      with_wl=True,
-                      astra_pipeline=None,
-                      datasum="0",
-                      nvisits=1,
-                      astra=False):
+def generate_boss_hdu(
+    observatory="APO",
+    with_wl=True,
+    astra=False,
+    astra_pipeline="ASPCAP",
+    datasum="0",
+    nvisits=1,
+):
     wl = (10 ** (3.5523 + 1e-4 * np.arange(4648))).reshape((1, -1))
     flux = np.array([np.zeros_like(wl)] * nvisits)
     ivar = np.array([np.zeros_like(wl)] * nvisits)
@@ -321,24 +325,28 @@ def fake_primary_hdu():
     ]))
 
 
-def mwm_HDUList(hduflags, with_wl=False, astra_pipeline=None,**kwargs):
+def mwm_HDUList(hduflags, with_wl=False, **kwargs):
     hdulist = [fake_primary_hdu()]
     for i, flag in enumerate(hduflags):
         obs = ["APO", "LCO"]
         if i <= 1:
             hdulist.append(
-                generate_boss_hdu(obs[i % 2],
-                                  with_wl=with_wl,
-                                  astra_pipeline=astra_pipeline,
-                                  datasum=str(flag),
-                                  **kwargs))
+                generate_boss_hdu(
+                    obs[i % 2],
+                    with_wl=with_wl,
+                    datasum=str(flag),
+                    **kwargs,
+                )
+            )
         else:
             hdulist.append(
-                generate_apogee_hdu(obs[i % 2],
-                                    with_wl=with_wl,
-                                    astra_pipeline=astra_pipeline,
-                                    datasum=str(flag),
-                                    **kwargs))
+                generate_apogee_hdu(
+                    obs[i % 2],
+                    with_wl=with_wl,
+                    datasum=str(flag),
+                    **kwargs,
+                )
+            )
 
     return fits.HDUList(hdulist)
 
@@ -514,33 +522,43 @@ def test_mwm_1d_nohdu(file_obj, hdu, with_wl, hduflags, nvisits):
 )
 def test_astra_nohdu(file_obj, hdu, with_wl, hduflags, nvisits):
     """Test astra Spectrum loader when HDU isn't specified"""
+
     tmpfile = str(file_obj) + ".fits"
-    mwm_HDUList(hduflags, with_wl, nvisits=nvisits,
-                astra=True).writeto(tmpfile, overwrite=True)
 
-    with pytest.warns(AstropyUserWarning):
-        data = Spectrum.read(tmpfile, hdu=hdu)
-        assert isinstance(data, Spectrum)
-        assert isinstance(data.meta["header"], fits.Header)
+    mwm_HDUList(
+        hduflags,
+        with_wl,
+        nvisits=nvisits,
+        astra=True,
+    ).writeto(
+        tmpfile,
+        overwrite=True,
+    )
 
-        if data.meta["instrument"].lower() == "apogee":
-            length = 8575
-        elif data.meta["instrument"].lower() == "boss":
-            length = 4648
-        else:
-            raise ValueError(
-                "INSTRMNT tag in test HDU header is not set properly.")
-        assert len(data.spectral_axis.value) == length
-        assert data.flux.value.shape[-1] == length
-        if nvisits > 1:
-            assert data.flux.value.shape[0] == nvisits
-        if with_wl:
-            assert data.meta["datatype"].lower() == "astrastar"
-        else:
-            assert data.meta["datatype"].lower() == "astravisit"
-        assert data.spectral_axis.unit == Angstrom
-        assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
-        os.remove(tmpfile)
+    data = Spectrum.read(tmpfile, hdu=hdu)
+
+    assert isinstance(data, Spectrum)
+    assert isinstance(data.meta["header"], fits.Header)
+
+    if data.meta["instrument"].lower() == "apogee":
+        length = 8575
+    elif data.meta["instrument"].lower() == "boss":
+        length = 4648
+    else:
+        raise ValueError("INSTRMNT tag in test HDU header is not set properly.")
+
+    assert len(data.spectral_axis.value) == length
+    assert data.flux.value.shape[-1] == length
+
+    if with_wl:
+        assert data.meta["datatype"].lower() == "astrastar"
+    else:
+        assert data.meta["datatype"].lower() == "astravisit"
+
+    assert data.spectral_axis.unit == Angstrom
+    assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
+
+    os.remove(tmpfile)
 
 
 def test_mwm_1d_baddatasum():
@@ -789,11 +807,14 @@ def test_mwm_1d_fail(file_obj, with_wl):
 )
 def test_astra_1d_fail(file_obj, with_wl):
     """Test astra Spectrum loader fail on empty"""
+
     tmpfile = str(file_obj) + ".fits"
+
     mwm_HDUList([0, 0, 0, 0], with_wl, astra=True).writeto(tmpfile, overwrite=True)
 
     with pytest.raises(ValueError):
         Spectrum.read(tmpfile)
+
     os.remove(tmpfile)
 
 

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -4,6 +4,7 @@ import warnings  # noqa ; required for pytest
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.table import Table
 from astropy.units import Angstrom, Unit
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -844,6 +845,23 @@ def test_astra_list_fail(file_obj, with_wl):
 
     with pytest.raises(ValueError):
         SpectrumList.read(tmpfile)
+    os.remove(tmpfile)
+
+
+def test_astra_no_model_flux_fail():
+    """Test astra loader fail when no model flux is present in the HDUList"""
+
+    tmpfile = "astra-temp.fits"
+    hdul = mwm_HDUList([0, 0, 1, 0], True, astra=True)
+    for hdu in hdul[1:]:
+        tt = Table(hdu.data)
+        tt.remove_column("model_flux")
+        hdu.data = tt.as_array()
+    hdul.writeto(tmpfile, overwrite=True)
+
+    with pytest.raises(OSError):
+        Spectrum.read(tmpfile, hdu=3)
+
     os.remove(tmpfile)
 
 

--- a/specutils/io/default_loaders/tests/test_sdss_v.py
+++ b/specutils/io/default_loaders/tests/test_sdss_v.py
@@ -12,10 +12,11 @@ from specutils import Spectrum, SpectrumList
 
 def generate_apogee_hdu(observatory="APO",
                         with_wl=True,
+                        astra_pipeline=None,
                         datasum="0",
                         nvisits=1,
                         astra=False):
-    wl = (10**(4.179 + 6e-6 * np.arange(8575))).reshape((1, -1))
+    wl = (10 ** (4.179 + 6e-6 * np.arange(8575))).reshape((1, -1))
     flux = np.array([np.zeros_like(wl)] * nvisits)
     ivar = np.array([np.zeros_like(wl)] * nvisits)
     pixel_flags = np.array([np.zeros_like(wl)] * nvisits)
@@ -30,37 +31,39 @@ def generate_apogee_hdu(observatory="APO",
         fits.Column(name="sdss_id", array=[42] * nvisits, format="K"),
         fits.Column(name="apred", array=[b"1.2"] * nvisits, format="3A"),
         fits.Column(name="obj", array=[b"2M19534321+6705175"], format="18A"),
-        fits.Column(name="telescope", array=[b"apo25m"] * nvisits,
-                    format="6A"),
+        fits.Column(name="telescope", array=[b"apo25m"] * nvisits, format="6A"),
         fits.Column(name="snr", array=[50] * nvisits, format="E"),
     ]
+
     if with_wl:
-        columns.append(
-            fits.Column(name="wavelength",
-                        array=wl,
-                        format="8575E",
-                        dim="(8575)"))
         columns += [
+            fits.Column(name="wavelength", array=wl, format="8575E", dim="(8575)"),
             fits.Column(name="min_mjd", array=[59804], format="J"),
             fits.Column(name="max_mjd", array=[59866], format="J"),
         ]
     else:
-        columns += [
-            fits.Column(name="mjd", array=[59804], format="J"),
-        ]
+        columns += [fits.Column(name="mjd", array=[59804], format="J")]
+
+    if astra_pipeline is not None:
+        if astra_pipeline == "ThePayne":
+            columns += [fits.Column(name="rho_fe_h_c12_c13", array=[1], format="E")]
+        elif astra_pipeline == "ASPCAP":
+            columns += [fits.Column(name="model_flux_nd_h", array=[1], format="E")]
+        elif astra_pipeline == "SnowWhite":
+            columns += [fits.Column(name="p_dc_ms", array=[1], format="E")]
+
     flux_col = "model_flux" if astra else "flux"
 
     columns += [
         fits.Column(name=flux_col, array=flux, format="8575E", dim="(8575)"),
         fits.Column(name="ivar", array=ivar, format="8575E", dim="(8575)"),
-        fits.Column(name="pixel_flags",
-                    array=pixel_flags,
-                    format="8575E",
-                    dim="(8575)"),
-        fits.Column(name="continuum",
-                    array=continuum,
-                    format="8575E",
-                    dim="(8575)"),
+        fits.Column(
+            name="pixel_flags",
+            array=pixel_flags,
+            format="8575E",
+            dim="(8575)",
+        ),
+        fits.Column(name="continuum", array=continuum, format="8575E", dim="(8575)"),
         fits.Column(
             name="nmf_rectified_model_flux",
             array=nmf_rectified_model_flux,
@@ -70,34 +73,39 @@ def generate_apogee_hdu(observatory="APO",
         fits.Column(name="nmf_rchi2", array=[2.3391197], format="E"),
         fits.Column(name="nmf_flags", array=[0], format="J"),
     ]
-    header = fits.Header(cards=[
-        ("EXTNAME", f"APOGEE/{observatory}", ""),
-        ("OBSRVTRY", observatory, None),
-        ("INSTRMNT", "APOGEE", None),
-        ("CRVAL", 4.179, None),
-        ("CDELT", 6e-6, None),
-        ("CTYPE", "LOG-LINEAR", None),
-        ("CUNIT", "Angstrom (Vacuum)"),
-        ("CRPIX", 1, None),
-        ("DC-FAG", 1, None),
-        ("NPIXELS", 8575, None),
-        ("DATASUM", datasum, "data unit checksum updated 2023-11-13T03:21:47"),
-    ])
+    header = fits.Header(
+        cards=[
+            ("EXTNAME", f"APOGEE/{observatory}", ""),
+            ("OBSRVTRY", observatory, None),
+            ("INSTRMNT", "APOGEE", None),
+            ("CRVAL", 4.179, None),
+            ("CDELT", 6e-6, None),
+            ("CTYPE", "LOG-LINEAR", None),
+            ("CUNIT", "Angstrom (Vacuum)"),
+            ("CRPIX", 1, None),
+            ("DC-FAG", 1, None),
+            ("NPIXELS", 8575, None),
+            ("DATASUM", datasum, "data unit checksum updated 2023-11-13T03:21:47"),
+        ]
+    )
 
     return fits.BinTableHDU.from_columns(columns, header=header)
 
 
 def generate_boss_hdu(observatory="APO",
                       with_wl=True,
+                      astra_pipeline=None,
                       datasum="0",
                       nvisits=1,
                       astra=False):
-    wl = (10**(3.5523 + 1e-4 * np.arange(4648))).reshape((1, -1))
+    wl = (10 ** (3.5523 + 1e-4 * np.arange(4648))).reshape((1, -1))
     flux = np.array([np.zeros_like(wl)] * nvisits)
     ivar = np.array([np.zeros_like(wl)] * nvisits)
     pixel_flags = np.array([np.zeros_like(wl)] * nvisits)
     continuum = np.array([np.zeros_like(wl)] * nvisits)
     nmf_rectified_model_flux = np.array([np.zeros_like(wl)] * nvisits)
+    pipeline_identify_column = np.array([np.zeros_like(wl)] * nvisits)
+
     columns = [
         fits.Column(name="spectrum_pk_id", array=[0] * nvisits, format="K"),
         fits.Column(name="release", array=["sdss5"] * nvisits, format="5A"),
@@ -110,31 +118,42 @@ def generate_boss_hdu(observatory="APO",
     ]
 
     if with_wl:
-        columns.append(
-            fits.Column(name="wavelength",
-                        array=wl,
-                        format="4648E",
-                        dim="(4648)"))
         columns += [
+            fits.Column(name="wavelength", array=wl, format="4648E", dim="(4648)"),
             fits.Column(name="min_mjd", array=[54], format="J"),
             fits.Column(name="max_mjd", array=[488], format="J"),
         ]
     else:
+        columns += [fits.Column(name="mjd", array=[59804], format="J")]
+
+    if astra_pipeline is not None:
+        if astra_pipeline == "ThePayne":
+            pipeline_column = "rho_fe_h_c12_c13"
+        elif astra_pipeline == "ASPCAP":
+            pipeline_column = "model_flux_nd_h"
+        elif astra_pipeline == "SnowWhite":
+            pipeline_column = "p_dc_ms"
+
         columns += [
-            fits.Column(name="mjd", array=[59804], format="J"),
+            fits.Column(
+                name=pipeline_column,
+                array=pipeline_identify_column,
+                format="4648E",
+                dim="(4648)",
+            ),
         ]
+
     flux_col = "model_flux" if astra else "flux"
     columns += [
         fits.Column(name=flux_col, array=flux, format="4648E", dim="(4648)"),
         fits.Column(name="ivar", array=ivar, format="4648E", dim="(4648)"),
-        fits.Column(name="pixel_flags",
-                    array=pixel_flags,
-                    format="4648E",
-                    dim="(4648)"),
-        fits.Column(name="continuum",
-                    array=continuum,
-                    format="4648E",
-                    dim="(4648)"),
+        fits.Column(
+            name="pixel_flags",
+            array=pixel_flags,
+            format="4648E",
+            dim="(4648)",
+        ),
+        fits.Column(name="continuum", array=continuum, format="4648E", dim="(4648)"),
         fits.Column(
             name="nmf_rectified_model_flux",
             array=nmf_rectified_model_flux,
@@ -144,19 +163,21 @@ def generate_boss_hdu(observatory="APO",
         fits.Column(name="nmf_rchi2", array=[5], format="E"),
         fits.Column(name="nmf_flags", array=[0], format="J"),
     ]
-    header = fits.Header(cards=[
-        ("EXTNAME", f"BOSS/{observatory}", ""),
-        ("OBSRVTRY", observatory, None),
-        ("INSTRMNT", "BOSS", None),
-        ("CRVAL", 3.5523, None),
-        ("CDELT", 1e-4, None),
-        ("CTYPE", "LOG-LINEAR", None),
-        ("CUNIT", "Angstrom (Vacuum)"),
-        ("CRPIX", 1, None),
-        ("DC-FAG", 1, None),
-        ("NPIXELS", 4648, None),
-        ("DATASUM", datasum, "data unit checksum updated 2023-11-13T03:21:47"),
-    ])
+    header = fits.Header(
+        cards=[
+            ("EXTNAME", f"BOSS/{observatory}", ""),
+            ("OBSRVTRY", observatory, None),
+            ("INSTRMNT", "BOSS", None),
+            ("CRVAL", 3.5523, None),
+            ("CDELT", 1e-4, None),
+            ("CTYPE", "LOG-LINEAR", None),
+            ("CUNIT", "Angstrom (Vacuum)"),
+            ("CRPIX", 1, None),
+            ("DC-FAG", 1, None),
+            ("NPIXELS", 4648, None),
+            ("DATASUM", datasum, "data unit checksum updated 2023-11-13T03:21:47"),
+        ]
+    )
 
     return fits.BinTableHDU.from_columns(columns, header=header)
 
@@ -300,7 +321,7 @@ def fake_primary_hdu():
     ]))
 
 
-def mwm_HDUList(hduflags, with_wl, **kwargs):
+def mwm_HDUList(hduflags, with_wl=False, astra_pipeline=None,**kwargs):
     hdulist = [fake_primary_hdu()]
     for i, flag in enumerate(hduflags):
         obs = ["APO", "LCO"]
@@ -308,16 +329,17 @@ def mwm_HDUList(hduflags, with_wl, **kwargs):
             hdulist.append(
                 generate_boss_hdu(obs[i % 2],
                                   with_wl=with_wl,
+                                  astra_pipeline=astra_pipeline,
                                   datasum=str(flag),
                                   **kwargs))
         else:
             hdulist.append(
                 generate_apogee_hdu(obs[i % 2],
                                     with_wl=with_wl,
+                                    astra_pipeline=astra_pipeline,
                                     datasum=str(flag),
                                     **kwargs))
 
-    print(hdulist)
     return fits.HDUList(hdulist)
 
 
@@ -574,34 +596,40 @@ def test_mwm_1d(file_obj, hdu, with_wl, hduflags, nvisits):
 
 
 @pytest.mark.parametrize(
-    "file_obj, hdu, with_wl, hduflags, nvisits",
+    "file_obj, hdu, with_wl, hduflags, nvisits, pipeline",
     [
-        ("astra-temp", 3, False, [0, 0, 1, 0], 1),
-        ("astra-temp", 3, False, [0, 1, 1, 0], 5),
-        ("astra-temp", 3, True, [0, 0, 1, 0], 1),
-        ("astra-temp", 2, True, [0, 1, 1, 0], 1),
+        ("astra-temp", 3, False, [0, 0, 1, 0], 1, "ThePayne"),
+        ("astra-temp", 3, True, [0, 0, 1, 0], 1, "SnowWhite"),
+        ("astra-temp", 2, True, [0, 1, 1, 0], 1, "ASPCAP"),
     ],
 )
-def test_astra_1d(file_obj, hdu, with_wl, hduflags, nvisits):
+def test_astra_1d(file_obj, hdu, with_wl, hduflags, nvisits, pipeline):
     """Test astra Spectrum loader"""
+
     tmpfile = str(file_obj) + ".fits"
-    mwm_HDUList(hduflags, with_wl, nvisits=nvisits,
-                astra=True).writeto(tmpfile, overwrite=True)
+
+    mwm_HDUList(
+        hduflags,
+        with_wl=with_wl,
+        astra_pipeline=pipeline,
+        nvisits=nvisits,
+        astra=True,
+    ).writeto(tmpfile, overwrite=True)
 
     data = Spectrum.read(tmpfile, hdu=hdu)
+
     assert isinstance(data, Spectrum)
     assert isinstance(data.meta["header"], fits.Header)
+
     if data.meta["instrument"].lower() == "apogee":
         length = 8575
     elif data.meta["instrument"].lower() == "boss":
         length = 4648
     else:
-        raise ValueError(
-            "INSTRMNT tag in test HDU header is not set properly.")
+        raise ValueError("INSTRMNT tag in test HDU header is not set properly.")
+
     assert len(data.spectral_axis.value) == length
     assert data.flux.value.shape[-1] == length
-    if nvisits > 1:
-        assert data.flux.value.shape[0] == nvisits
 
     if with_wl:
         assert data.meta["datatype"].lower() == "astrastar"
@@ -610,6 +638,7 @@ def test_astra_1d(file_obj, hdu, with_wl, hduflags, nvisits):
 
     assert data.spectral_axis.unit == Angstrom
     assert data.flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
+
     os.remove(tmpfile)
 
 
@@ -659,47 +688,63 @@ def test_mwm_list(file_obj, with_wl, hduflags):
 
 
 @pytest.mark.parametrize(
-    "file_obj, with_wl, hduflags",
+    "file_obj, with_wl, hduflags, pipeline",
     [
-        ("astra-temp", False, [0, 0, 1, 1]),
-        ("astra-temp", False, [0, 1, 1, 0]),
-        ("astra-temp", False, [1, 1, 0, 0]),
-        ("astra-temp", False, [1, 1, 1, 1]),
-        ("astra-temp", True, [0, 0, 1, 1]),
-        ("astra-temp", True, [0, 1, 1, 0]),
-        ("astra-temp", True, [1, 1, 0, 0]),
-        ("astra-temp", True, [1, 1, 1, 1]),
+        ("astra-temp", False, [0, 0, 1, 1], "ThePayne"),
+        ("astra-temp", False, [0, 1, 1, 0], "ThePayne"),
+        ("astra-temp", False, [1, 1, 0, 0], "ThePayne"),
+        ("astra-temp", False, [1, 1, 1, 1], "ThePayne"),
+        ("astra-temp", True, [0, 0, 1, 1], "ThePayne"),
+        ("astra-temp", True, [0, 1, 1, 0], "ThePayne"),
+        ("astra-temp", True, [1, 1, 0, 0], "ThePayne"),
+        ("astra-temp", True, [1, 1, 1, 1], "ThePayne"),
     ],
 )
-def test_astra_list(file_obj, with_wl, hduflags):
+def test_astra_list(file_obj, with_wl, hduflags, pipeline):
     """Test astra SpectrumList loader"""
+
     tmpfile = str(file_obj) + ".fits"
     nvisits = 1 if with_wl else 3
-    mwm_HDUList(hduflags, with_wl, nvisits=nvisits,
-                astra=True).writeto(tmpfile, overwrite=True)
+
+    mwm_HDUList(
+        hduflags,
+        with_wl,
+        astra_pipeline=pipeline,
+        nvisits=nvisits,
+        astra=True,
+    ).writeto(
+        tmpfile,
+        overwrite=True,
+    )
 
     data = SpectrumList.read(tmpfile)
     assert isinstance(data, SpectrumList)
+
+    if nvisits > 1:
+        assert len(data) == nvisits * sum(hduflags)
+
     for i in range(len(data)):
         assert isinstance(data[i], Spectrum)
         assert isinstance(data[i].meta["header"], fits.Header)
+
         if data[i].meta["instrument"].lower() == "apogee":
             length = 8575
         elif data[i].meta["instrument"].lower() == "boss":
             length = 4648
         else:
-            raise ValueError(
-                "INSTRMNT tag in test HDU header is not set properly.")
+            raise ValueError("INSTRMNT tag in test HDU header is not set properly.")
+
         if with_wl:
             assert data[i].meta["datatype"].lower() == "astrastar"
         else:
             assert data[i].meta["datatype"].lower() == "astravisit"
+
         assert len(data[i].spectral_axis.value) == length
         assert data[i].flux.value.shape[-1] == length
-        if nvisits > 1:
-            assert data[i].flux.value.shape[0] == nvisits
+
         assert data[i].spectral_axis.unit == Angstrom
         assert data[i].flux.unit == Unit("1e-17 erg / (s cm2 Angstrom)")
+
     os.remove(tmpfile)
 
 
@@ -740,16 +785,12 @@ def test_mwm_1d_fail(file_obj, with_wl):
 
 @pytest.mark.parametrize(
     "file_obj, with_wl",
-    [
-        ("astra-temp", False),
-        ("astra-temp", True),
-    ],
+    [("astra-temp", False), ("astra-temp", True)],
 )
 def test_astra_1d_fail(file_obj, with_wl):
     """Test astra Spectrum loader fail on empty"""
     tmpfile = str(file_obj) + ".fits"
-    mwm_HDUList([0, 0, 0, 0], with_wl, astra=True).writeto(tmpfile,
-                                                           overwrite=True)
+    mwm_HDUList([0, 0, 0, 0], with_wl, astra=True).writeto(tmpfile, overwrite=True)
 
     with pytest.raises(ValueError):
         Spectrum.read(tmpfile)
@@ -758,13 +799,11 @@ def test_astra_1d_fail(file_obj, with_wl):
 
 @pytest.mark.parametrize(
     "file_obj, with_wl",
-    [
-        ("mwm-temp", False),
-        ("mwm-temp", True),
-    ],
+    [("mwm-temp", False), ("mwm-temp", True)],
 )
 def test_mwm_list_fail(file_obj, with_wl):
     """Test mwm SpectrumList loader fail on empty"""
+
     tmpfile = str(file_obj) + ".fits"
     mwm_HDUList([0, 0, 0, 0], with_wl).writeto(tmpfile, overwrite=True)
 
@@ -775,16 +814,12 @@ def test_mwm_list_fail(file_obj, with_wl):
 
 @pytest.mark.parametrize(
     "file_obj, with_wl",
-    [
-        ("astra-temp", False),
-        ("astra-temp", True),
-    ],
+    [("astra-temp", False), ("astra-temp", True)],
 )
 def test_astra_list_fail(file_obj, with_wl):
     """Test astra SpectrumList loader fail on empty"""
     tmpfile = str(file_obj) + ".fits"
-    mwm_HDUList([0, 0, 0, 0], with_wl, astra=True).writeto(tmpfile,
-                                                           overwrite=True)
+    mwm_HDUList([0, 0, 0, 0], with_wl, astra=True).writeto(tmpfile, overwrite=True)
 
     with pytest.raises(ValueError):
         SpectrumList.read(tmpfile)


### PR DESCRIPTION
This PR provides default loaders for the SDSS-V Astra `astraStar` and `astraVisit` files, which include model spectra resulting from running different Astra pipelines. The files are similar to the already included `mwmStar` files but with model spectra instead of reduced data, and with some changes depending on the pipeline that produced the spectrum.

The code is based on the PR #1203 from @rileythai but with support for all the current pipelines and running tests. I recommend that #1203 is closed.

@havok2063 

Closes #1183