### PR TITLE
Upgrade PyPI CI publishing to use Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,11 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     if: github.repository == 'astropy/specutils'
-
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/specutils
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
@@ -49,6 +53,3 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
       if: github.event_name != 'pull_request'
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
- Background: #1323

Migrates PyPI publishing from a long-lived API token to [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), motivated by recent supply chain attacks ([litellm](https://blog.pypi.org/posts/2026-04-02-incident-report-litellm-telnyx-supply-chain-attack/), [lightning](https://cybersecuritynews.com/python-package-lightning-hacked/)).

The code changes here require some further (trivial) setup on the PyPI-side. Specifically, the PyPI admin (not just maintainer) needs to register the TP on PyPI at https://pypi.org/manage/project/specutils/settings/publishing/

- Owner: `astropy`
- Repo: `specutils`  
- Workflow: `publish.yml`
- Environment: `pypi`

I think the `PYPI_TOKEN` secret has [already](https://github.com/astropy/specutils/issues/1323#issuecomment-4200846240) been deleted from the repo secrets by @rosteen and can be invalidated on PyPI (if not already done so) too.